### PR TITLE
Issue / Multi Document

### DIFF
--- a/docs/release-notes/v0-10.md
+++ b/docs/release-notes/v0-10.md
@@ -7,7 +7,7 @@
 - __DO__ is renamed as __Baked (Objects)__
   - Root namespace is `Baked`
   - `Forge` is now `Bake`
-  - `Bluprints` are now `Recipes`
+  - `Blueprints` is now `Recipe`
 - `Authentication.Disabled` was removed
 - NHibernate logs are now redirected to logger instead of direct console logging
 - Default levels are added to enable request/response and sql logging for

--- a/src/recipe/Baked.Recipe.Service.Application/Authentication/AddParameterOperationFilter.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Authentication/AddParameterOperationFilter.cs
@@ -3,11 +3,12 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Baked.Authentication;
 
-public class AddParameterOperationFilter<T>(string _name, ParameterLocation _in, bool _required)
+public class AddParameterOperationFilter<T>(string _name, ParameterLocation _in, bool _required, string _documentName)
     : IOperationFilter where T : Attribute
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
+        if (!string.IsNullOrWhiteSpace(_documentName) && context.DocumentName != _documentName) { return; }
         if (!context.MethodInfo.CustomAttributes.Any(a => a.AttributeType == typeof(T))) { return; }
 
         operation.Parameters.Add(new()

--- a/src/recipe/Baked.Recipe.Service.Application/Authentication/AuthenticationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Authentication/AuthenticationExtensions.cs
@@ -13,14 +13,20 @@ public static class AuthenticationExtensions
     public static void AddAuthentications(this List<IFeature> source, IEnumerable<Func<AuthenticationConfigurator, IFeature<AuthenticationConfigurator>>> configures) =>
         source.AddRange(configures.Select(configure => configure(new())));
 
-    public static void AddSecurityRequirementToOperationsThatUse<TAttribute>(this SwaggerGenOptions source, string schemeId) where TAttribute : Attribute =>
-        source.OperationFilter<SecurityRequirementOperationFilter<TAttribute>>([schemeId]);
+    public static void AddSecurityDefinition(this SwaggerGenOptions source, string schemeId, OpenApiSecurityScheme scheme, string? documentName) =>
+        source.DocumentFilter<SecurityDefinitionDocumentFilter>(schemeId, scheme, documentName ?? string.Empty);
+
+    public static void AddSecurityRequirementToOperationsThatUse<TAttribute>(this SwaggerGenOptions source, string schemeId,
+        string? documentName = default
+    ) where TAttribute : Attribute =>
+        source.OperationFilter<SecurityRequirementOperationFilter<TAttribute>>(schemeId, documentName ?? string.Empty);
 
     public static void AddParameterToOperationsThatUse<TAttribute>(this SwaggerGenOptions source, string name,
         ParameterLocation @in = ParameterLocation.Header,
-        bool required = false
+        bool required = false,
+        string? documentName = default
     ) where TAttribute : Attribute =>
-        source.OperationFilter<AddParameterOperationFilter<TAttribute>>(name, @in, required);
+        source.OperationFilter<AddParameterOperationFilter<TAttribute>>(name, @in, required, documentName ?? string.Empty);
 
     public static bool HasMetadata<T>(this HttpContext source) where T : Attribute
     {

--- a/src/recipe/Baked.Recipe.Service.Application/Authentication/AuthenticationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Authentication/AuthenticationExtensions.cs
@@ -10,27 +10,27 @@ namespace Baked;
 
 public static class AuthenticationExtensions
 {
-    public static void AddAuthentications(this List<IFeature> source, IEnumerable<Func<AuthenticationConfigurator, IFeature<AuthenticationConfigurator>>> configures) =>
-        source.AddRange(configures.Select(configure => configure(new())));
+    public static void AddAuthentications(this List<IFeature> features, IEnumerable<Func<AuthenticationConfigurator, IFeature<AuthenticationConfigurator>>> configures) =>
+        features.AddRange(configures.Select(configure => configure(new())));
 
-    public static void AddSecurityDefinition(this SwaggerGenOptions source, string schemeId, OpenApiSecurityScheme scheme, string? documentName) =>
-        source.DocumentFilter<SecurityDefinitionDocumentFilter>(schemeId, scheme, documentName ?? string.Empty);
+    public static void AddSecurityDefinition(this SwaggerGenOptions swaggerGenOptions, string schemeId, OpenApiSecurityScheme scheme, string? documentName) =>
+        swaggerGenOptions.DocumentFilter<SecurityDefinitionDocumentFilter>(schemeId, scheme, documentName ?? string.Empty);
 
-    public static void AddSecurityRequirementToOperationsThatUse<TAttribute>(this SwaggerGenOptions source, string schemeId,
+    public static void AddSecurityRequirementToOperationsThatUse<TAttribute>(this SwaggerGenOptions swaggerGenOptions, string schemeId,
         string? documentName = default
     ) where TAttribute : Attribute =>
-        source.OperationFilter<SecurityRequirementOperationFilter<TAttribute>>(schemeId, documentName ?? string.Empty);
+        swaggerGenOptions.OperationFilter<SecurityRequirementOperationFilter<TAttribute>>(schemeId, documentName ?? string.Empty);
 
-    public static void AddParameterToOperationsThatUse<TAttribute>(this SwaggerGenOptions source, string name,
+    public static void AddParameterToOperationsThatUse<TAttribute>(this SwaggerGenOptions swaggerGenOptions, string name,
         ParameterLocation @in = ParameterLocation.Header,
         bool required = false,
         string? documentName = default
     ) where TAttribute : Attribute =>
-        source.OperationFilter<AddParameterOperationFilter<TAttribute>>(name, @in, required, documentName ?? string.Empty);
+        swaggerGenOptions.OperationFilter<AddParameterOperationFilter<TAttribute>>(name, @in, required, documentName ?? string.Empty);
 
-    public static bool HasMetadata<T>(this HttpContext source) where T : Attribute
+    public static bool HasMetadata<T>(this HttpContext httpContext) where T : Attribute
     {
-        var metadata = source.Features.Get<IEndpointFeature>()?.Endpoint?.Metadata;
+        var metadata = httpContext.Features.Get<IEndpointFeature>()?.Endpoint?.Metadata;
 
         return metadata?.GetMetadata<T>() is not null;
     }

--- a/src/recipe/Baked.Recipe.Service.Application/Authentication/FixedBearerToken/FixedBearerTokenAuthenticationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Authentication/FixedBearerToken/FixedBearerTokenAuthenticationExtensions.cs
@@ -14,21 +14,24 @@ public static class FixedBearerTokenAuthenticationExtensions
 {
     public static FixedBearerTokenAuthenticationFeature FixedBearerToken(this AuthenticationConfigurator _,
         Action<List<Token>>? configure = default,
-        List<string>? formPostParameters = default
+        IEnumerable<string>? formPostParameters = default,
+        IEnumerable<string>? documentNames = default,
+        string description = "Enter your token provided by the development team"
     )
     {
         configure ??= tokens => tokens.Add("Default");
         formPostParameters ??= [];
+        documentNames ??= [string.Empty];
 
         var tokens = new List<Token>();
         configure(tokens);
 
-        return new(tokens, formPostParameters);
+        return new(tokens, formPostParameters, documentNames, description);
     }
 
     public static void Add(this List<Token> tokens, string name,
         IEnumerable<string>? claims = default
-    ) => tokens.Add(new(name, claims ?? ["User"]));
+    ) => tokens.Add(new(name, claims ?? []));
 
     public static IAuthenticationHandler AFixedBearerTokenAuthenticationHandler(this Stubber giveMe, HttpRequest request, Action<List<Token>> configure)
     {
@@ -42,7 +45,7 @@ public static class FixedBearerTokenAuthenticationExtensions
             giveMe.The<ILoggerFactory>(),
             UrlEncoder.Default
         );
-        handler.InitializeAsync(new AuthenticationScheme("FixedBearerToken", "FixedBearerToken", handler.GetType()), request.HttpContext).GetAwaiter().GetResult();
+        handler.InitializeAsync(new AuthenticationScheme(nameof(FixedBearerToken), nameof(FixedBearerToken), handler.GetType()), request.HttpContext).GetAwaiter().GetResult();
 
         return handler;
     }

--- a/src/recipe/Baked.Recipe.Service.Application/Authentication/SecurityDefinitionDocumentFilter.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Authentication/SecurityDefinitionDocumentFilter.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Baked.Authentication;
+
+public class SecurityDefinitionDocumentFilter(string _schemeId, OpenApiSecurityScheme _scheme, string _documentName)
+    : IDocumentFilter
+{
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        if (!string.IsNullOrWhiteSpace(_documentName) && context.DocumentName != _documentName) { return; }
+
+        swaggerDoc.Components.SecuritySchemes[_schemeId] = _scheme;
+    }
+}

--- a/src/recipe/Baked.Recipe.Service.Application/Authentication/SecurityRequirementOperationFilter.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Authentication/SecurityRequirementOperationFilter.cs
@@ -3,11 +3,12 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Baked.Authentication;
 
-public class SecurityRequirementOperationFilter<T>(string _schemeId)
+public class SecurityRequirementOperationFilter<T>(string _schemeId, string _documentName)
     : IOperationFilter where T : Attribute
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
+        if (!string.IsNullOrWhiteSpace(_documentName) && context.DocumentName != _documentName) { return; }
         if (!context.MethodInfo.CustomAttributes.Any(a => a.AttributeType == typeof(T))) { return; }
 
         operation.Security.Add(new()

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
@@ -164,6 +164,8 @@ public class DomainAssembliesBusinessFeature(List<Assembly> _assemblies, Func<IE
             conventions.Add(new RemoveFromRouteConvention(["Get"]));
             conventions.Add(new RemoveFromRouteConvention(["Update", "Change", "Set"]));
             conventions.Add(new RemoveFromRouteConvention(["Delete", "Remove", "Clear"]));
+            conventions.Add(new ConsumesJsonConvention(_when: c => c.Action.HasBody), order: 10);
+            conventions.Add(new ProducesJsonConvention(_when: c => !c.Action.Return.IsVoid), order: 10);
         });
 
         configurator.ConfigureSwaggerGenOptions(swaggerGenOptions =>

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/UseBuiltInTypes/ConvertEnumToStringSchemaFilter.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/UseBuiltInTypes/ConvertEnumToStringSchemaFilter.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using System.Runtime.Serialization;
 
 namespace Baked.CodingStyle.UseBuiltInTypes;
 
@@ -17,14 +16,7 @@ public class ConvertEnumToStringSchemaFilter : ISchemaFilter
 
         foreach (var enumName in Enum.GetNames(context.Type))
         {
-            var memberInfo = context.Type.GetMember(enumName).FirstOrDefault(m => m.DeclaringType == context.Type);
-            var enumMemberAttribute = memberInfo?.GetCustomAttributes(typeof(EnumMemberAttribute), false).OfType<EnumMemberAttribute>().FirstOrDefault();
-
-            var label = enumMemberAttribute == null || string.IsNullOrWhiteSpace(enumMemberAttribute.Value)
-                ? enumName
-                : enumMemberAttribute.Value;
-
-            schema.Enum.Add(new OpenApiString(label.ToLowerInvariant()));
+            schema.Enum.Add(new OpenApiString(enumName.ToLowerInvariant()));
         }
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/RestApi/Conventions/ConsumesJsonConvention.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/RestApi/Conventions/ConsumesJsonConvention.cs
@@ -1,0 +1,15 @@
+﻿using Baked.RestApi.Configuration;
+
+namespace Baked.RestApi.Conventions;
+
+public class ConsumesJsonConvention(
+    Func<ActionModelContext, bool>? _when = default
+) : IApiModelConvention<ActionModelContext>
+{
+    public void Apply(ActionModelContext context)
+    {
+        if (_when is not null && !_when(context)) { return; }
+
+        context.Action.AdditionalAttributes.Add("Consumes(\"application/json\")");
+    }
+}

--- a/src/recipe/Baked.Recipe.Service.Application/RestApi/Conventions/ProducesJsonConvention.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/RestApi/Conventions/ProducesJsonConvention.cs
@@ -1,0 +1,15 @@
+﻿using Baked.RestApi.Configuration;
+
+namespace Baked.RestApi.Conventions;
+
+public class ProducesJsonConvention(
+    Func<ActionModelContext, bool>? _when = default
+) : IApiModelConvention<ActionModelContext>
+{
+    public void Apply(ActionModelContext context)
+    {
+        if (_when is not null && !_when(context)) { return; }
+
+        context.Action.AdditionalAttributes.Add("Produces(\"application/json\")");
+    }
+}

--- a/test/recipe/Baked.Test.Recipe.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
@@ -29,18 +29,33 @@ public class ConfigurationOverriderFeature : IFeature
 
         configurator.ConfigureSwaggerGenOptions(swaggerGenOptions =>
         {
-            swaggerGenOptions.AddSecurityDefinition("AdditionalSecurity",
+            swaggerGenOptions.SwaggerDoc("samples", new() { Title = "Samples", Version = "v1" });
+            swaggerGenOptions.SwaggerDoc("external", new() { Title = "External", Version = "v1" });
+
+            swaggerGenOptions.AddSecurityDefinition("Custom",
                 new()
                 {
                     Type = SecuritySchemeType.ApiKey,
                     In = ParameterLocation.Header,
-                    Name = "X-Secret",
-                    Description = "Enter secret information",
-                }
+                    Name = "X-Custom-API-Key",
+                    Description = "Demonstration of additional security definitions",
+                },
+                documentName: "external"
             );
 
-            swaggerGenOptions.AddSecurityRequirementToOperationsThatUse<AuthorizeAttribute>("AdditionalSecurity");
-            swaggerGenOptions.AddParameterToOperationsThatUse<AuthorizeAttribute>("X-Security", @in: ParameterLocation.Header);
+            swaggerGenOptions.DocInclusionPredicate((documentName, api) =>
+                documentName == "samples" ||
+                documentName == "external" && api.GroupName == "ExternalSamples"
+            );
+
+            swaggerGenOptions.AddSecurityRequirementToOperationsThatUse<AuthorizeAttribute>("Custom", documentName: "external");
+            swaggerGenOptions.AddParameterToOperationsThatUse<AuthorizeAttribute>("X-Security", @in: ParameterLocation.Header, documentName: "external");
+        });
+
+        configurator.ConfigureSwaggerUIOptions(swaggerUIOptions =>
+        {
+            swaggerUIOptions.SwaggerEndpoint($"samples/swagger.json", "Samples");
+            swaggerUIOptions.SwaggerEndpoint($"external/swagger.json", "External");
         });
     }
 }

--- a/test/recipe/Baked.Test.Recipe.Service.Application/Program.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/Program.cs
@@ -18,7 +18,8 @@ Bake.New
                     tokens.Add("ClassClaims", claims: ["GivenA", "GivenB", "BaseA", "BaseB"]);
                     tokens.Add("MethodOverClassClaims", claims: ["GivenC"]);
                 },
-                formPostParameters: ["additional"]
+                formPostParameters: ["additional"],
+                documentNames: ["samples"]
             ),
             c => c.ApiKey()
         ],

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Authentication/AddingParametersToFormPost.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Authentication/AddingParametersToFormPost.cs
@@ -19,7 +19,7 @@ public class AddingParametersToFormPost : TestServiceNfr
         var response = await Client.PostAsync("authentication-samples/form-post-authenticate", new FormUrlEncodedContent(form));
 
         var content = await response.Content.ReadAsStringAsync();
-        content.ShouldBe("FixedBearerToken");
+        content.ShouldBe("\"FixedBearerToken\"");
     }
 
     [Test]

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Authentication/ValidatingAuthorizationHeader.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Authentication/ValidatingAuthorizationHeader.cs
@@ -14,8 +14,8 @@ public class ValidatingAuthorizationHeader : TestServiceSpec
         var handler = GiveMe.AFixedBearerTokenAuthenticationHandler(request,
              tokens =>
              {
-                 tokens.Add("A", ["ClaimA"]);
-                 tokens.Add("B", ["ClaimB"]);
+                 tokens.Add("A", claims: ["ClaimA"]);
+                 tokens.Add("B", claims: ["ClaimB"]);
              });
         MockMe.ASetting("Authentication:FixedBearerToken:A", "token_a");
         MockMe.ASetting("Authentication:FixedBearerToken:B", "token_b");
@@ -32,7 +32,7 @@ public class ValidatingAuthorizationHeader : TestServiceSpec
             header: GiveMe.ADictionary(("Authorization", "Bearer wrong_token"))
         );
         var handler = GiveMe.AFixedBearerTokenAuthenticationHandler(request,
-             tokens => tokens.Add("Default", ["User"])
+             tokens => tokens.Add("Default", claims: ["User"])
         );
         MockMe.ASetting("Authentication:FixedBearerToken:Default", "test_token");
 
@@ -50,7 +50,7 @@ public class ValidatingAuthorizationHeader : TestServiceSpec
             header: GiveMe.ADictionary(("Authorization", "Bearer test_token "))
         );
         var handler = GiveMe.AFixedBearerTokenAuthenticationHandler(request,
-            tokens => tokens.Add("Default", ["User"])
+            tokens => tokens.Add("Default", claims: ["User"])
         );
         MockMe.ASetting("Authentication:FixedBearerToken:Default", "test_token");
 

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Authentication/ValidatingFormPost.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Authentication/ValidatingFormPost.cs
@@ -15,7 +15,7 @@ public class ValidatingFormPost : TestServiceSpec
             )
         );
         var handler = GiveMe.AFixedBearerTokenAuthenticationHandler(request,
-            tokens => tokens.Add("Default", ["User"])
+            tokens => tokens.Add("Default", claims: ["User"])
         );
         MockMe.ASetting(key: "Authentication:FixedBearerToken:Default", value: "token");
 
@@ -37,7 +37,7 @@ public class ValidatingFormPost : TestServiceSpec
            )
        );
         var handler = GiveMe.AFixedBearerTokenAuthenticationHandler(request,
-             tokens => tokens.Add("Default", ["User"])
+             tokens => tokens.Add("Default", claims: ["User"])
          );
         MockMe.ASetting(key: "Authentication:FixedBearerToken:Default", value: "other-token");
 
@@ -55,7 +55,7 @@ public class ValidatingFormPost : TestServiceSpec
             form: GiveMe.ADictionary()
         );
         var handler = GiveMe.AFixedBearerTokenAuthenticationHandler(request,
-            tokens => tokens.Add("Default", ["User"])
+            tokens => tokens.Add("Default", claims: ["User"])
         );
         MockMe.ASetting(key: "Authentication:FixedBearerToken:Default", value: GiveMe.AString());
 

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
@@ -5,7 +5,7 @@ public class SwaggerSchemaGeneration : TestServiceNfr
     [Test]
     public async Task Generates_swagger_json_automatically()
     {
-        var response = await Client.GetAsync("/swagger/v1/swagger.json");
+        var response = await Client.GetAsync("/swagger/samples/swagger.json");
 
         dynamic? content = await response.Content.Deserialize();
 

--- a/test/recipe/Baked.Test.Recipe.Service.Test/CodingStyle/RoutingCommands.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/CodingStyle/RoutingCommands.cs
@@ -25,7 +25,7 @@ public class RoutingCommands : TestServiceNfr
 
         var actual = await response.Content.ReadAsStringAsync();
 
-        actual.ShouldBe("q:b");
+        actual.ShouldBe("\"q:b\"");
     }
 
     [Test]

--- a/test/recipe/Baked.Test.Recipe.Service.Test/DataAccess/MappingProperties.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/DataAccess/MappingProperties.cs
@@ -99,7 +99,7 @@ public class MappingProperties : TestServiceSpec
         await entity.Update(@enum: Enumeration.Member2);
         entity.Enum.ShouldBe(Enumeration.Member2);
 
-        var actual = GiveMe.The<Entities>().By(status: Enumeration.Member2).FirstOrDefault();
+        var actual = GiveMe.The<Entities>().By(@enum: Enumeration.Member2).FirstOrDefault();
         actual.ShouldBe(entity);
     }
 

--- a/test/recipe/Baked.Test.Recipe.Service.Test/HttpServer/ConfiguringMultipleAuthenticationHandlers.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/HttpServer/ConfiguringMultipleAuthenticationHandlers.cs
@@ -5,8 +5,8 @@ namespace Baked.Test.HttpServer;
 
 public class ConfiguringMultipleAuthenticationHandlers : TestServiceNfr
 {
-    [TestCase("Authorization", "token-jane", "FixedBearerToken")]
-    [TestCase("X-Api-Key", "apikey", "ApiKey")]
+    [TestCase("Authorization", "token-jane", "\"FixedBearerToken\"")]
+    [TestCase("X-Api-Key", "apikey", "\"ApiKey\"")]
     public async Task Request_can_be_forwarded_to_available_handlers(string header, string value, string authenticationType)
     {
         Client.DefaultRequestHeaders.Clear();
@@ -27,7 +27,7 @@ public class ConfiguringMultipleAuthenticationHandlers : TestServiceNfr
         var response = await Client.PostAsync("authentication-samples/authenticate", null);
         var result = await response.Content.ReadAsStringAsync();
 
-        result.ShouldBe("FixedBearerToken");
+        result.ShouldBe("\"FixedBearerToken\"");
     }
 
     [Test]

--- a/test/recipe/Baked.Test.Recipe.Service/Orm/Entity.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Orm/Entity.cs
@@ -162,7 +162,7 @@ public class Entities(IQueryContext<Entity> _context)
         int? int32 = default,
         string? unique = default,
         Uri? uri = default,
-        Enumeration? status = default,
+        Enumeration? @enum = default,
         DateTime? dateTime = default,
         int? take = default,
         int? skip = default
@@ -174,7 +174,7 @@ public class Entities(IQueryContext<Entity> _context)
                 (int32 == default || e.Int32 == int32) &&
                 (unique == default || e.Unique == unique) &&
                 (uri == default || e.Uri == uri) &&
-                (status == default || e.Enum == status) &&
+                (@enum == default || e.Enum == @enum) &&
                 (dateTime == default || e.DateTime == dateTime),
             take: take,
             skip: skip

--- a/unreleased.md
+++ b/unreleased.md
@@ -4,3 +4,8 @@
 
 - Existing swashbuckle configuration and filters now allow a multi document
   setup
+  - `FixedBearerToken` now accepts document names and description of token
+    parameter
+  - Document based securtiy definition extension is added
+- `json` request and response types were documented as more than one type,
+  restricted to `application/json`

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,6 @@
 # Unreleased
+
+## Improvements
+
+- Existing swashbuckle configuration and filters now allow a multi document
+  setup


### PR DESCRIPTION
Enable multi document setup by adding document support to existing filters

## Tasks

- [x] Research - https://github.com/mouseless/learn-dotnet/pull/33
- [x] Add document support to existing filters
- [x] Docs based security definition
- [x] Add document option for fixed bearer token
- [x] Create test case for document support

## Additional Tasks

- [x] fix release notes typos
- [x] simplify enum lower case filter
- [x] remove default `User` claim from `Add` extension
- [x] restrict request and response body schemas with `application/json`
