### PR TITLE
Issue / Auto Find Entry Assembly

### DIFF
--- a/docs/features/coding-style.md
+++ b/docs/features/coding-style.md
@@ -64,7 +64,7 @@ c => c.ObjectAsJson()
 
 ## Records are DTOs
 
-Configures domain type records as valid input paramters. Methods containing
+Configures domain type records as valid input parameters. Methods containing
 record parameters render as api endpoints.
 
 ```csharp

--- a/src/core/Baked.Architecture/Testing/Nfr.cs
+++ b/src/core/Baked.Architecture/Testing/Nfr.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using NUnit.Framework;
+﻿using NUnit.Framework;
+using System.Reflection;
 
 namespace Baked.Testing;
 

--- a/src/core/Baked.Architecture/Testing/Nfr.cs
+++ b/src/core/Baked.Architecture/Testing/Nfr.cs
@@ -1,9 +1,17 @@
-﻿using NUnit.Framework;
+﻿using System.Reflection;
+using NUnit.Framework;
 
 namespace Baked.Testing;
 
 public abstract class Nfr
 {
+    public static Assembly? EntryAssembly { get; private set; }
+
+    protected static void Init<TEntryPoint>() where TEntryPoint : class
+    {
+        EntryAssembly = typeof(TEntryPoint).Assembly;
+    }
+
     [OneTimeSetUp]
     public virtual Task OneTimeSetUp() => Task.CompletedTask;
 

--- a/src/recipe/Baked.Recipe.Service.Application/Core/Dotnet/DotnetCoreExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Core/Dotnet/DotnetCoreExtensions.cs
@@ -11,7 +11,6 @@ public static class DotnetCoreExtensions
         Func<Assembly, string?>? baseNamespace = default
     )
     {
-        entryAssembly ??= Assembly.GetEntryAssembly() ?? throw new("'EntryAssembly' should have existed");
         baseNamespace ??= assembly => Regexes.AssemblyNameBeforeApplicationSuffix().Match(assembly.FullName ?? string.Empty).Value;
 
         return new(entryAssembly, baseNamespace);

--- a/src/recipe/Baked.Recipe.Service.Application/Core/Dotnet/DotnetCoreFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Core/Dotnet/DotnetCoreFeature.cs
@@ -1,24 +1,27 @@
 ﻿using Baked.Architecture;
+using Baked.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using System.Reflection;
 
 namespace Baked.Core.Dotnet;
 
-public class DotnetCoreFeature(Assembly _entryAssembly, Func<Assembly, string?> _baseNamespace)
+public class DotnetCoreFeature(Assembly? _entryAssembly, Func<Assembly, string?> _baseNamespace)
     : IFeature<CoreConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
         configurator.ConfigureServiceCollection(services =>
         {
+            var entryAssembly = _entryAssembly
+                ?? (configurator.IsNfr() ? Nfr.EntryAssembly : Assembly.GetEntryAssembly())
+                ?? throw new("'EntryAssembly' should have existed");
+
             services.AddSingleton(TimeProvider.System);
             services.AddSingleton<ITextTransformer, HumanizerTextTransformer>();
 
-            services.AddFileProvider(new EmbeddedFileProvider(_entryAssembly, _baseNamespace(_entryAssembly)));
-            services.AddFileProvider(new PhysicalFileProvider(Path.GetDirectoryName(_entryAssembly.Location) ??
-                throw new("'EntryAssembly' should have a not null location"))
-            );
+            services.AddFileProvider(new EmbeddedFileProvider(entryAssembly, _baseNamespace(entryAssembly)));
+            services.AddFileProvider(new PhysicalFileProvider(Path.GetDirectoryName(entryAssembly.Location) ?? string.Empty));
         });
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Testing/WebApplicationNfr.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Testing/WebApplicationNfr.cs
@@ -15,8 +15,10 @@ public abstract class WebApplicationNfr : Nfr
 
     protected static IConfiguration Configuration => ServiceProvider.GetRequiredService<IConfiguration>();
 
-    protected static void Init<TEntryPoint>() where TEntryPoint : class
+    protected static new void Init<TEntryPoint>() where TEntryPoint : class
     {
+        Nfr.Init<TEntryPoint>();
+
         Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", nameof(Nfr));
 
         var webApplicationFactory = new WebApplicationFactory<TEntryPoint>();

--- a/test/recipe/Baked.Test.Recipe.Service.Application/Program.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Baked.Test.Orm;
-using System.Reflection;
 
 Bake.New
     .Service(
@@ -28,9 +27,7 @@ Bake.New
             claims: ["User", "Admin", "BaseA", "BaseB", "GivenA", "GivenB", "GivenC"],
             baseClaims: ["BaseA", "BaseB"]
         ),
-        core: c => c
-            .Dotnet(baseNamespace: _ => "Baked.Test")
-            .ForNfr(c.Dotnet(entryAssembly: Assembly.GetExecutingAssembly(), baseNamespace: _ => "Baked.Test")),
+        core: c => c.Dotnet(baseNamespace: _ => "Baked.Test"),
         cors: c => c.AspNetCore(Settings.Required<string>("CorsOrigin")),
         database: c => c
             .Sqlite()

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Core/ReadingResources.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Core/ReadingResources.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net.Http.Json;
 
-namespace Baked.Test.Runtime;
+namespace Baked.Test.Core;
 
 public class ReadingResources : TestServiceNfr
 {

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Core/ReadingResourcesDuringTests.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Core/ReadingResourcesDuringTests.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.FileProviders;
+
+namespace Baked.Test.Core;
+
+public class ReadingResourcesDuringTests : TestServiceSpec
+{
+    [TestCase("Core/DomainEmbedded.txt")]
+    public void Specs_includes_business_resources(string subpath)
+    {
+        var provider = GiveMe.The<IFileProvider>();
+
+        var exists = provider.Exists(subpath);
+
+        exists.ShouldBeTrue();
+    }
+
+    [TestCase("Core/ApplicationEmbedded.txt")]
+    [TestCase("Core/ApplicationPhysical.txt")]
+    public void Specs_excludes_application_resources(string subpath)
+    {
+        var provider = GiveMe.The<IFileProvider>();
+
+        var exists = provider.Exists(subpath);
+
+        exists.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
during nfrs, it requires entry assembly to be given manually which is not
convenient.

- When running a spec, entry assembly and application resources are available by
  design.

## Tasks

- [x] add resource tests for specs
- [x] nfr auto find entry assembly
