### PR TITLE
Issue / Reporting Issues

### DIFF
--- a/docs/recipes/data-source.md
+++ b/docs/recipes/data-source.md
@@ -39,6 +39,7 @@ Bake.New
 |                    | Namespace as Route                 |                                    |
 |                    | Records are DTOs                   |                                    |
 |                    | Remaining Services are Singleton   |                                    |
+|                    | Rich Transient                     |                                    |
 |                    | Scoped by Suffix                   |                                    |
 |                    | Use Built-in Types                 |                                    |
 |                    | Use Nullable Types                 |                                    |

--- a/docs/recipes/service.md
+++ b/docs/recipes/service.md
@@ -46,6 +46,7 @@ Bake.New
 |                    | Records are DTOs                   |                                    |
 |                    | Remaining Services are Singleton   |                                    |
 |                    | Rich Entity                        |                                    |
+|                    | Rich Transient                     |                                    |
 |                    | Scoped by Suffix                   |                                    |
 |                    | Single by Unique                   |                                    |
 |                    | `Uri` Return is Redirect           |                                    |

--- a/samples/event-scheduler/src/Mouseless.EventScheduler.Application/Program.cs
+++ b/samples/event-scheduler/src/Mouseless.EventScheduler.Application/Program.cs
@@ -1,6 +1,6 @@
 Bake.New
     .Service(
-        business: c => c.DomainAssemblies([typeof(Contact).Assembly]),
+        business: c => c.DomainAssemblies(typeof(Contact).Assembly),
         database: c => c.Sqlite("Mouseless.EventScheduler.Application.db"),
         configure: app => app.Features.AddConfigurationOverrider()
     )

--- a/src/recipe/Baked.Recipe.Service.Application/BakeExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/BakeExtensions.cs
@@ -134,6 +134,7 @@ public static class BakeExtensions
                 c => c.NamespaceAsRoute(),
                 c => c.RecordsAreDtos(),
                 c => c.RemainingServicesAreSingleton(),
+                c => c.RichTransient(),
                 c => c.ScopedBySuffix(),
                 c => c.UseBuiltInTypes(),
                 c => c.UseNullableTypes(),

--- a/src/recipe/Baked.Recipe.Service.Application/Business/BusinessExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/BusinessExtensions.cs
@@ -76,7 +76,7 @@ public static class BusinessExtensions
 
     public static bool TryGetNamespace(this TypeModel type, [NotNullWhen(true)] out string? @namespace)
     {
-        if (!type.TryGetNamespaceAttribute(out var namespaceAttribute))
+        if (!type.TryGetNamespaceAttribute(out var namespaceAttribute) || string.IsNullOrWhiteSpace(namespaceAttribute.Value))
         {
             @namespace = null;
 

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessExtensions.cs
@@ -8,18 +8,35 @@ namespace Baked;
 
 public static class DomainAssembliesBusinessExtensions
 {
-    public static DomainAssembliesBusinessFeature DomainAssemblies(this BusinessConfigurator configurator, List<Assembly> assemblies,
+    public static DomainAssembliesBusinessFeature DomainAssemblies(this BusinessConfigurator configurator, Assembly assembly,
+        string? baseNamespace = default,
         Func<IEnumerable<MethodOverloadModel>, MethodOverloadModel>? defaultOverloadSelector = default,
         bool addEmbeddedFileProviders = true,
-        string? baseNamespace = default,
         Func<TypeModel, bool>? setNamespaceWhen = default
-    ) => configurator.DomainAssemblies(assemblies.Select(a => (a, baseNamespace)),
+    ) => configurator.DomainAssemblies([assembly],
+        baseNamespace: baseNamespace is not null ? _ => baseNamespace : null,
         defaultOverloadSelector: defaultOverloadSelector,
         addEmbeddedFileProviders: addEmbeddedFileProviders,
         setNamespaceWhen: setNamespaceWhen
     );
 
-    public static DomainAssembliesBusinessFeature DomainAssemblies(this BusinessConfigurator _, IEnumerable<(Assembly, string?)> assemblyDescriptors,
+    public static DomainAssembliesBusinessFeature DomainAssemblies(this BusinessConfigurator configurator, IEnumerable<Assembly> assemblies,
+        Func<Assembly, string>? baseNamespace,
+        Func<IEnumerable<MethodOverloadModel>, MethodOverloadModel>? defaultOverloadSelector = default,
+        bool addEmbeddedFileProviders = true,
+        Func<TypeModel, bool>? setNamespaceWhen = default
+    )
+    {
+        baseNamespace ??= (a => a.GetName().Name ?? string.Empty);
+
+        return configurator.DomainAssemblies(assemblies.Select(a => (a, baseNamespace(a))),
+            defaultOverloadSelector: defaultOverloadSelector,
+            addEmbeddedFileProviders: addEmbeddedFileProviders,
+            setNamespaceWhen: setNamespaceWhen
+        );
+    }
+
+    public static DomainAssembliesBusinessFeature DomainAssemblies(this BusinessConfigurator _, IEnumerable<(Assembly assembly, string baseNamespace)> assemblyDescriptors,
         Func<IEnumerable<MethodOverloadModel>, MethodOverloadModel>? defaultOverloadSelector = default,
         bool addEmbeddedFileProviders = true,
         Func<TypeModel, bool>? setNamespaceWhen = default

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
@@ -13,13 +13,13 @@ using System.Reflection;
 namespace Baked.Business.DomainAssemblies;
 
 public class DomainAssembliesBusinessFeature(
-    IEnumerable<(Assembly assembly, string? baseNamespace)> _assemblyDescriptors,
+    IEnumerable<(Assembly assembly, string baseNamespace)> _assemblyDescriptors,
     Func<IEnumerable<MethodOverloadModel>, MethodOverloadModel> _defaultOverloadSelector,
     bool _addEmbeddedFileProviders,
     Func<TypeModel, bool> setNamespaceWhen
 ) : IFeature<BusinessConfigurator>
 {
-    Dictionary<Assembly, string> BaseNamespaces { get; } = _assemblyDescriptors.ToDictionary(kvp => kvp.assembly, kvp => kvp.baseNamespace ?? kvp.assembly.GetName().Name ?? string.Empty);
+    Dictionary<Assembly, string> BaseNamespaces { get; } = _assemblyDescriptors.ToDictionary(kvp => kvp.assembly, kvp => kvp.baseNamespace);
 
     public void Configure(LayerConfigurator configurator)
     {

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/RichEntity/EntityUnderPluralGroupConvention.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/RichEntity/EntityUnderPluralGroupConvention.cs
@@ -4,13 +4,13 @@ using Humanizer;
 
 namespace Baked.CodingStyle.RichEntity;
 
-public class EntityUnderEntitiesConvention : IApiModelConvention<ControllerModelContext>
+public class EntityUnderPluralGroupConvention : IApiModelConvention<ControllerModelContext>
 {
     public void Apply(ControllerModelContext context)
     {
         if (!context.Controller.MappedType.TryGetMetadata(out var metadata)) { return; }
         if (!metadata.Has<EntityAttribute>()) { return; }
 
-        context.Controller.GroupName = context.Controller.GroupName.Pluralize(inputIsKnownToBeSingular: true);
+        context.Controller.GroupName = context.Controller.GroupName.Pluralize();
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/RichEntity/RichEntityCodingStyleFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/RichEntity/RichEntityCodingStyleFeature.cs
@@ -65,7 +65,7 @@ public class RichEntityCodingStyleFeature : IFeature<CodingStyleConfigurator>
         {
             var domainModel = configurator.Context.GetDomainModel();
 
-            conventions.Add(new EntityUnderEntitiesConvention());
+            conventions.Add(new EntityUnderPluralGroupConvention());
             conventions.Add(new EntityInitializerIsPostResourceConvention());
             conventions.Add(new FindTargetUsingQueryContextConvention(domainModel), order: 20);
         });

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/RichTransient/RichTransientCodingStyleFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/RichTransient/RichTransientCodingStyleFeature.cs
@@ -49,6 +49,7 @@ public class RichTransientCodingStyleFeature : IFeature<CodingStyleConfigurator>
 
         configurator.ConfigureApiModelConventions(conventions =>
         {
+            conventions.Add(new RichTransientUnderPluralGroupConvention());
             conventions.Add(new AddInitializerParametersToQueryConvention());
             conventions.Add(new AddIdParameterToRouteConvention());
             conventions.Add(new LookupRichTransientByIdConvention());

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/RichTransient/RichTransientUnderPluralGroupConvention.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/RichTransient/RichTransientUnderPluralGroupConvention.cs
@@ -1,0 +1,16 @@
+﻿using Baked.Business;
+using Baked.RestApi.Configuration;
+using Humanizer;
+
+namespace Baked.CodingStyle.RichTransient;
+
+public class RichTransientUnderPluralGroupConvention : IApiModelConvention<ControllerModelContext>
+{
+    public void Apply(ControllerModelContext context)
+    {
+        if (!context.Controller.MappedType.TryGetMetadata(out var metadata)) { return; }
+        if (!metadata.Has<LocatableAttribute>()) { return; }
+
+        context.Controller.GroupName = context.Controller.GroupName.Pluralize();
+    }
+}

--- a/src/recipe/Baked.Recipe.Service.Application/Core/Dotnet/DotnetCoreExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Core/Dotnet/DotnetCoreExtensions.cs
@@ -8,11 +8,6 @@ public static class DotnetCoreExtensions
 {
     public static DotnetCoreFeature Dotnet(this CoreConfigurator _,
         Assembly? entryAssembly = default,
-        Func<Assembly, string?>? baseNamespace = default
-    )
-    {
-        baseNamespace ??= assembly => Regexes.AssemblyNameBeforeApplicationSuffix().Match(assembly.FullName ?? string.Empty).Value;
-
-        return new(entryAssembly, baseNamespace);
-    }
+        string? baseNamespace = default
+    ) => new(entryAssembly, baseNamespace is not null ? _ => baseNamespace : a => a.GetNameBeforeApplicationSuffix());
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Core/Regexes.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Core/Regexes.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Baked.Core;
 
@@ -6,4 +7,9 @@ internal static partial class Regexes
 {
     [GeneratedRegex(@"[\s\S]*?(?=.Application|$)")]
     public static partial Regex AssemblyNameBeforeApplicationSuffix();
+
+    public static string GetNameBeforeApplicationSuffix(this Assembly assembly) =>
+        AssemblyNameBeforeApplicationSuffix()
+            .Match(assembly.FullName ?? string.Empty)
+            .Value;
 }

--- a/src/recipe/Baked.Recipe.Service.Application/DataAccess/DataAccessLayer.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/DataAccess/DataAccessLayer.cs
@@ -43,6 +43,10 @@ public class DataAccessLayer : LayerBase<AddServices, PostBuild>
 
                 services.AddSingleton(sp => _fluentConfiguration.BuildConfiguration());
                 services.AddSingleton(sp => sp.GetRequiredService<NHConfiguration>().BuildSessionFactory());
+                services.AddScoped(sp => sp.GetRequiredService<ISessionFactory>().OpenSession());
+                services.AddScoped(sp => sp.GetRequiredService<ISessionFactory>().OpenStatelessSession());
+                services.AddSingleton<Func<ISession>>(sp => () => sp.UsingCurrentScope().GetRequiredService<ISession>());
+                services.AddSingleton<Func<IStatelessSession>>(sp => () => sp.UsingCurrentScope().GetRequiredService<IStatelessSession>());
             })
             .Build();
     }

--- a/src/recipe/Baked.Recipe.Service.Application/DataSourceSpec.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/DataSourceSpec.cs
@@ -47,6 +47,7 @@ public abstract class DataSourceSpec : Spec
                 c => c.NamespaceAsRoute(),
                 c => c.RecordsAreDtos(),
                 c => c.RemainingServicesAreSingleton(),
+                c => c.RichTransient(),
                 c => c.ScopedBySuffix(),
                 c => c.UseBuiltInTypes(),
                 c => c.UseNullableTypes(),

--- a/src/recipe/Baked.Recipe.Service.Application/Orm/AutoMap/AutoMapOrmFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Orm/AutoMap/AutoMapOrmFeature.cs
@@ -70,8 +70,6 @@ public class AutoMapOrmFeature : IFeature<OrmConfigurator>
         configurator.ConfigureServiceCollection(services =>
         {
             services.AddFromAssembly(configurator.Context.GetGeneratedAssembly(nameof(AutoMapOrmFeature)));
-            services.AddScoped(sp => sp.GetRequiredService<ISessionFactory>().OpenSession());
-            services.AddSingleton<Func<ISession>>(sp => () => sp.UsingCurrentScope().GetRequiredService<ISession>());
             services.AddScoped(typeof(IEntityContext<>), typeof(EntityContext<>));
             services.AddSingleton(typeof(IQueryContext<>), typeof(QueryContext<>));
         });

--- a/src/recipe/Baked.Recipe.Service.Application/Reporting/Fake/FakeReportingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Reporting/Fake/FakeReportingExtensions.cs
@@ -1,5 +1,6 @@
 using Baked.Reporting;
 using Baked.Reporting.Fake;
+using Baked.Runtime;
 using Baked.Testing;
 using Microsoft.Extensions.FileProviders;
 
@@ -7,8 +8,9 @@ namespace Baked;
 
 public static class FakeReportingExtensions
 {
-    public static FakeReportingFeature Fake(this ReportingConfigurator _) =>
-        new();
+    public static FakeReportingFeature Fake(this ReportingConfigurator _,
+        Setting<string>? basePath = default
+    ) => new(basePath ?? string.Empty);
 
     public static IReportContext AFakeReportContext(this Stubber giveMe,
         string basePath = "Fake"

--- a/src/recipe/Baked.Recipe.Service.Application/Reporting/Fake/FakeReportingFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Reporting/Fake/FakeReportingFeature.cs
@@ -1,14 +1,17 @@
 using Baked.Architecture;
+using Baked.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Baked.Reporting.Fake;
 
-public class FakeReportingFeature : IFeature<ReportingConfigurator>
+public class FakeReportingFeature(Setting<string> _basePath) :
+    IFeature<ReportingConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
         configurator.ConfigureServiceCollection(services =>
         {
+            services.AddSingleton(new ReportOptions(_basePath));
             services.AddSingleton<IReportContext, ReportContext>();
         });
     }

--- a/src/recipe/Baked.Recipe.Service.Application/Reporting/NativeSql/NativeSqlReportingFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Reporting/NativeSql/NativeSqlReportingFeature.cs
@@ -1,7 +1,6 @@
 using Baked.Architecture;
 using Baked.Runtime;
 using Microsoft.Extensions.DependencyInjection;
-using NHibernate;
 
 namespace Baked.Reporting.NativeSql;
 
@@ -28,8 +27,6 @@ public class NativeSqlReportingFeature(Setting<string> _basePath)
         {
             services.AddSingleton(new ReportOptions(_basePath));
             services.AddSingleton<IReportContext, ReportContext>();
-            services.AddScoped(sp => sp.GetRequiredService<ISessionFactory>().OpenStatelessSession());
-            services.AddSingleton<Func<IStatelessSession>>(sp => () => sp.UsingCurrentScope().GetRequiredService<IStatelessSession>());
         });
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Reporting/ReportingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Reporting/ReportingExtensions.cs
@@ -11,7 +11,8 @@ public static class ReportingExtensions
         features.Add(configure(new()));
 
     public static IReportContext TheReportContext(this Mocker mockMe,
-        object?[][]? data = default
+        object?[][]? data = default,
+        bool? queryNotFound = default
     )
     {
         data ??= [];
@@ -23,6 +24,13 @@ public static class ReportingExtensions
             result
                 .Setup(df => df.Execute(It.IsAny<string>(), It.IsAny<Dictionary<string, object>>()))
                 .ReturnsAsync(data);
+        }
+
+        if (queryNotFound == true)
+        {
+            result
+                .Setup(c => c.Execute(It.IsAny<string>(), It.IsAny<Dictionary<string, object>>()))
+                .Throws((string queryName, Dictionary<string, object> _) => new QueryNotFoundException(queryName));
         }
 
         return result.Object;

--- a/src/recipe/Baked.Recipe.Service.Application/ServiceSpec.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/ServiceSpec.cs
@@ -60,6 +60,7 @@ public abstract class ServiceSpec : Spec
                 c => c.RecordsAreDtos(),
                 c => c.RemainingServicesAreSingleton(),
                 c => c.RichEntity(),
+                c => c.RichTransient(),
                 c => c.ScopedBySuffix(),
                 c => c.SingleByUnique(),
                 c => c.UriReturnIsRedirect(),

--- a/test/recipe/Baked.Test.Recipe.Service.Application/Program.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/Program.cs
@@ -2,7 +2,7 @@
 
 Bake.New
     .Service(
-        business: c => c.DomainAssemblies([typeof(Entity).Assembly],
+        business: c => c.DomainAssemblies(typeof(Entity).Assembly,
             baseNamespace: "Baked.Test",
             setNamespaceWhen: t => t.Namespace is not null && t.Namespace.StartsWith("Baked.Test.CodingStyle.NamespaceAsRoute")
         ),
@@ -30,7 +30,7 @@ Bake.New
             claims: ["User", "Admin", "BaseA", "BaseB", "GivenA", "GivenB", "GivenC"],
             baseClaims: ["BaseA", "BaseB"]
         ),
-        core: c => c.Dotnet(baseNamespace: _ => "Baked.Test"),
+        core: c => c.Dotnet(baseNamespace: "Baked.Test"),
         cors: c => c.AspNetCore(Settings.Required<string>("CorsOrigin")),
         database: c => c
             .Sqlite()

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Reporting/MockingReportResults.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Reporting/MockingReportResults.cs
@@ -29,6 +29,17 @@ public class MockingReportResults : TestServiceSpec
     }
 
     [Test]
+    public void Sets_up_mock_report_to_throw_query_not_found()
+    {
+        MockMe.TheReportContext(queryNotFound: true);
+        var reportSamples = GiveMe.The<ReportSamples>();
+
+        var action = reportSamples.GetEntity("test");
+
+        action.ShouldThrow<QueryNotFoundException>().Message.ShouldContain("entity");
+    }
+
+    [Test]
     public async Task Verifies_execute_with_given_query_and_parameters()
     {
         var reportContext = MockMe.TheReportContext();

--- a/test/recipe/Baked.Test.Recipe.Service.Test/TestServiceSpec.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/TestServiceSpec.cs
@@ -7,7 +7,7 @@ public abstract class TestServiceSpec : ServiceSpec
 {
     static TestServiceSpec() =>
         Init(
-            business: c => c.DomainAssemblies([typeof(Entity).Assembly], baseNamespace: "Baked.Test"),
+            business: c => c.DomainAssemblies(typeof(Entity).Assembly, baseNamespace: "Baked.Test"),
             communication: c => c.Mock(defaultResponses: response =>
             {
                 response.ForClient<ExternalSamples>(response: "test result");

--- a/unreleased.md
+++ b/unreleased.md
@@ -7,7 +7,6 @@
 - Data source spec was throwing missing `ISession` error, fixed
 - Add query not found option to report context mocking
 - Rich transient wasn't added to data source recipe, fixed
-- Rich transient and command were causing a route conflict, fixed
 - Rich transient group names are now plural, making it similar to rich entity
 - Domain assemblies feature now accepts one assembly when it accepts one base
   namespace, to avoid confusion

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,15 @@
 # Unreleased
+
+## Improvements
+
+- Fake reporting wasn't working without registering a `ReportOptions`, fixed
+- Fake reporting now allows to provide a base path
+- Data source spec was throwing missing `ISession` error, fixed
+- Add query not found option to report context mocking
+- Rich transient wasn't added to data source recipe, fixed
+- Rich transient and command were causing a route conflict, fixed
+- Rich transient group names are now plural, making it similar to rich entity
+- Domain assemblies feature now accepts one assembly when it accepts one base
+  namespace, to avoid confusion
+- File provider wasn't working without providing a base namespace in domain
+  assemblies, fixed


### PR DESCRIPTION
Fix issues regarding reporting and data source release (v0.12.0).

## Tasks

- [x] Provide base path in fake reporting extensions and feature.
  - and register Fake.ReportOptions with given base path
- [x] Move isession and istatelesssession back to data access
- [x] ~~in memory database should use stateless session in setup~~
  - this is not possible since this setup is shared in both of recipes
- [x] add query not found option to report context mocking
- [x] rich transient doesn't exist in data source recipe
- [x] ~~rich transient and command causes a route conflict~~
  - this is not a conflict between command and rich transient, it removes
    `Execute` from any route
- [x] rich transient group name should be plural just like rich entity
- [x] remove list input in domain assemblies override that takes accepts
  baseNamespace
- [x] file provider doesn't work without providing a base namespace in domain
  assemblies
