### PR TITLE
Issue / SQLite for ARM

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="8.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
@@ -24,13 +25,14 @@
     <PackageVersion Include="MySql.Data" Version="9.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NHibernate" Version="5.5.2" />
+    <PackageVersion Include="NHibernate.Extensions.Sqlite" Version="8.0.8" />
     <PackageVersion Include="NUnit" Version="4.1.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.8" />
     <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
-    <PackageVersion Include="System.Data.SQLite" Version="1.0.118" />
   </ItemGroup>
 
 </Project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3.9'
 services:
   db:
-    image: mysql
+    image: mariadb
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:
@@ -11,22 +10,11 @@ services:
     ports:
       - 3366:3366
     healthcheck:
-      test: ["CMD", 'mysqladmin', 'ping', '-h', 'localhost','-P','3366', '-u', 'root', '-p$$MYSQL_ROOT_PASSWORD' ]
-      start_period: 2s
-      interval: 5s
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
       timeout: 5s
-      retries: 5
-  phpmyadmin:
-    image: phpmyadmin/phpmyadmin
-    depends_on:
-      db:
-        condition: service_healthy
-    environment:
-      PMA_HOST: db
-      PMA_PORT: 3366
-    restart: always
-    ports:
-      - 8080:80
+      retries: 3
   recipe.service:
     build:
       dockerfile: test/recipe/Baked.Test.Recipe.Service.Application/Dockerfile

--- a/docs/features/database.md
+++ b/docs/features/database.md
@@ -23,7 +23,7 @@ Adds local Sqlite database setup which creates local sqlite database in
 documents folder with given name.
 
 ```csharp
-c => c.Sqlite(fileName: "test.db")
+c => c.Sqlite(fileName: "test.db", autoExportSchema: false)
 ```
 
 ## MySql

--- a/src/recipe/Baked.Recipe.Service.Application/Baked.Recipe.Service.Application.csproj
+++ b/src/recipe/Baked.Recipe.Service.Application/Baked.Recipe.Service.Application.csproj
@@ -22,13 +22,15 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Moq" />
     <PackageReference Include="MySql.Data" />
     <PackageReference Include="NHibernate" />
+    <PackageReference Include="NHibernate.Extensions.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
-    <PackageReference Include="System.Data.SQLite" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/recipe/Baked.Recipe.Service.Application/DataAccess/DataAccessLayer.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/DataAccess/DataAccessLayer.cs
@@ -39,7 +39,7 @@ public class DataAccessLayer : LayerBase<AddServices, PostBuild>
 
             if (_persistenceConfiguration.AutoUpdateSchema)
             {
-                builder.ExposeConfiguration(c => new SchemaUpdate(c).Execute(true, true));
+                builder.ExposeConfiguration(c => new SchemaUpdate(c).Execute(false, true));
             }
 
             return builder.BuildConfiguration();

--- a/src/recipe/Baked.Recipe.Service.Application/DataAccess/Sqlite/SQLiteConfiguration.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/DataAccess/Sqlite/SQLiteConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using FluentNHibernate.Cfg.Db;
+using Microsoft.Data.Sqlite;
+using NHibernate.Extensions.Sqlite;
+
+namespace Baked.DataAccess.Sqlite;
+
+public class SQLiteConfiguration : PersistenceConfiguration<SQLiteConfiguration>
+{
+    public static SQLiteConfiguration Microsoft => new();
+
+    public SQLiteConfiguration()
+    {
+        Driver<SqliteDriver>();
+        Dialect<SqliteDialect>();
+        Raw("query.substitutions", "true=1;false=0");
+    }
+
+    public SQLiteConfiguration InMemory()
+    {
+        Raw("connection.release_mode", "on_close");
+
+        return ConnectionString(c => c.Is(new SqliteConnectionStringBuilder { DataSource = ":memory:" }.ToString()));
+    }
+
+    public SQLiteConfiguration UsingFile(string fileName) =>
+        ConnectionString(c => c.Is(new SqliteConnectionStringBuilder { DataSource = fileName }.ToString()));
+}

--- a/src/recipe/Baked.Recipe.Service.Application/Database/InMemory/InMemoryDatabaseFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Database/InMemory/InMemoryDatabaseFeature.cs
@@ -1,7 +1,6 @@
 ﻿using Baked.Architecture;
-using FluentNHibernate.Cfg.Db;
+using Baked.DataAccess.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
-using NHibernate.Dialect;
 
 namespace Baked.Database.InMemory;
 
@@ -16,12 +15,11 @@ public class InMemoryDatabaseFeature : IFeature<DatabaseConfigurator>
 
         configurator.ConfigurePersistence(persistence =>
         {
-            var sqlite = SQLiteConfiguration.Standard.InMemory().Dialect<SQLiteDialect>();
-
-            sqlite.MaxFetchDepth(1);
-
-            persistence.Configurer = sqlite;
             persistence.AutoExportSchema = true;
+            persistence.Configurer =
+                SQLiteConfiguration.Microsoft
+                    .InMemory()
+                    .MaxFetchDepth(1);
         });
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Database/Sqlite/SqliteDatabaseExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Database/Sqlite/SqliteDatabaseExtensions.cs
@@ -7,8 +7,10 @@ namespace Baked;
 public static class SqliteDatabaseExtensions
 {
     public static SqliteDatabaseFeature Sqlite(this DatabaseConfigurator _,
-        Setting<string>? fileName = default
+        Setting<string>? fileName = default,
+        Setting<bool>? autoExportSchema = default
     ) => new(
-        fileName ?? Settings.Required<string>("Database:Sqlite:FileName")
+        fileName ?? Settings.Required<string>("Database:Sqlite:FileName"),
+        autoExportSchema ?? Settings.Optional("Database:Sqlite:AutoExportSchema", true)
     );
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Database/Sqlite/SqliteDatabaseFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Database/Sqlite/SqliteDatabaseFeature.cs
@@ -1,12 +1,11 @@
 ﻿using Baked.Architecture;
 using Baked.Configuration;
-using FluentNHibernate.Cfg.Db;
+using Baked.DataAccess.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
-using NHibernate.Dialect;
 
 namespace Baked.Database.Sqlite;
 
-public class SqliteDatabaseFeature(Setting<string> _fileName)
+public class SqliteDatabaseFeature(Setting<string> _fileName, Setting<bool> _autoExportSchema)
     : IFeature<DatabaseConfigurator>
 {
     string FullFilePath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), _fileName);
@@ -20,12 +19,11 @@ public class SqliteDatabaseFeature(Setting<string> _fileName)
 
         configurator.ConfigurePersistence(persistence =>
         {
-            var sqlite = SQLiteConfiguration.Standard.UsingFile(FullFilePath).Dialect<SQLiteDialect>();
-
-            sqlite.MaxFetchDepth(1);
-
-            persistence.Configurer = sqlite;
-            persistence.AutoUpdateSchema = true;
+            persistence.AutoExportSchema = _autoExportSchema;
+            persistence.Configurer =
+                SQLiteConfiguration.Microsoft
+                    .UsingFile(FullFilePath)
+                    .MaxFetchDepth(1);
         });
 
         configurator.ConfigureMiddlewareCollection(middlewares =>

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,6 @@
 # Unreleased
+
+## Improvements
+
+- `InMemory` and `Sqlite` data base features were not working under ARM
+  processors, fixed.

--- a/unreleased.md
+++ b/unreleased.md
@@ -3,4 +3,19 @@
 ## Improvements
 
 - `InMemory` and `Sqlite` data base features were not working under ARM
-  processors, fixed.
+  processors, fixed
+- Automatic schema update is removed from `Sqlite` database because
+  `Microsoft.Data.Sqlite.Core` does not support `SchemaUpdate`
+- `autoExportSchema` parameter is introduced to `Sqlite` database with default
+  value `true` to use automatic schema for development databases which clears
+  data each time your application runs. You may set it to false if you want your
+  data to retain.
+
+## Library Upgrades
+
+| Package                       | Old Version | New Version |
+| ----------------------------- | ----------- | ----------- |
+| Microsoft.Data.Sqlite.Core    | new         | 8.0.7       |
+| NHibernate.Extensions.Sqlite  | new         | 8.0.8       |
+| SQLitePCLRaw.bundle_e_sqlite3 | new         | 2.1.8       |
+| System.Data.SQLite            | 1.0.118     | removed     |


### PR DESCRIPTION
Add SQLite driver that uses microsoft.data.sqlite to be able to run tests in ARM
processors.

## Tasks

- [x] Research for sqlite driver that uses `Microsoft.Data.Sqlite`
- [x] Implement/use new sqlite driver for `InMemory` and `Sqlite` features

## Additional Tasks

- [x] Fix MySql problem in docker-compose in Docker Server v27.0.3
  - currently works in Docker Desktop 4.31.0 (engine version 26.1.4)
  - switched to mariadb
