### PR TITLE
Issue / .NET 9 Update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8
+          dotnet-version: 9
       - name: Pack
         run: |
           dotnet pack -o "packages" -c Release
@@ -109,7 +109,7 @@ jobs:
         with:
           node-version: 22
       - name: Disable AppArmour
-        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns        
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Build Docs
         run: |
           cd docs/.theme/

--- a/.github/workflows/regular-checks-docs.yml
+++ b/.github/workflows/regular-checks-docs.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 22
       - name: Disable AppArmour
-        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns    
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Generate
         run: |
           cd docs/.theme/

--- a/.github/workflows/regular-checks-project.yml
+++ b/.github/workflows/regular-checks-project.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8
+          dotnet-version: 9
       - name: Restore Dependencies
         run: dotnet restore
       - name: Format Solution
@@ -63,7 +63,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8
+          dotnet-version: 9
       - name: Test
         if: ${{ matrix.os != 'ubuntu-latest' }}
         run: dotnet test -c Release

--- a/.github/workflows/regular-checks-samples.yml
+++ b/.github/workflows/regular-checks-samples.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8
+          dotnet-version: 9
       - name: samples/event-scheduler
         working-directory: samples/event-scheduler
         run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12.0</LangVersion>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>13.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,36 +6,36 @@
 
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentNHibernate" Version="3.4.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
-    <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.6.0" />
+    <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.7.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.1.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MySql.Data" Version="9.1.0" />
+    <PackageVersion Include="MySql.Data" Version="9.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NHibernate" Version="5.5.2" />
-    <PackageVersion Include="NHibernate.Extensions.Sqlite" Version="8.0.14" />
-    <PackageVersion Include="NUnit" Version="4.2.2" />
+    <PackageVersion Include="NHibernate.Extensions.Sqlite" Version="9.0.0" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageVersion Include="Npgsql" Version="8.0.5" />
-    <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="Npgsql" Version="9.0.2" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
     <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.9.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,10 +10,8 @@
     <PackageVersion Include="FluentNHibernate" Version="3.4.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.7.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.1" />

--- a/research/domain-model-over-reflection/DomainModelOverReflection.Generator/DomainModelGenerator.cs
+++ b/research/domain-model-over-reflection/DomainModelOverReflection.Generator/DomainModelGenerator.cs
@@ -42,10 +42,10 @@ public class DomainModelGenerator : IIncrementalGenerator
 using DomainModelOverReflection.Models.Domain;
 
 namespace {{compilation.AssemblyName}};
-                
+
 public class DomainModelWithGeneration : IDomainModel
 {
-    static TypeModel[] _typeModels = new TypeModel[{{counter}}] 
+    static TypeModel[] _typeModels = new TypeModel[{{counter}}]
     {
 {{builder}}
     };

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12.0</LangVersion>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>13.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/event-scheduler/src/Mouseless.EventScheduler.Application/Mouseless.EventScheduler.Application.csproj
+++ b/samples/event-scheduler/src/Mouseless.EventScheduler.Application/Mouseless.EventScheduler.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/core/Baked.Architecture/Architecture/Application.cs
+++ b/src/core/Baked.Architecture/Architecture/Application.cs
@@ -91,7 +91,7 @@ public class Application(ApplicationContext _context,
                 Apply(phase, context);
             }
 
-            phases = phases.Except(phasesOfThisIteration).ToList();
+            phases = [.. phases.Except(phasesOfThisIteration)];
         }
     }
 

--- a/src/core/Baked.Architecture/Architecture/LayerConfigurator.cs
+++ b/src/core/Baked.Architecture/Architecture/LayerConfigurator.cs
@@ -37,7 +37,7 @@ public class LayerConfigurator
     readonly ApplicationContext _context;
     readonly List<Target> _targets;
 
-    LayerConfigurator(ApplicationContext context, params Target[] targets)
+    LayerConfigurator(ApplicationContext context, params IEnumerable<Target> targets)
     {
         _context = context;
         _targets = [.. targets];
@@ -66,9 +66,9 @@ public class LayerConfigurator
         configuration(ValueAs<TTarget1>(0), ValueAs<TTarget2>(1), ValueAs<TTarget3>(2));
     }
 
-    bool Matches(params Type[] types)
+    bool Matches(params IList<Type> types)
     {
-        if (_targets.Count != types.Length) { return false; }
+        if (_targets.Count != types.Count) { return false; }
 
         for (var i = 0; i < _targets.Count; i++)
         {

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
@@ -6,7 +6,6 @@ using Baked.Domain.Model;
 using Baked.RestApi;
 using Baked.RestApi.Conventions;
 using Baked.RestApi.Model;
-// using Humanizer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using System.Reflection;
@@ -279,7 +278,7 @@ public class DomainAssembliesBusinessFeature(
 
             swaggerGenOptions.EnableAnnotations();
 
-            var schemaHelper = new SwashbuckleSchemaHelper();
+            var schemaHelper = new SwaggerSchemaHelper();
             swaggerGenOptions.CustomSchemaIds(type => schemaHelper.GetSchemaId(type));
 
             swaggerGenOptions.OrderActionsBy(apiDescription =>

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
@@ -279,7 +279,7 @@ public class DomainAssembliesBusinessFeature(
             swaggerGenOptions.EnableAnnotations();
 
             var schemaHelper = new SwaggerSchemaHelper();
-            swaggerGenOptions.CustomSchemaIds(type => schemaHelper.GetSchemaId(type));
+            swaggerGenOptions.CustomSchemaIds(schemaHelper.GetSchemaId);
 
             swaggerGenOptions.OrderActionsBy(apiDescription =>
             {

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
@@ -6,7 +6,7 @@ using Baked.Domain.Model;
 using Baked.RestApi;
 using Baked.RestApi.Conventions;
 using Baked.RestApi.Model;
-using Humanizer;
+// using Humanizer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using System.Reflection;
@@ -278,19 +278,9 @@ public class DomainAssembliesBusinessFeature(
             }
 
             swaggerGenOptions.EnableAnnotations();
-            swaggerGenOptions.CustomSchemaIds(t =>
-            {
-                string[] splitedNamespace = t.Namespace?.Split(".") ?? [];
-                string name = t.IsNested && t.FullName is not null
-                    ? t.FullName.Replace($"{t.Namespace}.", string.Empty).Replace("+", "_")
-                    : t.Name;
 
-                var result = splitedNamespace.Length > 1
-                    ? $"{splitedNamespace.Skip(1).Join('_')}_{name}"
-                    : name;
-
-                return result.Replace("_", "--").Kebaberize();
-            });
+            var schemaHelper = new SwashbuckleSchemaHelper();
+            swaggerGenOptions.CustomSchemaIds(type => schemaHelper.GetSchemaId(type));
 
             swaggerGenOptions.OrderActionsBy(apiDescription =>
             {

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
@@ -244,10 +244,10 @@ public class DomainAssembliesBusinessFeature(
             configurator.Context.Add(new TagDescriptions());
 
             conventions.Add(new AutoHttpMethodConvention([
-                (Regexes.StartsWithGet(), HttpMethod.Get),
-                (Regexes.IsUpdateChangeOrSet(), HttpMethod.Put),
-                (Regexes.StartsWithUpdateChangeOrSet(), HttpMethod.Patch),
-                (Regexes.StartsWithDeleteRemoveOrClear(), HttpMethod.Delete)
+                (Regexes.StartsWithGet, HttpMethod.Get),
+                (Regexes.IsUpdateChangeOrSet, HttpMethod.Put),
+                (Regexes.StartsWithUpdateChangeOrSet, HttpMethod.Patch),
+                (Regexes.StartsWithDeleteRemoveOrClear, HttpMethod.Delete)
             ]));
             conventions.Add(new GetAndDeleteAcceptsOnlyQueryConvention());
             conventions.Add(new RemoveFromRouteConvention(["Get"]));

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/SwaggerSchemaHelper.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/SwaggerSchemaHelper.cs
@@ -2,33 +2,40 @@ namespace Baked.Business.DomainAssemblies;
 
 public class SwaggerSchemaHelper
 {
-    private readonly Dictionary<string, List<string>> _schemaNameRepetition = new();
-
-    private string DefaultSchemaIdSelector(Type modelType)
-    {
-        if (!modelType.IsConstructedGenericType) return modelType.Name.Replace("[]", "Array");
-
-        var prefix = modelType.GetGenericArguments()
-            .Select(genericArg => DefaultSchemaIdSelector(genericArg))
-            .Aggregate((previous, current) => previous + current);
-
-        return prefix + modelType.Name.Split('`').First();
-    }
+    readonly Dictionary<string, List<string>> _schemaNameRepetition = [];
 
     public string GetSchemaId(Type modelType)
     {
-        string id = DefaultSchemaIdSelector(modelType);
+        var id = DefaultSchemaIdSelector(modelType);
 
         if (!_schemaNameRepetition.ContainsKey(id))
+        {
             _schemaNameRepetition.Add(id, new List<string>());
+        }
 
         var modelNameList = _schemaNameRepetition[id];
         var fullName = modelType.FullName ?? string.Empty;
         if (!string.IsNullOrEmpty(fullName) && !modelNameList.Contains(fullName))
+        {
             modelNameList.Add(fullName);
+        }
 
-        int index = modelNameList.IndexOf(fullName);
+        var index = modelNameList.IndexOf(fullName);
 
         return $"{id}{(index >= 1 ? index.ToString() : string.Empty)}";
+    }
+
+    string DefaultSchemaIdSelector(Type modelType)
+    {
+        if (!modelType.IsConstructedGenericType)
+        {
+            return modelType.Name.Replace("[]", "Array");
+        }
+
+        var prefix = modelType.GetGenericArguments()
+            .Select(DefaultSchemaIdSelector)
+            .Aggregate((previous, current) => previous + current);
+
+        return prefix + modelType.Name.Split('`').First();
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/SwaggerSchemaHelper.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/SwaggerSchemaHelper.cs
@@ -1,6 +1,6 @@
 namespace Baked.Business.DomainAssemblies;
 
-public class SwashbuckleSchemaHelper
+public class SwaggerSchemaHelper
 {
     private readonly Dictionary<string, List<string>> _schemaNameRepetition = new();
 

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/SwashbuckleSchemaHelper.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/SwashbuckleSchemaHelper.cs
@@ -1,0 +1,34 @@
+namespace Baked.Business.DomainAssemblies;
+
+public class SwashbuckleSchemaHelper
+{
+    private readonly Dictionary<string, List<string>> _schemaNameRepetition = new();
+
+    private string DefaultSchemaIdSelector(Type modelType)
+    {
+        if (!modelType.IsConstructedGenericType) return modelType.Name.Replace("[]", "Array");
+
+        var prefix = modelType.GetGenericArguments()
+            .Select(genericArg => DefaultSchemaIdSelector(genericArg))
+            .Aggregate((previous, current) => previous + current);
+
+        return prefix + modelType.Name.Split('`').First();
+    }
+
+    public string GetSchemaId(Type modelType)
+    {
+        string id = DefaultSchemaIdSelector(modelType);
+
+        if (!_schemaNameRepetition.ContainsKey(id))
+            _schemaNameRepetition.Add(id, new List<string>());
+
+        var modelNameList = _schemaNameRepetition[id];
+        var fullName = modelType.FullName ?? string.Empty;
+        if (!string.IsNullOrEmpty(fullName) && !modelNameList.Contains(fullName))
+            modelNameList.Add(fullName);
+
+        int index = modelNameList.IndexOf(fullName);
+
+        return $"{id}{(index >= 1 ? index.ToString() : string.Empty)}";
+    }
+}

--- a/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationExtensions.cs
@@ -69,9 +69,8 @@ public static class CodeGenerationExtensions
     }
 
     public static GeneratedAssemblyDescriptor AddCode(this GeneratedAssemblyDescriptor descriptor, string code) => descriptor.AddCodes(code);
-    public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, ICodeTemplate codeTemplate) => descriptor.AddCodes(codeTemplate.Render());
-    public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, IEnumerable<string> codes) => descriptor.AddCodes([.. codes]);
-    public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, params string[] codes)
+    public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, ICodeTemplate codeTemplate) => descriptor.AddCodes([.. codeTemplate.Render()]);
+    public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, params List<string> codes)
     {
         descriptor.Codes.AddRange(codes);
 
@@ -81,8 +80,7 @@ public static class CodeGenerationExtensions
     public static GeneratedAssemblyDescriptor AddReferenceFrom<T>(this GeneratedAssemblyDescriptor descriptor) => descriptor.AddReferenceFrom(typeof(T));
     public static GeneratedAssemblyDescriptor AddReferenceFrom(this GeneratedAssemblyDescriptor descriptor, Type type) => descriptor.AddReference(type.Assembly);
     public static GeneratedAssemblyDescriptor AddReference(this GeneratedAssemblyDescriptor descriptor, Assembly reference) => descriptor.AddReferences(reference);
-    public static GeneratedAssemblyDescriptor AddReferences(this GeneratedAssemblyDescriptor descriptor, IEnumerable<Assembly> references) => descriptor.AddReferences([.. references]);
-    public static GeneratedAssemblyDescriptor AddReferences(this GeneratedAssemblyDescriptor descriptor, params Assembly[] references)
+    public static GeneratedAssemblyDescriptor AddReferences(this GeneratedAssemblyDescriptor descriptor, params IEnumerable<Assembly> references)
     {
         descriptor.References.AddRange(references);
 

--- a/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationExtensions.cs
@@ -70,7 +70,7 @@ public static class CodeGenerationExtensions
 
     public static GeneratedAssemblyDescriptor AddCode(this GeneratedAssemblyDescriptor descriptor, string code) => descriptor.AddCodes(code);
     public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, ICodeTemplate codeTemplate) => descriptor.AddCodes(codeTemplate.Render());
-    public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, IEnumerable<string> codes) => descriptor.AddCodes(codes.ToArray());
+    public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, IEnumerable<string> codes) => descriptor.AddCodes([.. codes]);
     public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, params string[] codes)
     {
         descriptor.Codes.AddRange(codes);
@@ -81,7 +81,7 @@ public static class CodeGenerationExtensions
     public static GeneratedAssemblyDescriptor AddReferenceFrom<T>(this GeneratedAssemblyDescriptor descriptor) => descriptor.AddReferenceFrom(typeof(T));
     public static GeneratedAssemblyDescriptor AddReferenceFrom(this GeneratedAssemblyDescriptor descriptor, Type type) => descriptor.AddReference(type.Assembly);
     public static GeneratedAssemblyDescriptor AddReference(this GeneratedAssemblyDescriptor descriptor, Assembly reference) => descriptor.AddReferences(reference);
-    public static GeneratedAssemblyDescriptor AddReferences(this GeneratedAssemblyDescriptor descriptor, IEnumerable<Assembly> references) => descriptor.AddReferences(references.ToArray());
+    public static GeneratedAssemblyDescriptor AddReferences(this GeneratedAssemblyDescriptor descriptor, IEnumerable<Assembly> references) => descriptor.AddReferences([.. references]);
     public static GeneratedAssemblyDescriptor AddReferences(this GeneratedAssemblyDescriptor descriptor, params Assembly[] references)
     {
         descriptor.References.AddRange(references);

--- a/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationExtensions.cs
@@ -70,7 +70,7 @@ public static class CodeGenerationExtensions
 
     public static GeneratedAssemblyDescriptor AddCode(this GeneratedAssemblyDescriptor descriptor, string code) => descriptor.AddCodes(code);
     public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, ICodeTemplate codeTemplate) => descriptor.AddCodes([.. codeTemplate.Render()]);
-    public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, params List<string> codes)
+    public static GeneratedAssemblyDescriptor AddCodes(this GeneratedAssemblyDescriptor descriptor, params IEnumerable<string> codes)
     {
         descriptor.Codes.AddRange(codes);
 

--- a/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeTemplateBase.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeTemplateBase.cs
@@ -4,7 +4,7 @@ public abstract class CodeTemplateBase : ICodeTemplate
 {
     protected abstract IEnumerable<string> Render();
 
-    protected string Join(string separator, params string[] statements) =>
+    protected string Join(string separator, params IEnumerable<string> statements) =>
         statements
             .Where(s => !string.IsNullOrWhiteSpace(s))
             .Join(separator ?? Environment.NewLine);

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/AddRemoveChild/AddRemoveChildCodingStyleFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/AddRemoveChild/AddRemoveChildCodingStyleFeature.cs
@@ -12,7 +12,7 @@ public class AddRemoveChildCodingStyleFeature : IFeature<CodingStyleConfigurator
         {
             conventions.Add(new PluralizeActionConvention(_when: c =>
                 (c.Action.Method == HttpMethod.Delete && c.Action.RouteParts.Count >= 2) ||
-                (c.Action.Method == HttpMethod.Post && Regexes.StartsWithAddOrCreate().IsMatch(c.Action.Name) && c.Action.RouteParts.Count >= 2)
+                (c.Action.Method == HttpMethod.Post && Regexes.StartsWithAddOrCreate.IsMatch(c.Action.Name) && c.Action.RouteParts.Count >= 2)
             ));
             conventions.Add(new OnlyEntityParameterIsInRouteForDeleteChildConvention());
             conventions.Add(new RemoveFromRouteConvention(["Add", "Create"]));

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/SingleByUnique/SingleByUniqueCodingStyleFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/SingleByUnique/SingleByUniqueCodingStyleFeature.cs
@@ -18,7 +18,7 @@ public class SingleByUniqueCodingStyleFeature : IFeature<CodingStyleConfigurator
             builder.Conventions.AddMethodMetadata(
                 apply: (c, add) =>
                 {
-                    var match = Regexes.StartsWithSingleBy().Match(c.Method.Name);
+                    var match = Regexes.StartsWithSingleBy.Match(c.Method.Name);
                     var propertyName = match.Groups["Name"].Value;
                     var propertyType = c.Method.DefaultOverload.Parameters[propertyName.Camelize()].ParameterType;
                     if (propertyType.Is<string>() || propertyType.IsEnum)
@@ -31,7 +31,7 @@ public class SingleByUniqueCodingStyleFeature : IFeature<CodingStyleConfigurator
                 },
                 when: c =>
                     c.Type.Has<QueryAttribute>() &&
-                    Regexes.StartsWithSingleBy().IsMatch(c.Method.Name)
+                    Regexes.StartsWithSingleBy.IsMatch(c.Method.Name)
             );
         });
 

--- a/src/recipe/Baked.Recipe.Service.Application/Communication/Mock/MockCommunicationExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Communication/Mock/MockCommunicationExtensions.cs
@@ -49,7 +49,7 @@ public static class MockCommunicationExtensions
         }
         else if (responses is not null)
         {
-            setup().ReturnsAsync(responses.Select(r => new Response(statusCode ?? HttpStatusCode.OK, r.ToJsonString())).ToArray());
+            setup().ReturnsAsync([.. responses.Select(r => new Response(statusCode ?? HttpStatusCode.OK, r.ToJsonString()))]);
         }
         else if (noResponse == true)
         {

--- a/src/recipe/Baked.Recipe.Service.Application/Core/CoreExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Core/CoreExtensions.cs
@@ -53,7 +53,7 @@ public static class CoreExtensions
     ) => new(year, month, day, hour, minute, second);
 
     public static Dictionary<string, string> ADictionary(this Stubber giveMe) => giveMe.ADictionary<string, string>();
-    public static Dictionary<TKey, TValue> ADictionary<TKey, TValue>(this Stubber _, params (TKey, TValue)[] pairs)
+    public static Dictionary<TKey, TValue> ADictionary<TKey, TValue>(this Stubber _, params IEnumerable<(TKey, TValue)> pairs)
         where TKey : notnull
     => pairs.ToDictionary(pair => pair.Item1, pair => pair.Item2);
 

--- a/src/recipe/Baked.Recipe.Service.Application/Core/Regexes.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Core/Regexes.cs
@@ -6,10 +6,10 @@ namespace Baked.Core;
 internal static partial class Regexes
 {
     [GeneratedRegex(@"[\s\S]*?(?=.Application|$)")]
-    public static partial Regex AssemblyNameBeforeApplicationSuffix();
+    public static partial Regex AssemblyNameBeforeApplicationSuffix { get; }
 
     public static string GetNameBeforeApplicationSuffix(this Assembly assembly) =>
-        AssemblyNameBeforeApplicationSuffix()
+        AssemblyNameBeforeApplicationSuffix
             .Match(assembly.FullName ?? string.Empty)
             .Value;
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Cors/AspNetCore/AspNetCoreCorsExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Cors/AspNetCore/AspNetCoreCorsExtensions.cs
@@ -11,7 +11,7 @@ public static class AspNetCoreCorsExtensions
     /// Returns 'AspNetCoreCors' feature with a single policy setup with given origins,
     /// any header and any method
     /// </note>
-    public static AspNetCoreCorsFeature AspNetCore(this CorsConfigurator configurator, params Setting<string>[] origins) =>
+    public static AspNetCoreCorsFeature AspNetCore(this CorsConfigurator configurator, params IEnumerable<Setting<string>> origins) =>
         configurator.AspNetCore(
             options => options
                 .AddPolicy("allow-origin", policy => policy

--- a/src/recipe/Baked.Recipe.Service.Application/Cors/AspNetCore/AspNetCoreCorsExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Cors/AspNetCore/AspNetCoreCorsExtensions.cs
@@ -15,7 +15,7 @@ public static class AspNetCoreCorsExtensions
         configurator.AspNetCore(
             options => options
                 .AddPolicy("allow-origin", policy => policy
-                    .WithOrigins(origins.Select(o => o.GetValue()).ToArray())
+                    .WithOrigins([.. origins.Select(o => o.GetValue())])
                     .AllowAnyHeader()
                     .AllowAnyMethod()
                 ),

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/Model/TypeModel.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/Model/TypeModel.cs
@@ -82,7 +82,7 @@ public class TypeModel : IModel, IEquatable<TypeModel>
         this.TryGetInheritance(out var inheritance) && (inheritance.BaseType?.IsAssignableTo(type) == true || inheritance.Interfaces.Contains(type))
     ;
 
-    public string MakeGenericTypeId(params TypeModel[] typeArguments) =>
+    public string MakeGenericTypeId(params IEnumerable<TypeModel> typeArguments) =>
         TypeModelReference.IdOf(this, typeArguments);
 
     public override bool Equals(object? obj) =>

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/Model/TypeModelGenerics.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/Model/TypeModelGenerics.cs
@@ -25,7 +25,7 @@ public class TypeModelGenerics : TypeModel
 
             if (type.IsGenericType)
             {
-                generics.GenericTypeArguments = new(type.GenericTypeArguments.Select(builder.GetReference));
+                generics.GenericTypeArguments = [.. type.GenericTypeArguments.Select(builder.GetReference)];
                 generics.GenericTypeDefinitionReference = !type.IsGenericTypeDefinition ? builder.GetReference(type.GetGenericTypeDefinition()) : default;
             }
             else

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/Model/TypeModelReference.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/Model/TypeModelReference.cs
@@ -8,7 +8,7 @@ public class TypeModelReference(Type _type, string _id)
             $"{type.Namespace}.{type.Name}<{type.GenericTypeArguments.Select(IdFrom).Join(',')}>"
             : type.FullName ?? type.Name;
 
-    internal static string IdOf(TypeModel typeDefinition, params TypeModel[] typeArguments) =>
+    internal static string IdOf(TypeModel typeDefinition, params IEnumerable<TypeModel> typeArguments) =>
         $"{typeDefinition.Namespace}.{typeDefinition.Name}<{typeArguments.Select(t => t.CSharpFriendlyFullName).Join(',')}>";
 
     internal TypeModelReference(Type type) : this(type, IdFrom(type)) { }

--- a/src/recipe/Baked.Recipe.Service.Application/MockOverrider/MockOverriderExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/MockOverrider/MockOverriderExtensions.cs
@@ -10,28 +10,28 @@ public static class MockOverriderExtensions
     public static void AddMockOverrider(this List<IFeature> features, Func<MockOverriderConfigurator, IFeature<MockOverriderConfigurator>> configure) =>
         features.Add(configure(new()));
 
-    public static T The<T>(this Stubber giveMe, object? mockOverride, params object?[] otherMockOverrides) where T : notnull =>
+    public static T The<T>(this Stubber giveMe, object? mockOverride, params IEnumerable<object?> otherMockOverrides) where T : notnull =>
         giveMe.TheServiceProvider().OverrideMocksAndGetRequiredService<T>([mockOverride, .. otherMockOverrides]);
 
-    public static object The(this Stubber giveMe, Type type, object? mockOverride, params object?[] otherMockOverrides) =>
+    public static object The(this Stubber giveMe, Type type, object? mockOverride, params IEnumerable<object?> otherMockOverrides) =>
         giveMe.TheServiceProvider().OverrideMocksAndGetRequiredService(type, [mockOverride, .. otherMockOverrides]);
 
-    public static T An<T>(this Stubber giveMe, object? mockOverride, params object?[] otherMockOverrides) where T : notnull =>
+    public static T An<T>(this Stubber giveMe, object? mockOverride, params IEnumerable<object?> otherMockOverrides) where T : notnull =>
         giveMe.TheServiceProvider().OverrideMocksAndGetRequiredService<T>([mockOverride, .. otherMockOverrides]);
 
-    public static object An(this Stubber giveMe, Type type, object? mockOverride, params object?[] otherMockOverrides) =>
+    public static object An(this Stubber giveMe, Type type, object? mockOverride, params IEnumerable<object?> otherMockOverrides) =>
         giveMe.TheServiceProvider().OverrideMocksAndGetRequiredService(type, [mockOverride, .. otherMockOverrides]);
 
-    public static T A<T>(this Stubber giveMe, object? mockOverride, params object?[] otherMockOverrides) where T : notnull =>
+    public static T A<T>(this Stubber giveMe, object? mockOverride, params IEnumerable<object?> otherMockOverrides) where T : notnull =>
         giveMe.TheServiceProvider().OverrideMocksAndGetRequiredService<T>([mockOverride, .. otherMockOverrides]);
 
-    public static object A(this Stubber giveMe, Type type, params object?[] mockOverrides) =>
+    public static object A(this Stubber giveMe, Type type, params IEnumerable<object?> mockOverrides) =>
         giveMe.TheServiceProvider().OverrideMocksAndGetRequiredService(type, mockOverrides);
 
-    static T OverrideMocksAndGetRequiredService<T>(this IServiceProvider serviceProvider, params object?[] mockOverrides) where T : notnull =>
+    static T OverrideMocksAndGetRequiredService<T>(this IServiceProvider serviceProvider, params IEnumerable<object?> mockOverrides) where T : notnull =>
         (T)serviceProvider.OverrideMocksAndGetRequiredService(typeof(T), mockOverrides);
 
-    static object OverrideMocksAndGetRequiredService(this IServiceProvider serviceProvider, Type type, params object?[] mockOverrides)
+    static object OverrideMocksAndGetRequiredService(this IServiceProvider serviceProvider, Type type, params IEnumerable<object?> mockOverrides)
     {
         var overrider = serviceProvider.GetRequiredService<IMockOverrider>();
 

--- a/src/recipe/Baked.Recipe.Service.Application/Orm/AutoMap/AutoMapOrmFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Orm/AutoMap/AutoMapOrmFeature.cs
@@ -145,7 +145,7 @@ public class AutoMapOrmFeature : IFeature<OrmConfigurator>
         {
             var domainModel = configurator.Context.GetDomainModel();
 
-            conventions.Add(new AutoHttpMethodConvention([(Regexes.StartsWithFirstBySingleByOrBy(), HttpMethod.Get)]), order: -10);
+            conventions.Add(new AutoHttpMethodConvention([(Regexes.StartsWithFirstBySingleByOrBy, HttpMethod.Get)]), order: -10);
             conventions.Add(new LookupEntityByIdConvention(domainModel));
             conventions.Add(new LookupEntitiesByIdsConvention(domainModel));
             conventions.Add(new RemoveFromRouteConvention(["FirstBy", "SingleBy", "By"],

--- a/src/recipe/Baked.Recipe.Service.Application/Orm/AutoMap/Regexes.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Orm/AutoMap/Regexes.cs
@@ -5,8 +5,8 @@ namespace Baked.Orm.AutoMap;
 internal static partial class Regexes
 {
     [GeneratedRegex(@"^(FirstBy|SingleBy|By).*$", RegexOptions.None, "en-US")]
-    public static partial Regex StartsWithFirstBySingleByOrBy();
+    public static partial Regex StartsWithFirstBySingleByOrBy { get; }
 
     [GeneratedRegex(@"^SingleBy(?<Name>.+)$", RegexOptions.None, "en-US")]
-    public static partial Regex StartsWithSingleBy();
+    public static partial Regex StartsWithSingleBy { get; }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Reporting/Fake/ReportContext.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Reporting/Fake/ReportContext.cs
@@ -17,6 +17,6 @@ public class ReportContext(IFileProvider _fileProvider, ReportOptions _options)
         var match = fakes.FirstOrDefault(fake => fake.Matches(parameters));
         if (match is null) { return []; }
 
-        return match.Result.Select(row => row.Values.ToArray()).ToArray();
+        return [.. match.Result.Select(row => row.Values.ToArray())];
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Reporting/NativeSql/ReportContext.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Reporting/NativeSql/ReportContext.cs
@@ -22,6 +22,6 @@ public class ReportContext(IFileProvider _fileProvider, Func<NHibernate.IStatele
 
         var result = await query.ListAsync();
 
-        return result.Cast<object[]>().ToArray();
+        return [.. result.Cast<object[]>()];
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/RestApi/Model/ActionModel.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/RestApi/Model/ActionModel.cs
@@ -30,7 +30,7 @@ public record ActionModel(
 
     public IEnumerable<ParameterModel> Parameters { get => Parameter.Values; init => Parameter = value.ToDictionary(p => p.Id); }
 
-    IEnumerable<ParameterModel> ActionParameters => Parameters.Where(p => !p.IsHardCoded).OrderBy(p => p.Order).OrderBy(p => p.IsOptional ? 1 : -1);
+    IEnumerable<ParameterModel> ActionParameters => Parameters.Where(p => !p.IsHardCoded).OrderBy(p => p.Order).ThenBy(p => p.IsOptional ? 1 : -1);
     IEnumerable<ParameterModel> RouteParameters => Parameters.Where(p => p.From == ParameterModelFrom.Route).OrderBy(p => p.RoutePosition);
     IEnumerable<ParameterModel> NonServiceParameters => ActionParameters.Where(p => p.From != ParameterModelFrom.Services);
 

--- a/src/recipe/Baked.Recipe.Service.Application/RestApi/Regexes.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/RestApi/Regexes.cs
@@ -5,17 +5,17 @@ namespace Baked.RestApi;
 internal static partial class Regexes
 {
     [GeneratedRegex(@"^Get.*$", RegexOptions.None, "en-US")]
-    public static partial Regex StartsWithGet();
+    public static partial Regex StartsWithGet { get; }
 
     [GeneratedRegex(@"^(Add|Create).*$", RegexOptions.None, "en-US")]
-    public static partial Regex StartsWithAddOrCreate();
+    public static partial Regex StartsWithAddOrCreate { get; }
 
     [GeneratedRegex(@"^(Delete|Remove|Clear).*$", RegexOptions.None, "en-US")]
-    public static partial Regex StartsWithDeleteRemoveOrClear();
+    public static partial Regex StartsWithDeleteRemoveOrClear { get; }
 
     [GeneratedRegex(@"^(Update|Change|Set)$", RegexOptions.None, "en-US")]
-    public static partial Regex IsUpdateChangeOrSet();
+    public static partial Regex IsUpdateChangeOrSet { get; }
 
     [GeneratedRegex(@"^(Update|Change|Set).*$", RegexOptions.None, "en-US")]
-    public static partial Regex StartsWithUpdateChangeOrSet();
+    public static partial Regex StartsWithUpdateChangeOrSet { get; }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Testing/TestingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Testing/TestingExtensions.cs
@@ -27,13 +27,13 @@ public static class TestingExtensions
             Setup: setup == default ? default : obj => setup(obj)
         ));
 
-    public static void Returns<TMock, TResult>(this ISetup<TMock, TResult> setup, params TResult[] results) where TMock : class
+    public static void Returns<TMock, TResult>(this ISetup<TMock, TResult> setup, params IList<TResult> results) where TMock : class
     {
         int currentResultIndex = 0;
 
         setup.Returns(() =>
         {
-            if (currentResultIndex >= results.Length)
+            if (currentResultIndex >= results.Count)
             {
                 currentResultIndex = 0;
             }
@@ -42,13 +42,13 @@ public static class TestingExtensions
         });
     }
 
-    public static void ReturnsAsync<TMock, TResult>(this ISetup<TMock, Task<TResult>> setup, params TResult[] results) where TMock : class
+    public static void ReturnsAsync<TMock, TResult>(this ISetup<TMock, Task<TResult>> setup, params IList<TResult> results) where TMock : class
     {
         int currentResultIndex = 0;
 
         setup.ReturnsAsync(() =>
         {
-            if (currentResultIndex >= results.Length)
+            if (currentResultIndex >= results.Count)
             {
                 currentResultIndex = 0;
             }

--- a/src/recipe/Baked.Recipe.Service.Application/Testing/WebApplicationNfr.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Testing/WebApplicationNfr.cs
@@ -48,6 +48,6 @@ public abstract class WebApplicationNfr : Nfr
     {
         base.TearDown();
 
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", string.Empty);
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", default);
     }
 }

--- a/test/recipe/Baked.Test.Recipe.Service.Application/Dockerfile
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7-labs
 ARG ENVIRONMENT Production
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 
 ARG ENVIRONMENT
 
@@ -9,7 +9,7 @@ EXPOSE 80
 ENV ASPNETCORE_ENVIRONMENT $ENVIRONMENT
 ENV ASPNETCORE_URLS=http://+:80
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS publish
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS publish
 
 ARG ENVIRONMENT
 

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/SwaggerSchemaGeneration.cs
@@ -88,21 +88,21 @@ public class SwaggerSchemaGeneration : TestServiceNfr
         var response = await Client.GetAsync("/swagger/samples/swagger.json");
 
         dynamic? content = await response.Content.Deserialize();
-        var schema = content?.components.schemas["test--business--documentation-samples--method-request"];
+        var schema = content?.components.schemas["MethodRequest"];
 
         ((string?)schema?.properties["parameter1"].description).ShouldBe("Parameter 1 documentation");
         ((string?)schema?.properties["parameter2"].description).ShouldBe("Parameter 2 documentation");
     }
 
-    [TestCase("entity-parameters", "entityId", "Entity description")]
-    [TestCase("entity-list-parameters", "entityIds", "Entities description")]
-    [TestCase("entity-list-parameters", "otherEntityIds", "Other entities description")]
+    [TestCase("EntityParameters", "entityId", "Entity description")]
+    [TestCase("EntityListParameters", "entityIds", "Entities description")]
+    [TestCase("EntityListParameters", "otherEntityIds", "Other entities description")]
     public async Task Entity_parameter_comments_are_kept_even_if_their_name_change(string method, string parameter, string expected)
     {
         var response = await Client.GetAsync("/swagger/samples/swagger.json");
 
         dynamic? content = await response.Content.Deserialize();
-        var schema = content?.components.schemas[$"test--business--method-samples--{method}-request"];
+        var schema = content?.components.schemas[$"{method}Request"];
 
         ((string?)schema?.properties[parameter].description).ShouldBe(expected);
     }
@@ -147,7 +147,7 @@ public class SwaggerSchemaGeneration : TestServiceNfr
         var response = await Client.GetAsync("/swagger/samples/swagger.json");
 
         dynamic? content = await response.Content.Deserialize();
-        var schema = content?.components.schemas["test--business--documented-data"];
+        var schema = content?.components.schemas["DocumentedData"];
 
         ((string?)schema?.description).ShouldBe("Data summary");
         ((string?)schema?.properties["property"].description).ShouldBe("Property summary");

--- a/test/recipe/Baked.Test.Recipe.Service/Reporting/ReportSamples.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Reporting/ReportSamples.cs
@@ -5,7 +5,7 @@ namespace Baked.Test.Reporting;
 public class ReportSamples(IReportContext _context)
 {
     public async Task<List<EntityReportData>> GetEntity(string @string) =>
-        (await _context.Execute("entity",
+        [.. (await _context.Execute("entity",
             new()
             {
                 { nameof(@string), $"{@string}%" }
@@ -16,8 +16,7 @@ public class ReportSamples(IReportContext _context)
                 Convert.ToInt32(row[0]),
                 (string?)row[1] ?? string.Empty
             )
-        )
-        .ToList();
+        )];
 
     public async Task GetNonExisting()
     {

--- a/unreleased.md
+++ b/unreleased.md
@@ -13,8 +13,7 @@ projects.
 - [ ] Upgrade Baked version
 - [ ] You can use `GeneratedRegex`es in properties instead of methods
 - [ ] If `Base64` encoded information is carried in the url, use `Base64Url`.
-  - [ ] If need to take parameters with an `Array` using params
-  and then convert to `IEnumerable` type, use `IEnumerable` instead of `Array`.
+- [ ] `params` arguments should be converted from arrays to `IEnumerable`
 - [ ] Use the new linQ extensions(`CountBy`, `AggregateBy`,
   `Index<TSource>(IEnumerable<TSource>))`.
 - [ ] Use new `TimeSpan.From*` overloads

--- a/unreleased.md
+++ b/unreleased.md
@@ -71,6 +71,7 @@ projects.
   - `ProblemDetails`
 - `GiveMe.PropertyOf<T>` helper is renamed to `ThePropertyOf<T>`
 - `GiveMe.MethodOf<T>` helper is renamed to `TheMethodOf<T>`
+- Removed namespaces from `SchemaId` created in Swagger.
 
 ## Library Upgrades
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,13 +1,47 @@
 # Unreleased
 
+## .NET Upgrade
+
+Baked now supports .NET 9! Below you can find a task list to upgrade your
+projects.
+
+```markdown
+- [ ] Upgrade .NET and C# versions
+  - [ ] in projects
+  - [ ] in docker files
+  - [ ] in GitHub workflows
+- [ ] Upgrade Baked version
+- [ ] You can use `GeneratedRegex`es in properties instead of methods
+- [ ] If `Base64` encoded information is carried in the url, use `Base64Url`.
+  - [ ] If need to take parameters with an `Array` using params
+  and then convert to `IEnumerable` type, use `IEnumerable` instead of `Array`.
+- [ ] Use the new linQ extensions(`CountBy`, `AggregateBy`,
+  `Index<TSource>(IEnumerable<TSource>))`.
+- [ ] Use new `TimeSpan.From*` overloads
+  - `FromDays`
+  - `FromHours`
+  - `FromMinutes`
+  - `FromSeconds`
+  - `FromMilliseconds`
+  - `FromMicroseconds`
+- [ ] Use Keyed Services in Middlewares.
+```
+
+### Upgrade .NET and C# versions
+
+- Upgrade the project's `C#` language to `13`.
+- Framework version upgrade to `net9.0` in the projects.
+- Framework and sdk version upgrade to `9` in `Dockerfile`.
+- Upgrade dotnet version `9` in Github actions.
+
 ## Features
 
-- `Application` now provies `Bake` and `Start` modes which can be run both 
+- `Application` now provies `Bake` and `Start` modes which can be run both
   together or individually with distinct `ApplicationContext`'s.
   - `RunFlags` is introduced for configuring application mode
 - `LayerBase` now provies `GetBakePhases()` method to enable registering
-  specific phases to run at `Bake` mode 
-- `Service` and `Data Source` recipies now triggers `Bake` mode run at post 
+  specific phases to run at `Bake` mode
+- `Service` and `Data Source` recipies now triggers `Bake` mode run at post
   build
 - `Domain` layer's `AddDomainTypes` and `BuildDomainModel` phases now only runs
   in `Bake` mode
@@ -20,22 +54,46 @@
 
 ## Improvements
 
-- `CodeGeneration` layer now compiles and saves generated assemblies and files 
+- `CodeGeneration` layer now compiles and saves generated assemblies and files
   to entry assembly location with `ASPNETCORE_ENVIRONMENT` subfolder
 - `DomainAssemblies` feature now generates
   - `ICasterConfigurer`
-  implementations and 
+  implementations and
   - `TagDescriptor`
   - `RequestResponseExample`
-  json files in `Bake` mode   
-- Following features now generates `IServiceAdder` implementations from 
-  `DomainModel` in `Bake` mode   
+  json files in `Bake` mode
+- Following features now generates `IServiceAdder` implementations from
+  `DomainModel` in `Bake` mode
   - `Transient`
   - `Scoped`
   - `Singleton`
   - `AutoMapOrm`
   - `ProblemDetails`
-- `GiveMe.PropertyOf<T>` helper is renamed to `ThePropertyOf<T>`  
-- `GiveMe.MethodOf<T>` helper is renamed to `TheMethodOf<T>`  
-  
-  
+- `GiveMe.PropertyOf<T>` helper is renamed to `ThePropertyOf<T>`
+- `GiveMe.MethodOf<T>` helper is renamed to `TheMethodOf<T>`
+
+## Library Upgrades
+
+| Package                                         | Old Version | New Version |
+| ----------------------------------------------- | ----------- | ----------- |
+| coverlet.collector                              | 6.0.2       | 6.0.4       |
+| Microsoft.AspNetCore.Mvc.NewtonsoftJson         | 8.0.8       | 9.0.1       |
+| Microsoft.AspNetCore.Mvc.Testing                | 8.0.10      | 9.0.1       |
+| Microsoft.AspNetCore.Authorization              | 8.0.8       | removed     |
+| Microsoft.CodeAnalysis.CSharp                   | 4.11.0      | 4.12.0      |
+| Microsoft.CodeAnalysis.Analyzers                | 3.3.4       | removed     |
+| Microsoft.Extensions.Caching.Abstraction        | 8.0.0       | 9.0.1       |
+| Microsoft.Extensions.Configuration.Abstractions | 8.0.0       | 9.0.1       |
+| Microsoft.Extensions.Configuration.Binder       | 8.0.2       | 9.0.1       |
+| Microsoft.Extensions.FileProviders.Abstractions | 8.0.0       | 9.0.1       |
+| Microsoft.Extensions.Logging.Abstractions       | 8.0.2       | 9.0.1       |
+| Microsoft.Extensions.TimeProvider.Testing       | 8.10.0      | 9.1.0       |
+| Microsoft.NET.Test.Sdk                          | 17.11.1     | 17.12.0     |
+| MySql.Data                                      | 9.1.0       | 9.2.0       |
+| NHibernate.Extensions.Sqlite                    | 8.0.14      | 9.0.0       |
+| NUnit                                           | 4.2.2       | 4.3.2       |
+| Npgsql                                          | 8.0.5       | 9.0.2       |
+| Oracle.ManagedDataAccess.Core                   | 23.6.0      | 23.7.0      |
+| Shouldly                                        | 4.2.1       | 4.3.0       |
+| Swashbuckle.AspNetCore                          | 6.9.0       | 7.2.0       |
+| Swashbuckle.AspNetCore.Annotations              | 6.9.0       | 7.2.0       |


### PR DESCRIPTION
Upgrade .Net, C# and other versions.

## Tasks

- [x] Learn .NET 8 https://github.com/mouseless/learn-dotnet/pull/36
- [x] Update .Net and Language version.
  - version in .csproj
  - version in workflows
  - version in sample
  - version in docker
- Migration plan
  - [x] Use status code selector in exception handler
  - [x] Migrate to property in regex source generation
  - [x] If `Base64` encoded information is carried in the url, use
    `Base64Url`.
  - [x] If need to take parameters with an `Array` using `params`
    and then convert to `IEnumerable` type, use `IEnumerable` instead of
    `Array`.
  - [x] Use the new linQ extensions(`CountBy`, `AggregateBy`,
    `Index<TSource>(IEnumerable<TSource>)`).
  - [x] Use new  `TimeSpan.From*` overloads
    - `FromDays`
    - `FromHours`
    - `FromMinutes`
    - `FromSeconds`
    - `FromMilliseconds`
    - `FromMicroseconds`
  - [x] Use Keyed Services in Middlewares.
- Upgrade Issues
  - [x] Antlr3.runtime access denied issue on windows, unable to access issue on
    linux
- [x] Migrations page on website

## Additional Tasks

- [x] Remove the whole base namespace (not just first part) from open api types
