### PR TITLE
Issue / XML Documentation for Domain

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
     <PackageVersion Include="System.Data.SQLite" Version="1.0.118" />
   </ItemGroup>
 

--- a/src/core/Baked.Architecture/Architecture/PhaseContextBuilder.cs
+++ b/src/core/Baked.Architecture/Architecture/PhaseContextBuilder.cs
@@ -50,32 +50,32 @@ public static class PhaseContextBuilderExtensions
     public static PhaseContext CreateEmptyContext(this IPhase _) =>
         PhaseContext.Empty;
 
-    public static PhaseContextBuilder CreateContextBuilder(this IPhase source) => new(source);
+    public static PhaseContextBuilder CreateContextBuilder(this IPhase phase) => new(phase);
 
-    public static PhaseContext CreateContext<TTarget>(this IPhase source, TTarget target,
+    public static PhaseContext CreateContext<TTarget>(this IPhase phase, TTarget target,
         Action? onDispose = default
     )
         where TTarget : notnull
     {
-        return source.CreateContextBuilder().Add(target).OnDispose(onDispose).Build();
+        return phase.CreateContextBuilder().Add(target).OnDispose(onDispose).Build();
     }
 
-    public static PhaseContext CreateContext<TTarget1, TTarget2>(this IPhase source, TTarget1 target1, TTarget2 target2,
+    public static PhaseContext CreateContext<TTarget1, TTarget2>(this IPhase phase, TTarget1 target1, TTarget2 target2,
         Action? onDispose = default
     )
         where TTarget1 : notnull
         where TTarget2 : notnull
     {
-        return source.CreateContextBuilder().Add(target1, target2).OnDispose(onDispose).Build();
+        return phase.CreateContextBuilder().Add(target1, target2).OnDispose(onDispose).Build();
     }
 
-    public static PhaseContext CreateContext<TTarget1, TTarget2, TTarget3>(this IPhase source, TTarget1 target1, TTarget2 target2, TTarget3 target3,
+    public static PhaseContext CreateContext<TTarget1, TTarget2, TTarget3>(this IPhase phase, TTarget1 target1, TTarget2 target2, TTarget3 target3,
         Action? onDispose = default
     )
         where TTarget1 : notnull
         where TTarget2 : notnull
         where TTarget3 : notnull
     {
-        return source.CreateContextBuilder().Add(target1, target2, target3).OnDispose(onDispose).Build();
+        return phase.CreateContextBuilder().Add(target1, target2, target3).OnDispose(onDispose).Build();
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Authentication/FixedBearerToken/AddParameterToFormPostConvention.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Authentication/FixedBearerToken/AddParameterToFormPostConvention.cs
@@ -4,7 +4,7 @@ using Baked.RestApi.Model;
 
 namespace Baked.Authentication.FixedBearerToken;
 
-public class AddParameterToFormPostConvention(DomainModel _domain, string _name)
+public class AddParameterToFormPostConvention(DomainModel _domain, string _name, string _description)
     : IApiModelConvention<ActionModelContext>
 {
     public void Apply(ActionModelContext context)
@@ -16,7 +16,8 @@ public class AddParameterToFormPostConvention(DomainModel _domain, string _name)
             _name,
             new(_domain.Types[typeof(string)], ParameterModelFrom.BodyOrForm, _name)
             {
-                IsInvokeMethodParameter = false
+                IsInvokeMethodParameter = false,
+                AdditionalAttributes = [$"SwaggerSchema(\"{_description}\")"]
             }
         );
     }

--- a/src/recipe/Baked.Recipe.Service.Application/Authorization/AuthorizationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Authorization/AuthorizationExtensions.cs
@@ -5,6 +5,6 @@ namespace Baked;
 
 public static class AuthorizationExtensions
 {
-    public static void AddAuthorization(this List<IFeature> source, Func<AuthorizationConfigurator, IFeature<AuthorizationConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddAuthorization(this List<IFeature> features, Func<AuthorizationConfigurator, IFeature<AuthorizationConfigurator>> configure) =>
+        features.Add(configure(new()));
 }

--- a/src/recipe/Baked.Recipe.Service.Application/BakeExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/BakeExtensions.cs
@@ -15,7 +15,7 @@ namespace Baked;
 
 public static class BakeExtensions
 {
-    public static Application Service(this Bake source,
+    public static Application Service(this Bake bake,
         Func<BusinessConfigurator, IFeature<BusinessConfigurator>> business,
         IEnumerable<Func<AuthenticationConfigurator, IFeature<AuthenticationConfigurator>>>? authentications = default,
         Func<AuthorizationConfigurator, IFeature<AuthorizationConfigurator>>? authorization = default,
@@ -42,7 +42,7 @@ public static class BakeExtensions
         orm ??= c => c.AutoMap();
         configure ??= _ => { };
 
-        return source.Application(app =>
+        return bake.Application(app =>
         {
             app.Layers.AddCodeGeneration();
             app.Layers.AddConfiguration();

--- a/src/recipe/Baked.Recipe.Service.Application/Baked.Recipe.Service.Application.csproj
+++ b/src/recipe/Baked.Recipe.Service.Application/Baked.Recipe.Service.Application.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="MySql.Data" />
     <PackageReference Include="NHibernate" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
     <PackageReference Include="System.Data.SQLite" />
   </ItemGroup>
 

--- a/src/recipe/Baked.Recipe.Service.Application/Business/BusinessExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/BusinessExtensions.cs
@@ -7,8 +7,8 @@ namespace Baked;
 
 public static class BusinessExtensions
 {
-    public static void AddBusiness(this List<IFeature> source, Func<BusinessConfigurator, IFeature<BusinessConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddBusiness(this List<IFeature> features, Func<BusinessConfigurator, IFeature<BusinessConfigurator>> configure) =>
+        features.Add(configure(new()));
 
     static readonly MethodInfo _addTransientWithFactory = typeof(BusinessExtensions).GetMethod(nameof(AddTransientWithFactory), 2, [typeof(IServiceCollection)]) ??
         throw new("AddTransientWithFactory<TService, TImplementation> should have existed");
@@ -16,48 +16,48 @@ public static class BusinessExtensions
     static readonly MethodInfo _addScopedWithFactory = typeof(BusinessExtensions).GetMethod(nameof(AddScopedWithFactory), 2, [typeof(IServiceCollection)]) ??
         throw new Exception("AddScopedWithFactory<TService, TImplementation> should have existed");
 
-    public static IServiceCollection AddTransientWithFactory(this IServiceCollection source, Type service) =>
-        (IServiceCollection?)_addTransientWithFactory.MakeGenericMethod(service, service).Invoke(null, [source]) ??
+    public static IServiceCollection AddTransientWithFactory(this IServiceCollection services, Type service) =>
+        (IServiceCollection?)_addTransientWithFactory.MakeGenericMethod(service, service).Invoke(null, [services]) ??
         throw new("Should've returned an IServiceCollection instance");
-    public static IServiceCollection AddTransientWithFactory(this IServiceCollection source, Type service, Type implementation) =>
-        (IServiceCollection?)_addTransientWithFactory.MakeGenericMethod(service, implementation).Invoke(null, [source]) ??
+    public static IServiceCollection AddTransientWithFactory(this IServiceCollection services, Type service, Type implementation) =>
+        (IServiceCollection?)_addTransientWithFactory.MakeGenericMethod(service, implementation).Invoke(null, [services]) ??
         throw new("Should've returned an IServiceCollection instance");
 
-    public static IServiceCollection AddTransientWithFactory<TService>(this IServiceCollection source) where TService : class =>
-        source.AddTransientWithFactory<TService, TService>();
+    public static IServiceCollection AddTransientWithFactory<TService>(this IServiceCollection services) where TService : class =>
+        services.AddTransientWithFactory<TService, TService>();
 
-    public static IServiceCollection AddTransientWithFactory<TService, TImplementation>(this IServiceCollection source)
+    public static IServiceCollection AddTransientWithFactory<TService, TImplementation>(this IServiceCollection services)
         where TService : class
         where TImplementation : class, TService
-    => source
+    => services
         .AddSingleton<Func<TService>>(sp => () => sp.GetRequiredServiceUsingRequestServices<TService>())
         .AddTransient<TService, TImplementation>();
 
-    public static IServiceCollection AddScopedWithFactory(this IServiceCollection source, Type service) =>
-        (IServiceCollection?)_addScopedWithFactory.MakeGenericMethod(service, service).Invoke(null, [source]) ??
+    public static IServiceCollection AddScopedWithFactory(this IServiceCollection services, Type service) =>
+        (IServiceCollection?)_addScopedWithFactory.MakeGenericMethod(service, service).Invoke(null, [services]) ??
         throw new("Should've returned an IServiceCollection instance");
-    public static IServiceCollection AddScopedWithFactory(this IServiceCollection source, Type service, Type implementation) =>
-        (IServiceCollection?)_addScopedWithFactory.MakeGenericMethod(service, implementation).Invoke(null, [source]) ??
+    public static IServiceCollection AddScopedWithFactory(this IServiceCollection services, Type service, Type implementation) =>
+        (IServiceCollection?)_addScopedWithFactory.MakeGenericMethod(service, implementation).Invoke(null, [services]) ??
         throw new("Should've returned an IServiceCollection instance");
-    public static void AddScopedWithFactory<TService>(this IServiceCollection source) where TService : class =>
-        source.AddScopedWithFactory<TService, TService>();
+    public static void AddScopedWithFactory<TService>(this IServiceCollection services) where TService : class =>
+        services.AddScopedWithFactory<TService, TService>();
 
-    public static IServiceCollection AddScopedWithFactory<TService, TImplementation>(this IServiceCollection source)
+    public static IServiceCollection AddScopedWithFactory<TService, TImplementation>(this IServiceCollection services)
         where TService : class
         where TImplementation : class, TService
-    => source
+    => services
         .AddSingleton<Func<TService>>(sp => () => sp.GetRequiredServiceUsingRequestServices<TService>())
         .AddScoped<TService, TImplementation>();
 
-    public static IServiceCollection AddSingleton<TService, TImplementation>(this IServiceCollection source, bool forward)
+    public static IServiceCollection AddSingleton<TService, TImplementation>(this IServiceCollection services, bool forward)
         where TService : class
         where TImplementation : class, TService
-    => source.AddSingleton(typeof(TService), typeof(TImplementation), forward: forward);
+    => services.AddSingleton(typeof(TService), typeof(TImplementation), forward: forward);
 
-    public static IServiceCollection AddSingleton(this IServiceCollection source, Type service, Type implementation, bool forward)
+    public static IServiceCollection AddSingleton(this IServiceCollection services, Type service, Type implementation, bool forward)
     {
-        if (!forward) { return source.AddSingleton(service, implementation); }
+        if (!forward) { return services.AddSingleton(service, implementation); }
 
-        return source.AddSingleton(service, sp => sp.GetRequiredServiceUsingRequestServices(implementation));
+        return services.AddSingleton(service, sp => sp.GetRequiredServiceUsingRequestServices(implementation));
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/ApplyTagDescriptionsDocumentFilter.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/ApplyTagDescriptionsDocumentFilter.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Baked.Business.DomainAssemblies;
+
+public class ApplyTagDescriptionsDocumentFilter(TagDescriptions _descriptions)
+    : IDocumentFilter
+{
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        foreach (var (name, description) in _descriptions.OrderBy(kvp => kvp.Key))
+        {
+            swaggerDoc.Tags.Add(new() { Name = name, Description = description });
+        }
+    }
+}

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/TagDescriptions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/TagDescriptions.cs
@@ -1,0 +1,3 @@
+﻿namespace Baked.Business.DomainAssemblies;
+
+public class TagDescriptions : Dictionary<string, string> { }

--- a/src/recipe/Baked.Recipe.Service.Application/Caching/CachingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Caching/CachingExtensions.cs
@@ -5,6 +5,6 @@ namespace Baked;
 
 public static class CachingExtensions
 {
-    public static void AddCaching(this List<IFeature> source, Func<CachingConfigurator, IFeature<CachingConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddCaching(this List<IFeature> features, Func<CachingConfigurator, IFeature<CachingConfigurator>> configure) =>
+        features.Add(configure(new()));
 }

--- a/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationExtensions.cs
@@ -10,14 +10,14 @@ public static class CodeGenerationExtensions
     public static void AddCodeGeneration(this ICollection<ILayer> layers) =>
         layers.Add(new CodeGenerationLayer());
 
-    public static IGeneratedAssemblyCollection GetGeneratedAssemblyCollection(this ApplicationContext source) =>
-        source.Get<IGeneratedAssemblyCollection>();
+    public static IGeneratedAssemblyCollection GetGeneratedAssemblyCollection(this ApplicationContext context) =>
+        context.Get<IGeneratedAssemblyCollection>();
 
-    public static GeneratedAssemblyProvider GetGeneratedAssemblyProvider(this ApplicationContext source) =>
-        source.Get<GeneratedAssemblyProvider>();
+    public static GeneratedAssemblyProvider GetGeneratedAssemblyProvider(this ApplicationContext context) =>
+        context.Get<GeneratedAssemblyProvider>();
 
-    public static Assembly GetGeneratedAssembly(this ApplicationContext source, string name) =>
-        source.GetGeneratedAssemblyProvider()[name];
+    public static Assembly GetGeneratedAssembly(this ApplicationContext context, string name) =>
+        context.GetGeneratedAssemblyProvider()[name];
 
     public static void ConfigureGeneratedAssemblyCollection(this LayerConfigurator configurator, Action<IGeneratedAssemblyCollection> configuration) =>
         configurator.Configure(configuration);

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/CodingStyleExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/CodingStyleExtensions.cs
@@ -5,6 +5,6 @@ namespace Baked;
 
 public static class CodingStyleExtensions
 {
-    public static void AddCodingStyles(this List<IFeature> source, IEnumerable<Func<CodingStyleConfigurator, IFeature<CodingStyleConfigurator>>> configures) =>
-        source.AddRange(configures.Select(configure => configure(new())));
+    public static void AddCodingStyles(this List<IFeature> features, IEnumerable<Func<CodingStyleConfigurator, IFeature<CodingStyleConfigurator>>> configures) =>
+        features.AddRange(configures.Select(configure => configure(new())));
 }

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/CommandPattern/CommandPatternCodingStyleFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/CommandPattern/CommandPatternCodingStyleFeature.cs
@@ -35,6 +35,7 @@ public class CommandPatternCodingStyleFeature : IFeature<CodingStyleConfigurator
         configurator.ConfigureApiModelConventions(conventions =>
         {
             conventions.Add(new InitializeUsingQueryParametersConvention(), order: -10);
+            conventions.Add(new IncludeClassDocsForActionNamesConvention(["Execute", "Process"]), order: -10);
             conventions.Add(new UseClassNameInsteadOfActionNamesConvention(["Execute", "Process"]), order: -10);
             conventions.Add(new RemoveFromRouteConvention(["Execute", "Process"]));
             conventions.Add(new UseRootPathAsGroupNameForSingleMethodNonLocatablesConvention());

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/CommandPattern/IncludeClassDocsForActionNamesConvention.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/CommandPattern/IncludeClassDocsForActionNamesConvention.cs
@@ -1,0 +1,22 @@
+﻿using Baked.RestApi.Configuration;
+
+namespace Baked.CodingStyle.CommandPattern;
+
+public class IncludeClassDocsForActionNamesConvention(IEnumerable<string> actionNames)
+    : IApiModelConvention<ActionModelContext>
+{
+    readonly HashSet<string> _actionNames = actionNames.ToHashSet();
+
+    public void Apply(ActionModelContext context)
+    {
+        if (!_actionNames.Contains(context.Action.Name)) { return; }
+        if (!context.Controller.MappedType.TryGetMembers(out var controllerMembers)) { return; }
+        if (controllerMembers.Documentation is null) { return; }
+
+        var summary = controllerMembers.Documentation["summary"]?.InnerText.Trim();
+        var remarks = controllerMembers.Documentation["remarks"]?.InnerText.Trim();
+        if (summary is null && remarks is null) { return; }
+
+        context.Action.AdditionalAttributes.Add($"SwaggerOperation(Summary = \"{summary}\", Description = \"{remarks}\")");
+    }
+}

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/RichEntity/TargetEntityFromRouteConvention.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/RichEntity/TargetEntityFromRouteConvention.cs
@@ -23,6 +23,7 @@ public class TargetEntityFromRouteConvention(DomainModel _domain)
         context.Parameter.ConvertToId(name: "id", dontAddRequired: true);
         context.Parameter.From = ParameterModelFrom.Route;
         context.Parameter.RoutePosition = 1;
+        context.Parameter.AdditionalAttributes.Add($"SwaggerSchema(\"Unique value to find {entityType.Name.Humanize().ToLowerInvariant()} resource\")");
         context.Action.RouteParts = [entityType.Name.Pluralize(), context.Action.Name];
         context.Action.FindTargetStatement = queryContextParameter.BuildSingleBy(context.Parameter.Name, fromRoute: true);
     }

--- a/src/recipe/Baked.Recipe.Service.Application/Communication/CommunicationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Communication/CommunicationExtensions.cs
@@ -5,6 +5,6 @@ namespace Baked;
 
 public static class CommunicationExtensions
 {
-    public static void AddCommunication(this List<IFeature> source, Func<CommunicationConfigurator, IFeature<CommunicationConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddCommunication(this List<IFeature> features, Func<CommunicationConfigurator, IFeature<CommunicationConfigurator>> configure) =>
+        features.Add(configure(new()));
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Communication/Http/DictionaryExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Communication/Http/DictionaryExtensions.cs
@@ -2,19 +2,19 @@
 
 internal static class DictionaryExtensions
 {
-    internal static Dictionary<string, string> Merge(this Dictionary<string, string>? source, Dictionary<string, string>? input)
+    internal static Dictionary<string, string> Merge(this Dictionary<string, string>? dictionary, Dictionary<string, string>? input)
     {
-        source ??= [];
+        dictionary ??= [];
         input ??= [];
 
         foreach (var (key, value) in input)
         {
-            if (!source.ContainsKey(key))
+            if (!dictionary.ContainsKey(key))
             {
-                source[key] = value;
+                dictionary[key] = value;
             }
         }
 
-        return source;
+        return dictionary;
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Communication/Mock/MockCommunicationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Communication/Mock/MockCommunicationExtensions.cs
@@ -53,7 +53,7 @@ public static class MockCommunicationExtensions
         return mock.Object;
     }
 
-    public static void VerifySent<T>(this IClient<T> source,
+    public static void VerifySent<T>(this IClient<T> client,
         string? path = default,
         string? url = default,
         HttpMethod? method = default,
@@ -63,7 +63,7 @@ public static class MockCommunicationExtensions
         (string key, string value)? header = default,
         string? excludesHeader = default,
         int? times = default
-    ) => Moq.Mock.Get(source).Verify(
+    ) => Moq.Mock.Get(client).Verify(
         c => c.Send(It.Is<Request>(r =>
             (path == default || r.UrlOrPath == path) &&
             (url == default || r.UrlOrPath == url) &&
@@ -77,9 +77,9 @@ public static class MockCommunicationExtensions
         times is null ? Times.AtLeastOnce() : Times.Exactly(times.Value)
     );
 
-    public static void VerifyNotSent<T>(this IClient<T> source) =>
-        Moq.Mock.Get(source).Verify(c => c.Send(It.IsAny<Request>()), Times.Never());
+    public static void VerifyNotSent<T>(this IClient<T> client) =>
+        Moq.Mock.Get(client).Verify(c => c.Send(It.IsAny<Request>()), Times.Never());
 
-    public static void VerifyNoContentIsSent<T>(this IClient<T> source) =>
-        Moq.Mock.Get(source).Verify(c => c.Send(It.Is<Request>(r => r.Content == null)));
+    public static void VerifyNoContentIsSent<T>(this IClient<T> client) =>
+        Moq.Mock.Get(client).Verify(c => c.Send(It.Is<Request>(r => r.Content == null)));
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Configuration/ConfigurationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Configuration/ConfigurationExtensions.cs
@@ -7,11 +7,11 @@ namespace Baked;
 
 public static class ConfigurationExtensions
 {
-    public static void AddConfiguration(this List<ILayer> source) =>
-        source.Add(new ConfigurationLayer());
+    public static void AddConfiguration(this List<ILayer> layers) =>
+        layers.Add(new ConfigurationLayer());
 
-    public static void ConfigureConfigurationBuilder(this LayerConfigurator source, Action<IConfigurationBuilder> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureConfigurationBuilder(this LayerConfigurator configurator, Action<IConfigurationBuilder> configuration) =>
+        configurator.Configure(configuration);
 
     public static void AddJson(this IConfigurationBuilder configuration, string json) =>
         configuration.AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)));

--- a/src/recipe/Baked.Recipe.Service.Application/Core/CoreExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Core/CoreExtensions.cs
@@ -12,8 +12,8 @@ namespace Baked;
 
 public static class CoreExtensions
 {
-    public static void AddCore(this List<IFeature> source, Func<CoreConfigurator, IFeature<CoreConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddCore(this List<IFeature> features, Func<CoreConfigurator, IFeature<CoreConfigurator>> configure) =>
+        features.Add(configure(new()));
 
     public static int AnInteger(this Stubber _) =>
         42;
@@ -25,8 +25,8 @@ public static class CoreExtensions
         string? value = default
     ) => value ?? "test string";
 
-    public static Guid ToGuid(this string source) =>
-        Guid.Parse(source);
+    public static Guid ToGuid(this string guidStr) =>
+        Guid.Parse(guidStr);
 
     public static DateTime ADateTime(this Stubber _,
         int year = 2023,
@@ -105,20 +105,20 @@ public static class CoreExtensions
     public static PropertyInfo? PropertyOf<T>(this Stubber _, string name) =>
         typeof(T).GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
 
-    public static void ShouldBe<T>(this Type source) =>
-        source.ShouldBe(typeof(T));
+    public static void ShouldBe<T>(this Type type) =>
+        type.ShouldBe(typeof(T));
 
-    public static void ShouldBeAbstract(this PropertyInfo source)
+    public static void ShouldBeAbstract(this PropertyInfo property)
     {
-        var getMethod = source.GetGetMethod(true);
+        var getMethod = property.GetGetMethod(true);
 
         getMethod.ShouldNotBeNull();
         getMethod.ShouldBeAbstract();
     }
 
-    public static void ShouldBeVirtual(this PropertyInfo source)
+    public static void ShouldBeVirtual(this PropertyInfo property)
     {
-        var getMethod = source.GetGetMethod(true);
+        var getMethod = property.GetGetMethod(true);
 
         getMethod.ShouldNotBeNull();
         getMethod.ShouldBeVirtual();
@@ -127,19 +127,19 @@ public static class CoreExtensions
     public static MethodInfo? MethodOf<T>(this Stubber _, string name) =>
         typeof(T).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
 
-    public static void ShouldBeAbstract(this MethodInfo source)
+    public static void ShouldBeAbstract(this MethodInfo method)
     {
-        source.IsAbstract.ShouldBeTrue();
+        method.IsAbstract.ShouldBeTrue();
     }
 
-    public static void ShouldBeVirtual(this MethodInfo source)
+    public static void ShouldBeVirtual(this MethodInfo method)
     {
-        source.IsVirtual.ShouldBeTrue();
+        method.IsVirtual.ShouldBeTrue();
     }
 
-    public static void ShouldHaveOneParameter<T>(this MethodInfo source)
+    public static void ShouldHaveOneParameter<T>(this MethodInfo method)
     {
-        source.GetParameters().Length.ShouldBe(1);
-        source.GetParameters().First().ParameterType.ShouldBe<T>();
+        method.GetParameters().Length.ShouldBe(1);
+        method.GetParameters().First().ParameterType.ShouldBe<T>();
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Database/DatabaseExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Database/DatabaseExtensions.cs
@@ -7,12 +7,12 @@ namespace Baked;
 
 public static class DatabaseExtensions
 {
-    public static void AddDatabase(this List<IFeature> source, Func<DatabaseConfigurator, IFeature<DatabaseConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddDatabase(this List<IFeature> features, Func<DatabaseConfigurator, IFeature<DatabaseConfigurator>> configure) =>
+        features.Add(configure(new()));
 
-    public static PropertyPart Index<TEntity>(this PropertyPart source, string name) =>
-        source.Index($"IX_{typeof(TEntity).Name}_{name}");
+    public static PropertyPart Index<TEntity>(this PropertyPart propertyPart, string name) =>
+        propertyPart.Index($"IX_{typeof(TEntity).Name}_{name}");
 
-    public static void Index(this IManyToOneInstance source, Type entity, string name) =>
-        source.Index($"IX_{entity.Name}_{name}");
+    public static void Index(this IManyToOneInstance manyToOne, Type entity, string name) =>
+        manyToOne.Index($"IX_{entity.Name}_{name}");
 }

--- a/src/recipe/Baked.Recipe.Service.Application/DependencyInjection/DependencyInjectionExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/DependencyInjection/DependencyInjectionExtensions.cs
@@ -6,18 +6,18 @@ namespace Baked;
 
 public static class DependencyInjectionExtensions
 {
-    public static void AddDependencyInjection(this List<ILayer> source) =>
-        source.Add(new DependencyInjectionLayer());
+    public static void AddDependencyInjection(this List<ILayer> layers) =>
+        layers.Add(new DependencyInjectionLayer());
 
-    public static IServiceCollection GetServiceCollection(this ApplicationContext source) =>
-        source.Get<IServiceCollection>();
+    public static IServiceCollection GetServiceCollection(this ApplicationContext context) =>
+        context.Get<IServiceCollection>();
 
-    public static IServiceProvider GetServiceProvider(this ApplicationContext source) =>
-        source.Get<IServiceProvider>();
+    public static IServiceProvider GetServiceProvider(this ApplicationContext context) =>
+        context.Get<IServiceProvider>();
 
-    public static void ConfigureServiceCollection(this LayerConfigurator source, Action<IServiceCollection> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureServiceCollection(this LayerConfigurator configurator, Action<IServiceCollection> configuration) =>
+        configurator.Configure(configuration);
 
-    public static void ConfigureServiceProvider(this LayerConfigurator source, Action<IServiceProvider> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureServiceProvider(this LayerConfigurator configurator, Action<IServiceProvider> configuration) =>
+        configurator.Configure(configuration);
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/DomainExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/DomainExtensions.cs
@@ -12,11 +12,11 @@ public static class DomainExtensions
     public static void AddDomain(this ICollection<ILayer> layers) =>
         layers.Add(new DomainLayer());
 
-    public static IDomainTypeCollection GetDomainTypes(this ApplicationContext source) =>
-        source.Get<IDomainTypeCollection>();
+    public static IDomainTypeCollection GetDomainTypes(this ApplicationContext application) =>
+        application.Get<IDomainTypeCollection>();
 
-    public static DomainModel GetDomainModel(this ApplicationContext source) =>
-        source.Get<DomainModel>();
+    public static DomainModel GetDomainModel(this ApplicationContext context) =>
+        context.Get<DomainModel>();
 
     public static void ConfigureDomainTypeCollection(this LayerConfigurator configurator, Action<IDomainTypeCollection> configuration) =>
         configurator.Configure(configuration);
@@ -49,14 +49,14 @@ public static class DomainExtensions
         }
     }
 
-    public static bool Contains(this ModelCollection<TypeModelReference> source, Type type) =>
-        source.Contains(TypeModelReference.IdFrom(type));
+    public static bool Contains(this ModelCollection<TypeModelReference> typeReferences, Type type) =>
+        typeReferences.Contains(TypeModelReference.IdFrom(type));
 
-    public static bool Contains(this ModelCollection<TypeModelReference> source, TypeModel type) =>
-        source.Contains(((IModel)type).Id);
+    public static bool Contains(this ModelCollection<TypeModelReference> typeReferences, TypeModel type) =>
+        typeReferences.Contains(((IModel)type).Id);
 
-    public static bool Contains(this ModelCollection<TypeModel> source, Type type) =>
-        source.Contains(TypeModelReference.IdFrom(type));
+    public static bool Contains(this ModelCollection<TypeModel> types, Type type) =>
+        types.Contains(TypeModelReference.IdFrom(type));
 
     public static bool Has<T>(this ICustomAttributesModel model) where T : Attribute =>
         model.CustomAttributes.Contains<T>();

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/Model/IDocumentedModel.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/Model/IDocumentedModel.cs
@@ -1,0 +1,8 @@
+﻿using System.Xml;
+
+namespace Baked.Domain.Model;
+
+public interface IDocumentedModel
+{
+    XmlNode? Documentation { get; }
+}

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/Model/MethodModel.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/Model/MethodModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Xml;
 
 namespace Baked.Domain.Model;
 
@@ -7,7 +8,9 @@ public record MethodModel(
     MethodOverloadModel DefaultOverload,
     ReadOnlyCollection<MethodOverloadModel> Overloads,
     AttributeCollection CustomAttributes
-) : IModel, ICustomAttributesModel
+) : IModel, ICustomAttributesModel, IDocumentedModel
 {
     string IModel.Id => Name;
+
+    public XmlNode? Documentation => DefaultOverload.Documentation;
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/Model/MethodOverloadModel.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/Model/MethodOverloadModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Baked.Domain.Model;
+﻿using System.Xml;
+
+namespace Baked.Domain.Model;
 
 public record MethodOverloadModel(
     bool IsPublic,
@@ -16,8 +18,10 @@ public record MethodOverloadModel(
     IsVirtual,
     false,
     Parameters
-)
+), IDocumentedModel
 {
     public TypeModel ReturnType => ReturnTypeReference.Model;
     public TypeModel? DeclaringType => DeclaringTypeReference?.Model;
+
+    public XmlNode? Documentation { get; init; }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/Model/ParameterModel.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/Model/ParameterModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Xml;
 
 namespace Baked.Domain.Model;
 
@@ -9,9 +10,11 @@ public record ParameterModel(
     object? DefaultValue,
     AttributeCollection CustomAttributes,
     Action<Action<ParameterInfo>> Apply
-) : IModel, ICustomAttributesModel
+) : IModel, ICustomAttributesModel, IDocumentedModel
 {
     public TypeModel ParameterType => ParameterTypeReference.Model;
 
     string IModel.Id => Name;
+
+    public XmlNode? Documentation { get; init; }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/Model/PropertyModel.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/Model/PropertyModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Baked.Domain.Model;
+﻿using System.Xml;
+
+namespace Baked.Domain.Model;
 
 public record PropertyModel(
     string Name,
@@ -6,9 +8,11 @@ public record PropertyModel(
     bool IsPublic,
     bool IsVirtual,
     AttributeCollection CustomAttributes
-) : IModel, ICustomAttributesModel
+) : IModel, ICustomAttributesModel, IDocumentedModel
 {
     public TypeModel PropertyType => PropertyTypeReference.Model;
 
     string IModel.Id { get; } = Name;
+
+    public XmlNode? Documentation { get; set; }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/XmlComments.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/XmlComments.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Concurrent;
+using System.Reflection;
+using System.Xml;
+
+namespace Baked.Domain;
+
+public class XmlComments
+{
+    static ConcurrentDictionary<Assembly, XmlNode> _comments = new();
+
+    public static XmlNode? Get(Assembly? assembly)
+    {
+        if (assembly is null) { return null; }
+        if (_comments.TryGetValue(assembly, out var result)) { return result; }
+
+        var document = new XmlDocument();
+        string filename = assembly.Location.Replace(".dll", ".xml");
+        if (!File.Exists(filename)) { return null; }
+
+        document.Load(filename);
+        if (document.DocumentElement is null) { return null; }
+
+        _comments.TryAdd(assembly, document.DocumentElement);
+
+        return document.DocumentElement;
+    }
+
+    public static XmlNode? Get(Type? type)
+    {
+        if (type is null) { return null; }
+
+        return
+            Get(type.Assembly)
+            ?.SelectSingleNode(MemberPath(XmlName(type)));
+    }
+
+    public static XmlNode? Get(PropertyInfo? propertyInfo)
+    {
+        if (propertyInfo is null) { return null; }
+
+        return
+            Get(propertyInfo.ReflectedType?.Assembly)
+            ?.SelectSingleNode(MemberPath(XmlName(propertyInfo)));
+    }
+
+    public static XmlNode? Get(MethodInfo? methodInfo)
+    {
+        if (methodInfo is null) { return null; }
+
+        return
+            Get(methodInfo.ReflectedType?.Assembly)
+            ?.SelectSingleNode(MemberPath(XmlName(methodInfo)));
+    }
+
+    public static XmlNode? Get(ParameterInfo? parameterInfo, XmlNode? methodDocumentation)
+    {
+        if (parameterInfo is null) { return null; }
+        if (methodDocumentation is null) { return null; }
+
+        return methodDocumentation?.SelectSingleNode(ParamPath(parameterInfo.Name));
+    }
+
+    static string MemberPath(string name) =>
+        $"members/member[@name='{name}']";
+
+    static string ParamPath(string? name) =>
+        $"param[@name='{name}']";
+
+    static string XmlName(Type type) =>
+        $"T:{type.FullName}";
+
+    static string XmlName(MethodInfo methodInfo) =>
+        $"M:{methodInfo.ReflectedType?.FullName}.{methodInfo.Name}({methodInfo.GetParameters().Select(p => p.ParameterType.FullName).Join(",")})";
+
+    static string XmlName(PropertyInfo propertyInfo) =>
+        $"P:{propertyInfo.ReflectedType?.FullName}.{propertyInfo.Name}";
+}

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/XmlComments.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/XmlComments.cs
@@ -69,8 +69,16 @@ public class XmlComments
     static string XmlName(Type type) =>
         $"T:{type.FullName}";
 
-    static string XmlName(MethodInfo methodInfo) =>
-        $"M:{methodInfo.ReflectedType?.FullName}.{methodInfo.Name}({methodInfo.GetParameters().Select(p => p.ParameterType.FullName).Join(",")})";
+    static string XmlName(MethodInfo methodInfo)
+    {
+        var parameters = methodInfo.GetParameters();
+        if (!parameters.Any())
+        {
+            return $"M:{methodInfo.ReflectedType?.FullName}.{methodInfo.Name}";
+        }
+
+        return $"M:{methodInfo.ReflectedType?.FullName}.{methodInfo.Name}({parameters.Select(p => p.ParameterType.FullName).Join(",")})";
+    }
 
     static string XmlName(PropertyInfo propertyInfo) =>
         $"P:{propertyInfo.ReflectedType?.FullName}.{propertyInfo.Name}";

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/XmlComments.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/XmlComments.cs
@@ -77,7 +77,26 @@ public class XmlComments
             return $"M:{methodInfo.ReflectedType?.FullName}.{methodInfo.Name}";
         }
 
-        return $"M:{methodInfo.ReflectedType?.FullName}.{methodInfo.Name}({parameters.Select(p => p.ParameterType.FullName).Join(",")})";
+        return $"M:{methodInfo.ReflectedType?.FullName}.{methodInfo.Name}({parameters.Select(p => XmlTypeName(p.ParameterType)).Join(",")})";
+    }
+
+    static string XmlTypeName(Type? type)
+    {
+        if (type is null) { return string.Empty; }
+
+        if (type.IsArray)
+        {
+            return $"{XmlTypeName(type.GetElementType())}[]";
+        }
+
+        var fullName = type.FullName ?? type.Name;
+
+        if (type.IsGenericType)
+        {
+            return $"{fullName[..fullName.IndexOf('`')]}{{{type.GenericTypeArguments.Select(XmlTypeName).Join(",")}}}";
+        }
+
+        return fullName;
     }
 
     static string XmlName(PropertyInfo propertyInfo) =>

--- a/src/recipe/Baked.Recipe.Service.Application/ExceptionHandling/ExceptionHandlingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/ExceptionHandling/ExceptionHandlingExtensions.cs
@@ -5,6 +5,6 @@ namespace Baked;
 
 public static class ExceptionHandlingExtensions
 {
-    public static void AddExceptionHandling(this IList<IFeature> source, Func<ExceptionHandlingConfigurator, IFeature<ExceptionHandlingConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddExceptionHandling(this IList<IFeature> features, Func<ExceptionHandlingConfigurator, IFeature<ExceptionHandlingConfigurator>> configure) =>
+        features.Add(configure(new()));
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Greeting/GreetingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Greeting/GreetingExtensions.cs
@@ -5,6 +5,6 @@ namespace Baked;
 
 public static class GreetingExtensions
 {
-    public static void AddGreeting(this List<IFeature> source, Func<GreetingConfigurator, IFeature<GreetingConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddGreeting(this List<IFeature> features, Func<GreetingConfigurator, IFeature<GreetingConfigurator>> configure) =>
+        features.Add(configure(new()));
 }

--- a/src/recipe/Baked.Recipe.Service.Application/HttpClient/HttpClientExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/HttpClient/HttpClientExtensions.cs
@@ -5,9 +5,9 @@ namespace Baked;
 
 public static class HttpClientExtensions
 {
-    public static void AddHttpClient(this List<ILayer> source) =>
-        source.Add(new HttpClientLayer());
+    public static void AddHttpClient(this List<ILayer> layers) =>
+        layers.Add(new HttpClientLayer());
 
-    public static void ConfigureHttpClients(this LayerConfigurator source, Action<List<HttpClientDescriptor>> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureHttpClients(this LayerConfigurator configurator, Action<List<HttpClientDescriptor>> configuration) =>
+        configurator.Configure(configuration);
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Lifetime/LifetimeExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Lifetime/LifetimeExtensions.cs
@@ -5,6 +5,6 @@ namespace Baked;
 
 public static class LifetimeExtensions
 {
-    public static void AddLifetimes(this List<IFeature> source, IEnumerable<Func<LifetimeConfigurator, IFeature<LifetimeConfigurator>>> configures) =>
-        source.AddRange(configures.Select(configure => configure(new())));
+    public static void AddLifetimes(this List<IFeature> features, IEnumerable<Func<LifetimeConfigurator, IFeature<LifetimeConfigurator>>> configures) =>
+        features.AddRange(configures.Select(configure => configure(new())));
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Logging/LoggingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Logging/LoggingExtensions.cs
@@ -5,6 +5,6 @@ namespace Baked;
 
 public static class LoggingExtensions
 {
-    public static void AddLogging(this List<IFeature> source, Func<LoggingConfigurator, IFeature<LoggingConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddLogging(this List<IFeature> features, Func<LoggingConfigurator, IFeature<LoggingConfigurator>> configure) =>
+        features.Add(configure(new()));
 }

--- a/src/recipe/Baked.Recipe.Service.Application/MockOverrider/MockOverriderExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/MockOverrider/MockOverriderExtensions.cs
@@ -7,8 +7,8 @@ namespace Baked;
 
 public static class MockOverriderExtensions
 {
-    public static void AddMockOverrider(this List<IFeature> source, Func<MockOverriderConfigurator, IFeature<MockOverriderConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddMockOverrider(this List<IFeature> features, Func<MockOverriderConfigurator, IFeature<MockOverriderConfigurator>> configure) =>
+        features.Add(configure(new()));
 
     public static T The<T>(this Stubber _, params object?[] mockOverrides) where T : notnull =>
         ServiceSpec.ServiceProvider.OverrideMocksAndGetRequiredService<T>(mockOverrides);

--- a/src/recipe/Baked.Recipe.Service.Application/Monitoring/MonitoringExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Monitoring/MonitoringExtensions.cs
@@ -6,9 +6,9 @@ namespace Baked;
 
 public static class MonitoringExtensions
 {
-    public static void AddMonitoring(this List<ILayer> source) =>
-        source.Add(new MonitoringLayer());
+    public static void AddMonitoring(this List<ILayer> layers) =>
+        layers.Add(new MonitoringLayer());
 
-    public static void ConfigureLoggingBuilder(this LayerConfigurator source, Action<ILoggingBuilder> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureLoggingBuilder(this LayerConfigurator configurator, Action<ILoggingBuilder> configuration) =>
+        configurator.Configure(configuration);
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Orm/OrmExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Orm/OrmExtensions.cs
@@ -12,8 +12,8 @@ namespace Baked;
 
 public static class OrmExtensions
 {
-    public static void AddOrm(this List<IFeature> source, Func<OrmConfigurator, IFeature<OrmConfigurator>> configure) =>
-        source.Add(configure(new()));
+    public static void AddOrm(this List<IFeature> features, Func<OrmConfigurator, IFeature<OrmConfigurator>> configure) =>
+        features.Add(configure(new()));
 
     public static void AddSingleById<T>(this ControllerModel controller, DomainModel domainModel) =>
         controller.Action["SingleById"] = new("SingleById", HttpMethod.Get, [controller.MappedType.Name], new(domainModel.Types[typeof(T)]), "target")

--- a/src/recipe/Baked.Recipe.Service.Application/RestApi/Conventions/UseDocumentationAsDescriptionConvention.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/RestApi/Conventions/UseDocumentationAsDescriptionConvention.cs
@@ -1,0 +1,41 @@
+﻿using Baked.Business.DomainAssemblies;
+using Baked.RestApi.Configuration;
+
+namespace Baked.RestApi.Conventions;
+
+public class UseDocumentationAsDescriptionConvention(TagDescriptions _descriptions)
+    : IApiModelConvention<ControllerModelContext>, IApiModelConvention<ActionModelContext>, IApiModelConvention<ParameterModelContext>
+{
+    public void Apply(ControllerModelContext context)
+    {
+        if (context.Controller.MappedType is null) { return; }
+        if (!context.Controller.MappedType.TryGetMembers(out var controllerMembers)) { return; }
+
+        var summary = controllerMembers.Documentation?["summary"]?.InnerText.Trim();
+
+        _descriptions[context.Controller.GroupName] = summary ?? string.Empty;
+    }
+
+    public void Apply(ActionModelContext context)
+    {
+        if (context.Action.MappedMethod is null) { return; }
+        if (context.Action.MappedMethod.Documentation is null) { return; }
+
+        var summary = context.Action.MappedMethod.Documentation["summary"]?.InnerText.Trim();
+        var remarks = context.Action.MappedMethod.Documentation["remarks"]?.InnerText.Trim();
+        if (summary is null && remarks is null) { return; }
+
+        context.Action.AdditionalAttributes.Add($"SwaggerOperation(Summary = \"{summary}\", Description = \"{remarks}\")");
+    }
+
+    public void Apply(ParameterModelContext context)
+    {
+        if (context.Parameter.MappedParameter is null) { return; }
+        if (context.Parameter.MappedParameter.Documentation is null) { return; }
+
+        var description = context.Parameter.MappedParameter.Documentation.InnerText.Trim();
+        if (description is null) { return; }
+
+        context.Parameter.AdditionalAttributes.Add($"SwaggerSchema(\"{description}\")");
+    }
+}

--- a/src/recipe/Baked.Recipe.Service.Application/RestApi/RestApiExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/RestApi/RestApiExtensions.cs
@@ -14,38 +14,38 @@ namespace Baked;
 
 public static class RestApiExtensions
 {
-    public static void AddRestApi(this IList<ILayer> source) =>
-        source.Add(new RestApiLayer());
+    public static void AddRestApi(this IList<ILayer> layers) =>
+        layers.Add(new RestApiLayer());
 
-    public static void ConfigureApiModel(this LayerConfigurator source, Action<ApiModel> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureApiModel(this LayerConfigurator configurator, Action<ApiModel> configuration) =>
+        configurator.Configure(configuration);
 
-    public static void ConfigureApiModelConventions(this LayerConfigurator source, Action<IApiModelConventionCollection> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureApiModelConventions(this LayerConfigurator configurator, Action<IApiModelConventionCollection> configuration) =>
+        configurator.Configure(configuration);
 
-    public static void ConfigureApplicationParts(this LayerConfigurator source, Action<IApplicationPartCollection> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureApplicationParts(this LayerConfigurator configurator, Action<IApplicationPartCollection> configuration) =>
+        configurator.Configure(configuration);
 
-    public static void ConfigureMvcNewtonsoftJsonOptions(this LayerConfigurator source, Action<MvcNewtonsoftJsonOptions> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureMvcNewtonsoftJsonOptions(this LayerConfigurator configurator, Action<MvcNewtonsoftJsonOptions> configuration) =>
+        configurator.Configure(configuration);
 
-    public static void ConfigureSwaggerGenOptions(this LayerConfigurator source, Action<SwaggerGenOptions> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureSwaggerGenOptions(this LayerConfigurator configurator, Action<SwaggerGenOptions> configuration) =>
+        configurator.Configure(configuration);
 
-    public static void ConfigureSwaggerOptions(this LayerConfigurator source, Action<SwaggerOptions> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureSwaggerOptions(this LayerConfigurator configurator, Action<SwaggerOptions> configuration) =>
+        configurator.Configure(configuration);
 
-    public static void ConfigureSwaggerUIOptions(this LayerConfigurator source, Action<SwaggerUIOptions> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureSwaggerUIOptions(this LayerConfigurator configurator, Action<SwaggerUIOptions> configuration) =>
+        configurator.Configure(configuration);
 
-    public static IMvcBuilder AddApplicationParts(this IMvcBuilder source, IApplicationPartCollection applicationParts)
+    public static IMvcBuilder AddApplicationParts(this IMvcBuilder mvcBuilder, IApplicationPartCollection applicationParts)
     {
         foreach (var applicationPart in applicationParts)
         {
-            source.AddApplicationPart(applicationPart.Assembly);
+            mvcBuilder.AddApplicationPart(applicationPart.Assembly);
         }
 
-        return source;
+        return mvcBuilder;
     }
 
     public static void Add(this IApiModelConventionCollection collection, IApiModelConvention convention,
@@ -103,12 +103,12 @@ public static class RestApiExtensions
         return parts;
     }
 
-    internal static IMvcBuilder AddNewtonsoftJson(this IMvcBuilder source, MvcNewtonsoftJsonOptions options)
+    internal static IMvcBuilder AddNewtonsoftJson(this IMvcBuilder mvcBuilder, MvcNewtonsoftJsonOptions options)
     {
-        source.AddNewtonsoftJson();
-        source.Services.AddOptions();
-        source.Services.AddSingleton<IOptions<MvcNewtonsoftJsonOptions>>(sp => new OptionsWrapper<MvcNewtonsoftJsonOptions>(options));
+        mvcBuilder.AddNewtonsoftJson();
+        mvcBuilder.Services.AddOptions();
+        mvcBuilder.Services.AddSingleton<IOptions<MvcNewtonsoftJsonOptions>>(sp => new OptionsWrapper<MvcNewtonsoftJsonOptions>(options));
 
-        return source;
+        return mvcBuilder;
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Testing/TestingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Testing/TestingExtensions.cs
@@ -8,31 +8,31 @@ namespace Baked;
 
 public static class TestingExtensions
 {
-    public static void AddTesting(this List<ILayer> source) =>
-        source.Add(new TestingLayer());
+    public static void AddTesting(this List<ILayer> layers) =>
+        layers.Add(new TestingLayer());
 
-    public static void ConfigureTestConfiguration(this LayerConfigurator source, Action<TestConfiguration> configuration) =>
-        source.Configure(configuration);
+    public static void ConfigureTestConfiguration(this LayerConfigurator configurator, Action<TestConfiguration> configuration) =>
+        configurator.Configure(configuration);
 
-    public static void Add<T>(this IMockCollection source, bool singleton = false, Action<Mock<T>>? setup = default) where T : class =>
-        source.Add(new(
+    public static void Add<T>(this IMockCollection mocks, bool singleton = false, Action<Mock<T>>? setup = default) where T : class =>
+        mocks.Add(new(
             Type: typeof(T),
             Singleton: singleton,
             Setup: setup == default ? default : obj => setup((Mock<T>)obj)
         ));
 
-    public static void Add(this IMockCollection source, Type service, bool singleton = false, Action<Mock>? setup = default) =>
-        source.Add(new(
+    public static void Add(this IMockCollection mocks, Type service, bool singleton = false, Action<Mock>? setup = default) =>
+        mocks.Add(new(
             Type: service,
             Singleton: singleton,
             Setup: setup == default ? default : obj => setup(obj)
         ));
 
-    public static void Returns<TMock, TResult>(this ISetup<TMock, TResult> source, params TResult[] results) where TMock : class
+    public static void Returns<TMock, TResult>(this ISetup<TMock, TResult> setup, params TResult[] results) where TMock : class
     {
         int currentResultIndex = 0;
 
-        source.Returns(() =>
+        setup.Returns(() =>
         {
             if (currentResultIndex >= results.Length)
             {
@@ -43,11 +43,11 @@ public static class TestingExtensions
         });
     }
 
-    public static void ReturnsAsync<TMock, TResult>(this ISetup<TMock, Task<TResult>> source, params TResult[] results) where TMock : class
+    public static void ReturnsAsync<TMock, TResult>(this ISetup<TMock, Task<TResult>> setup, params TResult[] results) where TMock : class
     {
         int currentResultIndex = 0;
 
-        source.ReturnsAsync(() =>
+        setup.ReturnsAsync(() =>
         {
             if (currentResultIndex >= results.Length)
             {

--- a/src/recipe/Baked.Recipe.Service/Authentication/StringExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service/Authentication/StringExtensions.cs
@@ -5,13 +5,13 @@ namespace System;
 
 public static partial class StringExtensions
 {
-    public static byte[] ToSHA256(this string source)
+    public static byte[] ToSHA256(this string str)
     {
         using var sha256 = SHA256.Create();
 
-        return sha256.ComputeHash(Encoding.UTF8.GetBytes(source));
+        return sha256.ComputeHash(Encoding.UTF8.GetBytes(str));
     }
 
-    public static string ToBase64(this byte[] source) =>
-        Convert.ToBase64String(source);
+    public static string ToBase64(this byte[] bytes) =>
+        Convert.ToBase64String(bytes);
 }

--- a/src/recipe/Baked.Recipe.Service/Communication/CommunicationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service/Communication/CommunicationExtensions.cs
@@ -4,9 +4,9 @@ namespace Baked.Communication;
 
 public static class CommunicationExtensions
 {
-    public static Uri WithQuery(this Uri source, Dictionary<string, string> parameters)
+    public static Uri WithQuery(this Uri uri, Dictionary<string, string> parameters)
     {
-        var builder = new UriBuilder(source);
+        var builder = new UriBuilder(uri);
 
         if (!string.IsNullOrEmpty(builder.Query))
         {

--- a/test/core/Baked.Test.Architecture/Extensions/BannerExtensions.cs
+++ b/test/core/Baked.Test.Architecture/Extensions/BannerExtensions.cs
@@ -8,8 +8,8 @@ public static class BannerExtensions
     public static IBanner ABanner(this Mocker _) =>
         new Mock<IBanner>().Object;
 
-    public static void VerifyPrinted(this IBanner source) =>
-        Mock.Get(source).Verify(b => b.Print());
+    public static void VerifyPrinted(this IBanner banner) =>
+        Mock.Get(banner).Verify(b => b.Print());
 
     public static BakedBanner ABakedBanner(this Stubber _) =>
         new();

--- a/test/core/Baked.Test.Architecture/Extensions/FeatureExtensions.cs
+++ b/test/core/Baked.Test.Architecture/Extensions/FeatureExtensions.cs
@@ -15,12 +15,12 @@ public static class FeatureExtensions
         return result.Object;
     }
 
-    public static void VerifyInitialized(this IFeature source) =>
-        Mock.Get(source).Verify(f => f.Configure(It.IsAny<LayerConfigurator>()));
+    public static void VerifyInitialized(this IFeature feature) =>
+        Mock.Get(feature).Verify(f => f.Configure(It.IsAny<LayerConfigurator>()));
 
-    public static void VerifyConfigures<TTarget>(this IFeature source, TTarget target) where TTarget : notnull =>
-        Mock.Get(source).Verify(f => f.Configure(LayerConfigurator.Create(new(), target)));
+    public static void VerifyConfigures<TTarget>(this IFeature feature, TTarget target) where TTarget : notnull =>
+        Mock.Get(feature).Verify(f => f.Configure(LayerConfigurator.Create(new(), target)));
 
-    public static void VerifyConfiguresNothing(this IFeature source) =>
-        Mock.Get(source).Verify(f => f.Configure(It.IsAny<LayerConfigurator>()), Times.Never());
+    public static void VerifyConfiguresNothing(this IFeature feature) =>
+        Mock.Get(feature).Verify(f => f.Configure(It.IsAny<LayerConfigurator>()), Times.Never());
 }

--- a/test/core/Baked.Test.Architecture/Extensions/LayerExtensions.cs
+++ b/test/core/Baked.Test.Architecture/Extensions/LayerExtensions.cs
@@ -34,11 +34,11 @@ public static class LayerExtensions
         return result.Object;
     }
 
-    public static void VerifyInitialized(this ILayer source) =>
-        Mock.Get(source).Verify(l => l.GetPhases());
+    public static void VerifyInitialized(this ILayer layer) =>
+        Mock.Get(layer).Verify(l => l.GetPhases());
 
-    public static void VerifyApplied(this ILayer source, IPhase phase) =>
-        Mock.Get(source)
+    public static void VerifyApplied(this ILayer layer, IPhase phase) =>
+        Mock.Get(layer)
             .Verify(l => l.GetContext(
                 phase,
                 It.IsAny<ApplicationContext>()

--- a/test/core/Baked.Test.Architecture/Extensions/PhaseContextExtensions.cs
+++ b/test/core/Baked.Test.Architecture/Extensions/PhaseContextExtensions.cs
@@ -21,10 +21,10 @@ public static class PhaseContextExtensions
         };
     }
 
-    public static void ShouldConfigureTarget<TTarget>(this PhaseContext source, TTarget expected)
+    public static void ShouldConfigureTarget<TTarget>(this PhaseContext phaseContext, TTarget expected)
     {
         var configured = false;
-        foreach (var configurator in source.Configurators)
+        foreach (var configurator in phaseContext.Configurators)
         {
             configurator.Configure((TTarget actual) =>
             {
@@ -37,10 +37,10 @@ public static class PhaseContextExtensions
         configured.ShouldBeTrue("Phase context didn't get configured");
     }
 
-    public static void ShouldConfigureTwoTargets<TTarget1, TTarget2>(this PhaseContext source, TTarget1 expected1, TTarget2 expected2)
+    public static void ShouldConfigureTwoTargets<TTarget1, TTarget2>(this PhaseContext phaseContext, TTarget1 expected1, TTarget2 expected2)
     {
         var configured = false;
-        foreach (var configurator in source.Configurators)
+        foreach (var configurator in phaseContext.Configurators)
         {
             configurator.Configure((TTarget1 actual1, TTarget2 actual2) =>
             {
@@ -54,10 +54,10 @@ public static class PhaseContextExtensions
         configured.ShouldBeTrue("Phase context didn't get configured");
     }
 
-    public static void ShouldConfigureThreeTargets<TTarget1, TTarget2, TTarget3>(this PhaseContext source, TTarget1 expected1, TTarget2 expected2, TTarget3 expected3)
+    public static void ShouldConfigureThreeTargets<TTarget1, TTarget2, TTarget3>(this PhaseContext phaseContext, TTarget1 expected1, TTarget2 expected2, TTarget3 expected3)
     {
         var configured = false;
-        foreach (var configurator in source.Configurators)
+        foreach (var configurator in phaseContext.Configurators)
         {
             configurator.Configure((TTarget1 actual1, TTarget2 actual2, TTarget3 actual3) =>
             {
@@ -72,9 +72,9 @@ public static class PhaseContextExtensions
         configured.ShouldBeTrue("Phase context didn't get configured");
     }
 
-    public static void ShouldAddValueToContextOnDispose<T>(this PhaseContext source, T value, ApplicationContext context)
+    public static void ShouldAddValueToContextOnDispose<T>(this PhaseContext phaseContext, T value, ApplicationContext context)
     {
-        using (source)
+        using (phaseContext)
         {
             context.ShouldNotHave(value);
         }

--- a/test/core/Baked.Test.Architecture/Extensions/PhaseExtensions.cs
+++ b/test/core/Baked.Test.Architecture/Extensions/PhaseExtensions.cs
@@ -35,15 +35,15 @@ public static class PhaseExtensions
         return result.Object;
     }
 
-    public static void VerifyInitialized(this IPhase source,
+    public static void VerifyInitialized(this IPhase phaseContext,
         ApplicationContext? context = default
     )
     {
-        Mock.Get(source).Verify(p => p.Initialize(), Times.Once);
+        Mock.Get(phaseContext).Verify(p => p.Initialize(), Times.Once);
 
         if (context is not null)
         {
-            source.Context.ShouldBeEquivalentTo(context);
+            phaseContext.Context.ShouldBeEquivalentTo(context);
         }
     }
 }

--- a/test/recipe/Baked.Test.Recipe.Service.Application/ConfigurationOverrider/ConfigurationOverriderExtensions.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/ConfigurationOverrider/ConfigurationOverriderExtensions.cs
@@ -5,6 +5,6 @@ namespace Baked;
 
 public static class ConfigurationOverriderExtensions
 {
-    public static void AddConfigurationOverrider(this List<IFeature> source) =>
-        source.Add(new ConfigurationOverriderFeature());
+    public static void AddConfigurationOverrider(this List<IFeature> features) =>
+        features.Add(new ConfigurationOverriderFeature());
 }

--- a/test/recipe/Baked.Test.Recipe.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
@@ -1,6 +1,7 @@
 ﻿using Baked.Architecture;
 using Baked.RestApi.Model;
 using Baked.Test.Authentication;
+using Baked.Test.Business;
 using Baked.Test.ExceptionHandling;
 using Baked.Test.Orm;
 using Microsoft.AspNetCore.Authorization;
@@ -23,6 +24,8 @@ public class ConfigurationOverriderFeature : IFeature
             var domainModel = configurator.Context.GetDomainModel();
 
             api.GetController<AuthenticationSamples>().Action[nameof(AuthenticationSamples.FormPostAuthenticate)].UseForm = true;
+            api.GetController<DocumentationSamples>().Action[nameof(DocumentationSamples.Route)].Parameter["route"].From = ParameterModelFrom.Route;
+            api.GetController<DocumentationSamples>().Action[nameof(DocumentationSamples.Route)].Parameter["route"].RoutePosition = 2;
             api.GetController<ExceptionSamples>().Action[nameof(ExceptionSamples.Throw)].Parameter["handled"].From = ParameterModelFrom.Query;
             api.GetController<Entities>().AddSingleById<Entity>(domainModel);
         });

--- a/test/recipe/Baked.Test.Recipe.Service.Application/appsettings.json
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/appsettings.json
@@ -1,6 +1,10 @@
 {
     "Authentication": {
         "FixedBearerToken": {
+            "Description": {
+                "additional": "Additional data for form post authentication"
+            },
+
             "Jane": "token-jane",
             "John": "token-john",
             "Postman": "token-postman",

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/IncludingXmlComments.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/IncludingXmlComments.cs
@@ -33,6 +33,24 @@ public class IncludingXmlComments : TestServiceSpec
         returns.InnerText.Trim().ShouldBe("Return documentation");
     }
 
+    [Test]
+    public void Accessing_method_documentation_of_a_parameterless_method()
+    {
+        var method =
+            DomainModel
+                .Types[typeof(DocumentationSamples)]
+                .GetMembers()
+                .GetMethod(nameof(DocumentationSamples.ParameterlessMethod));
+
+        var summary = method.Documentation?["summary"];
+        summary.ShouldNotBeNull();
+        summary.InnerText.Trim().ShouldBe("Method summary");
+
+        var returns = method.Documentation?["returns"];
+        returns.ShouldNotBeNull();
+        returns.InnerText.Trim().ShouldBe("Return documentation");
+    }
+
     [TestCase("parameter1", "Parameter 1 documentation")]
     [TestCase("parameter2", "Parameter 2 documentation")]
     public void Accessing_parameter_documentation(string name, string expectedDocumentation)

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/IncludingXmlComments.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/IncludingXmlComments.cs
@@ -1,0 +1,69 @@
+namespace Baked.Test.Business;
+
+public class IncludingXmlComments : TestServiceSpec
+{
+    [Test]
+    public void Accessing_class_documentation()
+    {
+        var members =
+            DomainModel
+                .Types[typeof(DocumentationSamples)]
+                .GetMembers();
+
+        var summary = members.Documentation?["summary"];
+        summary.ShouldNotBeNull();
+        summary.InnerText.Trim().ShouldBe("Class summary");
+    }
+
+    [Test]
+    public void Accessing_method_documentation()
+    {
+        var method =
+            DomainModel
+                .Types[typeof(DocumentationSamples)]
+                .GetMembers()
+                .GetMethod(nameof(DocumentationSamples.Method));
+
+        var summary = method.Documentation?["summary"];
+        summary.ShouldNotBeNull();
+        summary.InnerText.Trim().ShouldBe("Method summary");
+
+        var returns = method.Documentation?["returns"];
+        returns.ShouldNotBeNull();
+        returns.InnerText.Trim().ShouldBe("Return documentation");
+    }
+
+    [TestCase("parameter1", "Parameter 1 documentation")]
+    [TestCase("parameter2", "Parameter 2 documentation")]
+    public void Accessing_parameter_documentation(string name, string expectedDocumentation)
+    {
+        var parameter =
+            DomainModel
+                .Types[typeof(DocumentationSamples)]
+                .GetMembers()
+                .GetMethod(nameof(DocumentationSamples.Method))
+                .Parameters[name];
+
+        var documentation = parameter.Documentation?.InnerText;
+        documentation.ShouldNotBeNull();
+        documentation.Trim().ShouldBe(expectedDocumentation);
+    }
+
+    [Test]
+    public void Accessing_property_documentation()
+    {
+        var property =
+            DomainModel
+                .Types[typeof(DocumentedData)]
+                .GetMembers()
+                .Properties[nameof(DocumentedData.Property)];
+
+        var summary = property.Documentation?["summary"];
+        summary.ShouldNotBeNull();
+        summary.InnerText.Trim().ShouldBe("Property summary");
+
+        var value = property.Documentation?["value"];
+        value.ShouldNotBeNull();
+        value.InnerText.Trim().ShouldBe("Value explanation");
+    }
+}

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/IncludingXmlComments.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/IncludingXmlComments.cs
@@ -1,4 +1,4 @@
-namespace Baked.Test.Business;
+﻿namespace Baked.Test.Business;
 
 public class IncludingXmlComments : TestServiceSpec
 {
@@ -60,6 +60,23 @@ public class IncludingXmlComments : TestServiceSpec
                 .Types[typeof(DocumentationSamples)]
                 .GetMembers()
                 .GetMethod(nameof(DocumentationSamples.Method))
+                .Parameters[name];
+
+        var documentation = parameter.Documentation?.InnerText;
+        documentation.ShouldNotBeNull();
+        documentation.Trim().ShouldBe(expectedDocumentation);
+    }
+
+    [TestCase("enumerable", "Enumerable description")]
+    [TestCase("array", "Array description")]
+    [TestCase("dictionary", "Dictionary description")]
+    public void Accessing_array_and_generic_parameter_documentation(string name, string expectedDocumentation)
+    {
+        var parameter =
+            DomainModel
+                .Types[typeof(DocumentationSamples)]
+                .GetMembers()
+                .GetMethod(nameof(DocumentationSamples.ArrayAndGenericParameters))
                 .Parameters[name];
 
         var documentation = parameter.Documentation?.InnerText;

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
@@ -1,4 +1,6 @@
-﻿namespace Baked.Test.Business;
+﻿using Newtonsoft.Json.Linq;
+
+namespace Baked.Test.Business;
 
 public class SwaggerSchemaGeneration : TestServiceNfr
 {
@@ -6,13 +8,77 @@ public class SwaggerSchemaGeneration : TestServiceNfr
     public async Task Generates_swagger_json_automatically()
     {
         var response = await Client.GetAsync("/swagger/samples/swagger.json");
-
         dynamic? content = await response.Content.Deserialize();
 
         ((string?)content?.paths["/time-provider-samples/now"].get.tags[0]).ShouldBe("TimeProviderSamples");
     }
 
     [Test]
-    [Ignore("not implemented")]
-    public void Swagger_includes_xml_documentation() => throw new("fail");
+    public async Task Class_summary_section_is_placed_in_tags_description()
+    {
+        var response = await Client.GetAsync("/swagger/samples/swagger.json");
+        dynamic? content = await response.Content.Deserialize();
+        JArray? tags = content?.tags;
+        var tag = tags?.Single(tag => tag["name"]?.Value<string>() == "DocumentationSamples");
+
+        tag.ShouldNotBeNull();
+        tag["description"].ShouldBe("Class summary");
+    }
+
+    [Test]
+    public async Task Method_summary_and_remarks_are_placed_in_endpoint_summary_and_description()
+    {
+        var response = await Client.GetAsync("/swagger/samples/swagger.json");
+        dynamic? content = await response.Content.Deserialize();
+        var endpoint = content?.paths["/documentation-samples/method"].post;
+
+        ((string?)endpoint?.summary).ShouldBe("Method summary");
+        ((string?)endpoint?.description).ShouldBe("Method description");
+    }
+
+    [Test]
+    public async Task Method_parameter_comments_are_placed_in_schema_property_descriptions()
+    {
+        var response = await Client.GetAsync("/swagger/samples/swagger.json");
+
+        dynamic? content = await response.Content.Deserialize();
+        var schema = content?.components.schemas["test--business--documentation-samples--method-request"];
+
+        ((string?)schema?.properties["parameter1"].description).ShouldBe("Parameter 1 documentation");
+        ((string?)schema?.properties["parameter2"].description).ShouldBe("Parameter 2 documentation");
+    }
+
+    [Test]
+    public async Task Route_parameters_are_placed_in_schema_description_under_parameters()
+    {
+        var response = await Client.GetAsync("/swagger/samples/swagger.json");
+
+        dynamic? content = await response.Content.Deserialize();
+        var endpoint = content?.paths["/documentation-samples/route/{route}"].post;
+
+        ((string?)endpoint?.parameters[0].schema?.description).ShouldBe("route description");
+    }
+
+    [Test]
+    public async Task Query_parameters_are_placed_in_schema_description_under_parameters()
+    {
+        var response = await Client.GetAsync("/swagger/samples/swagger.json");
+
+        dynamic? content = await response.Content.Deserialize();
+        var endpoint = content?.paths["/redirect-samples/form-post"].post;
+
+        ((string?)endpoint?.parameters[0].schema?.description).ShouldBe("uri description");
+    }
+
+    [Test]
+    public async Task Form_post_parameter_comments_are_placed_in_schema_property_descriptions()
+    {
+        var response = await Client.GetAsync("/swagger/samples/swagger.json");
+
+        dynamic? content = await response.Content.Deserialize();
+        var endpoint = content?.paths["/redirect-samples/form-post"].post;
+        var schema = endpoint?.requestBody.content["multipart/form-data"].schema;
+
+        ((string?)schema?.properties["key"].description).ShouldBe("key description");
+    }
 }

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
@@ -11,4 +11,8 @@ public class SwaggerSchemaGeneration : TestServiceNfr
 
         ((string?)content?.paths["/time-provider-samples/now"].get.tags[0]).ShouldBe("TimeProviderSamples");
     }
+
+    [Test]
+    [Ignore("not implemented")]
+    public void Swagger_includes_xml_documentation() => throw new("fail");
 }

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
@@ -37,6 +37,17 @@ public class SwaggerSchemaGeneration : TestServiceNfr
     }
 
     [Test]
+    public async Task Class_summary_and_remarks_are_used_for_non_documented_methods_in_command_classes()
+    {
+        var response = await Client.GetAsync("/swagger/samples/swagger.json");
+        dynamic? content = await response.Content.Deserialize();
+        var endpoint = content?.paths["/command"].post;
+
+        ((string?)endpoint?.summary).ShouldBe("Command summary from class");
+        ((string?)endpoint?.description).ShouldBe("Command remarks from class");
+    }
+
+    [Test]
     public async Task Method_parameter_comments_are_placed_in_schema_property_descriptions()
     {
         var response = await Client.GetAsync("/swagger/samples/swagger.json");

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
@@ -59,6 +59,19 @@ public class SwaggerSchemaGeneration : TestServiceNfr
         ((string?)schema?.properties["parameter2"].description).ShouldBe("Parameter 2 documentation");
     }
 
+    [TestCase("entity-parameters", "entityId", "Entity description")]
+    [TestCase("entity-list-parameters", "entityIds", "Entities description")]
+    [TestCase("entity-list-parameters", "otherEntityIds", "Other entities description")]
+    public async Task Entity_parameter_comments_are_kept_even_if_their_name_change(string method, string parameter, string expected)
+    {
+        var response = await Client.GetAsync("/swagger/samples/swagger.json");
+
+        dynamic? content = await response.Content.Deserialize();
+        var schema = content?.components.schemas[$"test--business--method-samples--{method}-request"];
+
+        ((string?)schema?.properties[parameter].description).ShouldBe(expected);
+    }
+
     [Test]
     public async Task Route_parameters_are_placed_in_schema_description_under_parameters()
     {

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Extensions/ExceptionExtensions.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Extensions/ExceptionExtensions.cs
@@ -2,9 +2,9 @@ namespace Baked.Test;
 
 public static class ExceptionExtensions
 {
-    public static void ShouldThrowExceptionWithServiceNotRegisteredMessage<T>(this Func<object> source) =>
-        source.ShouldThrowExceptionWithServiceNotRegisteredMessage(typeof(T));
+    public static void ShouldThrowExceptionWithServiceNotRegisteredMessage<T>(this Func<object> func) =>
+        func.ShouldThrowExceptionWithServiceNotRegisteredMessage(typeof(T));
 
-    public static void ShouldThrowExceptionWithServiceNotRegisteredMessage(this Func<object> source, Type serviceType) =>
-        source.ShouldThrow<Exception>().Message.ShouldBe($"No service for type '{serviceType}' has been registered.");
+    public static void ShouldThrowExceptionWithServiceNotRegisteredMessage(this Func<object> func, Type serviceType) =>
+        func.ShouldThrow<Exception>().Message.ShouldBe($"No service for type '{serviceType}' has been registered.");
 }

--- a/test/recipe/Baked.Test.Recipe.Service/Baked.Test.Recipe.Service.csproj
+++ b/test/recipe/Baked.Test.Recipe.Service/Baked.Test.Recipe.Service.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\recipe\Baked.Recipe.Service\Baked.Recipe.Service.csproj" />
   </ItemGroup>

--- a/test/recipe/Baked.Test.Recipe.Service/Business/DocumentationSamples.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/DocumentationSamples.cs
@@ -8,15 +8,18 @@ public class DocumentationSamples
     /// <summary>
     /// Method summary
     /// </summary>
+    /// <remarks>
+    /// Method description
+    /// </remarks>
+    /// <returns>
+    /// Return documentation
+    /// </returns>
     /// <param name="parameter1">
     /// Parameter 1 documentation
     /// </param>
     /// <param name="parameter2">
     /// Parameter 2 documentation
     /// </param>
-    /// <returns>
-    /// Return documentation
-    /// </returns>
     public DocumentedData Method(string parameter1, string parameter2) =>
         new() { Property = $"{parameter1} - {parameter2}" };
 }

--- a/test/recipe/Baked.Test.Recipe.Service/Business/DocumentationSamples.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/DocumentationSamples.cs
@@ -1,0 +1,22 @@
+﻿namespace Baked.Test.Business;
+
+/// <summary>
+/// Class summary
+/// </summary>
+public class DocumentationSamples
+{
+    /// <summary>
+    /// Method summary
+    /// </summary>
+    /// <param name="parameter1">
+    /// Parameter 1 documentation
+    /// </param>
+    /// <param name="parameter2">
+    /// Parameter 2 documentation
+    /// </param>
+    /// <returns>
+    /// Return documentation
+    /// </returns>
+    public DocumentedData Method(string parameter1, string parameter2) =>
+        new() { Property = $"{parameter1} - {parameter2}" };
+}

--- a/test/recipe/Baked.Test.Recipe.Service/Business/DocumentationSamples.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/DocumentationSamples.cs
@@ -23,6 +23,17 @@ public class DocumentationSamples
     public DocumentedData Method(string parameter1, string parameter2) =>
         new() { Property = $"{parameter1} - {parameter2}" };
 
+    /// <summary>
+    /// Method summary
+    /// </summary>
+    /// <remarks>
+    /// Method description
+    /// </remarks>
+    /// <returns>
+    /// Return documentation
+    /// </returns>
+    public void ParameterlessMethod() { }
+
     /// <param name="route">
     /// route description
     /// </param>

--- a/test/recipe/Baked.Test.Recipe.Service/Business/DocumentationSamples.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/DocumentationSamples.cs
@@ -34,6 +34,18 @@ public class DocumentationSamples
     /// </returns>
     public void ParameterlessMethod() { }
 
+    /// <param name="enumerable">
+    /// Enumerable description
+    /// </param>
+    /// <param name="array">
+    /// Array description
+    /// </param>
+    /// <param name="dictionary">
+    /// Dictionary description
+    /// </param>
+    public string ArrayAndGenericParameters(IEnumerable<string> enumerable, string[] array, Dictionary<string, string> dictionary) =>
+        $"{enumerable.Join(", ")} - {array.Join(", ")} - {dictionary.Join(", ")}";
+
     /// <param name="route">
     /// route description
     /// </param>

--- a/test/recipe/Baked.Test.Recipe.Service/Business/DocumentationSamples.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/DocumentationSamples.cs
@@ -22,4 +22,10 @@ public class DocumentationSamples
     /// </param>
     public DocumentedData Method(string parameter1, string parameter2) =>
         new() { Property = $"{parameter1} - {parameter2}" };
+
+    /// <param name="route">
+    /// route description
+    /// </param>
+    public string Route(string route) =>
+        route;
 }

--- a/test/recipe/Baked.Test.Recipe.Service/Business/DocumentedData.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/DocumentedData.cs
@@ -1,0 +1,15 @@
+﻿namespace Baked.Test.Business;
+
+/// <summary>
+/// Data summary
+/// </summary>
+public class DocumentedData
+{
+    /// <summary>
+    /// Property summary
+    /// </summary>
+    /// <value>
+    /// Value explanation
+    /// </value>
+    public string Property { get; init; } = default!;
+}

--- a/test/recipe/Baked.Test.Recipe.Service/Business/MethodSamples.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/MethodSamples.cs
@@ -60,9 +60,18 @@ public class MethodSamples(ILogger<MethodSamples> _logger)
     public void PrimitiveListParameters(List<string> strings, int[] ints, IEnumerable<DateTime> dateTimes) =>
         _logger.LogInformation($"{nameof(PrimitiveListParameters)} was called with [{strings.Join(", ")}], [{ints.Join(", ")}] and [{dateTimes.Join(", ")}]");
 
+    /// <param name="entity">
+    /// Entity description
+    /// </param>
     public Entity EntityParameters(Entity entity) =>
         entity;
 
+    /// <param name="entities">
+    /// Entities description
+    /// </param>
+    /// <param name="otherEntities">
+    /// Other entities description
+    /// </param>
     public IEnumerable<Entity> EntityListParameters(IEnumerable<Entity> entities, Entity[] otherEntities) =>
         [.. entities, .. otherEntities];
 

--- a/test/recipe/Baked.Test.Recipe.Service/CodingStyle/CommandPattern/ExecuteCommand.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/CodingStyle/CommandPattern/ExecuteCommand.cs
@@ -1,5 +1,11 @@
 ﻿namespace Baked.Test.CodingStyle.CommandPattern;
 
+/// <summary>
+/// Command summary from class
+/// </summary>
+/// <remarks>
+/// Command remarks from class
+/// </remarks>
 public class ExecuteCommand
 {
     public void Execute() { }

--- a/test/recipe/Baked.Test.Recipe.Service/CodingStyle/UriReturnIsRedirect/RedirectSamples.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/CodingStyle/UriReturnIsRedirect/RedirectSamples.cs
@@ -4,6 +4,9 @@ public class RedirectSamples
 {
     Uri _uri = default!;
 
+    /// <param name="uri">
+    /// uri description
+    /// </param>
     public RedirectSamples With(Uri uri)
     {
         _uri = uri;
@@ -11,6 +14,15 @@ public class RedirectSamples
         return this;
     }
 
+    /// <summary>
+    /// Form post summary
+    /// </summary>
+    /// <remarks>
+    /// Form post description
+    /// </remarks>
+    /// <param name="key">
+    /// key description
+    /// </param>
     public Uri FormPost(string key) =>
         new($"{_uri}?key={key}");
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -9,3 +9,5 @@
   - Document based securtiy definition extension is added
 - `json` request and response types were documented as more than one type,
   restricted to `application/json`
+- Domain model now comes with extensions to read xml documentation
+- Swagger now includes xml documentation coming from doman model

--- a/unreleased.md
+++ b/unreleased.md
@@ -9,5 +9,5 @@
   - Document based securtiy definition extension is added
 - `json` request and response types were documented as more than one type,
   restricted to `application/json`
-- Domain model now comes with extensions to read xml documentation
+- Domain model now contains xml comments as `XmlNode` instances
 - Swagger now includes xml documentation coming from doman model


### PR DESCRIPTION
Add support for xml documentations in domain model.

## Tasks

- [x] add xml doc helper functions
- [x] bind them to swagger docs through filters
  - [x] implement
  - [x] write tests so far
  - [x] query parameters
  - [x] form parameters
  - [x] route parameters
  - [x] command objects
  - [x] unique route parameter documentation
  - [x] fixed bearer token security definition docs

## Additional Tasks

- [x] rename all extension method this parameters from `source` to a relevant
  name
