### PR TITLE
Issue / Don't Ensure Success

### DIFF
--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,7 @@
 # Unreleased
+
+## Improvements
+
+- Change `Response.StatusCode` property type to `HttpStatusCode`
+- Mock `Client` now returns empty `200` response when no response parameter is
+  set


### PR DESCRIPTION
Improve mocking client

## Tasks

- [ ] Change `Response.StatusCode` type to `HttpStatusCode`
- [ ] Return empty success response when not parameters are set for mock `Client`
- [ ] `VerifySend` should allow null for `allowErrorResponse` parameter
- [ ] Improve MockingClients test coverage
  - [ ] Test all possible cases when mocking
  - [ ] Test all possible cases for verify



