### PR TITLE
Issue / Internals Visible to Generated Assemblies

### DIFF
--- a/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationExtensions.cs
@@ -22,6 +22,12 @@ public static class CodeGenerationExtensions
     public static void ConfigureGeneratedAssemblyCollection(this LayerConfigurator configurator, Action<IGeneratedAssemblyCollection> configuration) =>
         configurator.Configure(configuration);
 
+    /// <summary>
+    /// Adds a descriptor for a generated assembly with given parameters
+    /// 
+    /// ℹ️  Any layer or feature generates code which accesses non-public members should
+    /// be explicitly added tobe added to abstraction project `.targets` file  
+    /// </summary>
     public static void Add(this IGeneratedAssemblyCollection generatedAssemblies, string name, Action<GeneratedAssemblyDescriptor> descriptorBuilder,
         Func<CSharpCompilationOptions, CSharpCompilationOptions>? compilationOptionsBuilder = default
     )

--- a/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/Compiler.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/Compiler.cs
@@ -33,7 +33,7 @@ public class Compiler(GeneratedAssemblyDescriptor _descriptor)
         ));
 
         var compilation = CSharpCompilation.Create(
-            Path.GetRandomFileName(),
+            $"Baked.g.{_descriptor.Name}",
             syntaxTrees: _descriptor.Codes.Select(c => CSharpSyntaxTree.ParseText(c)),
             references: _references.Values,
             options: _descriptor.CompilationOptions

--- a/src/recipe/Baked.Recipe.Service/Baked.Recipe.Service.targets
+++ b/src/recipe/Baked.Recipe.Service/Baked.Recipe.Service.targets
@@ -9,4 +9,9 @@
     <Using Include="System.Threading.Tasks" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Baked.g.AutoMapOrmFeature"/>
+    <InternalsVisibleTo Include="Baked.g.RestApiLayer"/>
+  </ItemGroup>  
+
 </Project>

--- a/test/recipe/Baked.Test.Recipe.Service/Baked.Test.Recipe.Service.csproj
+++ b/test/recipe/Baked.Test.Recipe.Service/Baked.Test.Recipe.Service.csproj
@@ -8,4 +8,9 @@
     <ProjectReference Include="..\..\..\src\recipe\Baked.Recipe.Service\Baked.Recipe.Service.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Baked.g.AutoMapOrmFeature"/>
+    <InternalsVisibleTo Include="Baked.g.RestApiLayer"/>
+  </ItemGroup>  
+
 </Project>

--- a/test/recipe/Baked.Test.Recipe.Service/Orm/Child.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Orm/Child.cs
@@ -8,6 +8,7 @@ public class Child(IEntityContext<Child> _context)
 
     public virtual Guid Id { get; protected set; } = default!;
     public virtual Parent Parent { get; protected set; } = default!;
+    protected internal virtual Parent? InternalParent { get; protected set; } = default!;
 
     protected internal virtual Child With(Parent parent)
     {

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,10 @@
 # Unreleased
+
+## Bugfixes
+
+- Generated `IManyToOneFecher`services was getting compiler error when a 
+  non-public member was accessed, fixed
+
+## Improvements
+
+- Generated assembly names can now be set

--- a/unreleased.md
+++ b/unreleased.md
@@ -7,4 +7,5 @@
 
 ## Improvements
 
-- Generated assembly names can now be set
+- Generated assembly names are now set from `Name` property of
+  `GeneratedAssemblyDescriptor` with `Baked.g.` prefix


### PR DESCRIPTION
Provide a way for enabling access of non-public members 
of domain assemblies from generated assemblies

## Tasks

- [x] Get generated assembly names from descripter and add `Baked.g.` prefix
- [x] Enable access to non-public members from generated code
