### PR TITLE
Feature / Add Service Using Domain Model

### DIFF
--- a/unreleased.md
+++ b/unreleased.md
@@ -17,6 +17,9 @@
   generating data files in `Bake` mode
 - `CodeGeneration` layer now introduces `GeneratedContext` at `BuildConfiguration`
   phase which provides access to generated assemblies and files in `Start` mode
+- `Domain` layer now provides a service descriptor collection which will then 
+  be used to generate `IServiceAdder` 
+
 
 ## Improvements
 


### PR DESCRIPTION
Migrate all service adders to be served from domain layer. This way, features
will have a service collection like object along with domain model, and domain
layer will use them to generate the service adder assembly.

## Tasks

- [ ] Provide a configuration target from `Domain` layer to generate `IServiceAdder`
- [ ] Update features to use configuration target, instead of generating individual `IServiceAdders`
  - [ ] `Transient`
  - [ ] `Scoped`
  - [ ] `Singleton`
  - [ ] `ProblemDetails`
  - [ ] TBD

## Additional  Tasks
  - [ ] remove context property from layer configurator to prevent context objects
    to be accessed directly from features
  - [ ] add all hash extensions to string extensions (including `SHA1`)
