### PR TITLE
Issue / Rename Start Phases

### DIFF
--- a/docs/architecture/application.md
+++ b/docs/architecture/application.md
@@ -111,7 +111,7 @@ Bake.New
 ```
 
 Application runs in phases provided by its layers. These phases come from 
-`GetPhases()` or `GetBakePhases()` methods of `ILayer`.
+`GetStartPhases()` or `GetGeneratePhases()` methods of `ILayer`.
 
 For example `HttpServerLayer` uses ASP.NET Core to build a web application which typically
 runs in three phases;
@@ -127,10 +127,10 @@ flowchart TB
 
 > [!TIP]
 >
-> Application has `Bake` and `Start` mode which is configured with `RunFlags` 
-> parameter. `RunFlags` enables running `Bake` and `Start` modes
-> modes individually or respectively. `Bake` mode calls `GetBakePhases()` and
-> `Start` mode calls `GetPhases()` methods to collect phases
+> Application has `Generate` and `Start` mode which is configured with `RunFlags` 
+> parameter. `RunFlags` enables running `Generate` and `Start` modes
+> modes individually or respectively. `Generate` mode calls `GetGeneratePhases()` and
+> `Start` mode calls `GetStartPhases()` methods to collect phases
 
 At the beginning of each phase, application initializes it by providing an
 `ApplicationContext` instance. This way each phase can add/get certain objects
@@ -170,9 +170,9 @@ sequenceDiagram
 
     autonumber
 
-    APP ->>+ LA: GetPhases()
+    APP ->>+ LA: GetStartPhases()
     LA -->>- APP: Phase A
-    APP ->>+ LB: GetPhases()
+    APP ->>+ LB: GetStartPhases()
     LB -->>- APP: Phase B
 
     APP ->>+ PA: Initialize

--- a/docs/architecture/layer.md
+++ b/docs/architecture/layer.md
@@ -75,18 +75,18 @@ public class LayerX : LayerBase
 ## Adding Phases
 
 By default `LayerBase` returns no phases. To add one or more phases into the
-application, you need to override `GetPhases()` or `GetBakePhases()` methods 
+application, you need to override `GetStartPhases()` or `GetGeneratePhases()` methods 
 as shown below;
 
 ```csharp
 public class SampleLayer : LayerBase
 {
-    protected override IEnumerable<IPhase> GetPhases()
+    protected override IEnumerable<IPhase> GetStartPhases()
     {
         yield return new DoA();
     }
 
-    protected override IEnumerable<IPhase> GetBakePhases()
+    protected override IEnumerable<IPhase> GetGeneratePhases()
     {
         yield return new DoB();
     }
@@ -96,7 +96,7 @@ public class SampleLayer : LayerBase
 }
 ```
 
-Here `SampleLayer` adds two phases, `DoA` to `Start` mode and `DoB` to `Bake` 
+Here `SampleLayer` adds two phases, `DoA` to `Start` mode and `DoB` to `Generate` 
 mode of the application.
 
 > [!TIP]

--- a/docs/layers/code-generation.md
+++ b/docs/layers/code-generation.md
@@ -47,7 +47,7 @@ configurator.ConfigureGeneratedFileCollection(files =>
 
 ## Phases
 
-This layer introduces following `Bake` phases to the application it is added;
+This layer introduces following `Generate` phases to the application it is added;
 
 - `GenerateCode`: This phase creates a `IGeneratedAssemblyCollection` instance
   and places it in the application context

--- a/docs/layers/domain.md
+++ b/docs/layers/domain.md
@@ -11,7 +11,7 @@ app.Layers.AddDomain();
 ## Configuration Targets
 
 This layer provides `IDomainTypeCollection` and `DomainModelBuilderOptions`
-configuration targets for building `DomainModel` in `Bake` mode. It also 
+configuration targets for building `DomainModel` in `Generate` mode. It also 
 provides `DomainServiceCollection` configuration target for features to add
 `DomainServiceDescriptor` for domain types which then be used to generate an
 `IServiceAdder` implementation. The generated `IServiceAdder` is then 
@@ -55,7 +55,7 @@ configurator.ConfigureDomainServiceCollection(services =>
 
 ## Phases
 
-This layer introduces following `Bake` phases to the application it is added;
+This layer introduces following `Generate` phases to the application it is added;
 
 - `AddDomainTypes`: This phase adds an `IDomainTypeCollection` instance to the
   application context

--- a/docs/layers/http-server.md
+++ b/docs/layers/http-server.md
@@ -49,7 +49,7 @@ configurator.ConfigureEndpointRouteBuilder(routes =>
 
 ## Phases
 
-This layer introduces following phases to the application it is added;
+This layer introduces following `Start` phases to the application it is added;
 
 - `CreateBuilder`: This phase is the earliest phase in an application which
   creates and adds a `WebApplicationBuilder` instance to the application context

--- a/docs/layers/runtime.md
+++ b/docs/layers/runtime.md
@@ -61,7 +61,7 @@ configurator.ConfigureServiceProvider(sp =>
 
 ## Phases
 
-This layer introduces following phases to the application it is added;
+This layer introduces following `Start` phases to the application it is added;
 
 - `BuildConfiguration`: This phase runs in the earliest stage to allow the usage
   of `Settings` API from features

--- a/docs/layers/testing.md
+++ b/docs/layers/testing.md
@@ -24,7 +24,7 @@ configurator.ConfigureTestConfiguration(test =>
 
 ## Phases
 
-This layer introduces following phases to the application it is added;
+This layer introduces following `Start` phases to the application it is added;
 
 - `CreateConfigurationManager`: This phase runs as the earliest stage of a test
   run to add an empty `ConfigurationManager` to the application context

--- a/src/core/Baked.Architecture/Architecture/Application.cs
+++ b/src/core/Baked.Architecture/Architecture/Application.cs
@@ -1,13 +1,13 @@
 ﻿namespace Baked.Architecture;
 
-public class Application(ApplicationContext _context,
-    ApplicationContext? _bakeContext = default
+public class Application(ApplicationContext _startContext,
+    ApplicationContext? _generateContext = default
 )
 {
     readonly List<ILayer> _layers = [];
     readonly List<IFeature> _features = [];
-    readonly List<IPhase> _phases = [];
-    readonly List<IPhase> _bakePhases = [];
+    readonly List<IPhase> _startPhases = [];
+    readonly List<IPhase> _generatePhases = [];
     RunFlags _runFlags = RunFlags.Start!;
 
     internal Application With(ApplicationDescriptor descriptor, RunFlags runFlags)
@@ -37,40 +37,40 @@ public class Application(ApplicationContext _context,
 
     void FillPhases()
     {
-        if (_runFlags.HasFlag(RunFlags.Bake))
+        if (_runFlags.HasFlag(RunFlags.Generate))
         {
             foreach (var layer in _layers)
             {
-                _bakePhases.AddRange(layer.GetBakePhases());
+                _generatePhases.AddRange(layer.GetGeneratePhases());
             }
 
-            _bakeContext ??= new();
-            _bakePhases.ForEach(p => p.Context = _bakeContext);
-            _bakePhases.Sort((l, r) => l.Order - r.Order);
+            _generateContext ??= new();
+            _generatePhases.ForEach(p => p.Context = _generateContext);
+            _generatePhases.Sort((l, r) => l.Order - r.Order);
         }
 
         if (_runFlags.HasFlag(RunFlags.Start))
         {
             foreach (var layer in _layers)
             {
-                _phases.AddRange(layer.GetPhases());
+                _startPhases.AddRange(layer.GetStartPhases());
             }
 
-            _phases.ForEach(p => p.Context = _context);
-            _phases.Sort((l, r) => l.Order - r.Order);
+            _startPhases.ForEach(p => p.Context = _startContext);
+            _startPhases.Sort((l, r) => l.Order - r.Order);
         }
     }
 
     public void Run()
     {
-        if (_runFlags.HasFlag(RunFlags.Bake))
+        if (_runFlags.HasFlag(RunFlags.Generate))
         {
-            ExecutePhases(_bakePhases, _bakeContext ?? new());
+            ExecutePhases(_generatePhases, _generateContext ?? new());
         }
 
         if (_runFlags.HasFlag(RunFlags.Start))
         {
-            ExecutePhases(_phases, _context);
+            ExecutePhases(_startPhases, _startContext);
         }
     }
 

--- a/src/core/Baked.Architecture/Architecture/CannotProceedException.cs
+++ b/src/core/Baked.Architecture/Architecture/CannotProceedException.cs
@@ -5,5 +5,4 @@ public class CannotProceedException(IEnumerable<IPhase> _phases)
         "Cannot proceed to run the application. " +
         $"Phases ({string.Join(", ", _phases.Select(p => p.GetType().Name))}) " +
         "won't get ready for initialization."
-    )
-{ }
+    );

--- a/src/core/Baked.Architecture/Architecture/IFeature.cs
+++ b/src/core/Baked.Architecture/Architecture/IFeature.cs
@@ -7,4 +7,4 @@ public interface IFeature
     public string Id => GetType().Name;
 }
 
-public interface IFeature<T> : IFeature { }
+public interface IFeature<T> : IFeature;

--- a/src/core/Baked.Architecture/Architecture/ILayer.cs
+++ b/src/core/Baked.Architecture/Architecture/ILayer.cs
@@ -3,7 +3,7 @@
 public interface ILayer
 {
     string Id { get; }
-    IEnumerable<IPhase> GetPhases();
-    IEnumerable<IPhase> GetBakePhases();
+    IEnumerable<IPhase> GetStartPhases();
+    IEnumerable<IPhase> GetGeneratePhases();
     PhaseContext GetContext(IPhase phase, ApplicationContext context);
 }

--- a/src/core/Baked.Architecture/Architecture/LayerBase.cs
+++ b/src/core/Baked.Architecture/Architecture/LayerBase.cs
@@ -6,10 +6,10 @@ public abstract class LayerBase : ILayer
 
     protected virtual string Id => GetType().Name;
 
-    protected virtual IEnumerable<IPhase> GetPhases() =>
+    protected virtual IEnumerable<IPhase> GetStartPhases() =>
         [];
 
-    protected virtual IEnumerable<IPhase> GetBakePhases() =>
+    protected virtual IEnumerable<IPhase> GetGeneratePhases() =>
         [];
 
     protected virtual PhaseContext GetContext(IPhase phase) =>
@@ -17,11 +17,11 @@ public abstract class LayerBase : ILayer
 
     string ILayer.Id => Id;
 
-    IEnumerable<IPhase> ILayer.GetPhases() =>
-        GetPhases();
+    IEnumerable<IPhase> ILayer.GetStartPhases() =>
+        GetStartPhases();
 
-    IEnumerable<IPhase> ILayer.GetBakePhases() =>
-        GetBakePhases();
+    IEnumerable<IPhase> ILayer.GetGeneratePhases() =>
+        GetGeneratePhases();
 
     PhaseContext ILayer.GetContext(IPhase phase, ApplicationContext context)
     {

--- a/src/core/Baked.Architecture/Architecture/OverlappingPhaseException.cs
+++ b/src/core/Baked.Architecture/Architecture/OverlappingPhaseException.cs
@@ -5,5 +5,4 @@ public class OverlappingPhaseException(PhaseOrder _order, IEnumerable<IPhase> _p
         $"More than one phase cannot have '{_order}' at the same time. " +
         "Change the order of phases. Overlapping phases are: " +
         $"{string.Join(", ", _phases.Where(p => p.Order == _order).Select(p => p.GetType().Name))}"
-    )
-{ }
+    );

--- a/src/core/Baked.Architecture/Architecture/RunFlags.cs
+++ b/src/core/Baked.Architecture/Architecture/RunFlags.cs
@@ -4,5 +4,5 @@
 public enum RunFlags
 {
     Start = 1 << 0,
-    Bake = 1 << 1
+    Generate = 1 << 1
 }

--- a/src/core/Baked.Architecture/Bake.cs
+++ b/src/core/Baked.Architecture/Bake.cs
@@ -14,9 +14,9 @@ public class Bake(IBanner _banner, Func<Application> _newApplication,
         {
             var args = Environment.GetCommandLineArgs();
             var runFlags = RunFlags.Start;
-            if (args.Contains("--bake"))
+            if (args.Contains("--generate"))
             {
-                runFlags |= RunFlags.Bake;
+                runFlags |= RunFlags.Generate;
             }
 
             if (args.Contains("--no-start"))
@@ -41,7 +41,7 @@ public class Bake(IBanner _banner, Func<Application> _newApplication,
 
         if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Nfr")
         {
-            return _newApplication().With(descriptor, RunFlags.Start | RunFlags.Bake);
+            return _newApplication().With(descriptor, RunFlags.Start | RunFlags.Generate);
         }
 
         return _newApplication().With(descriptor, _runFlags);

--- a/src/core/Baked.Architecture/Testing/Spec.cs
+++ b/src/core/Baked.Architecture/Testing/Spec.cs
@@ -7,17 +7,17 @@ namespace Baked.Testing;
 
 public abstract class Spec
 {
-    private static ApplicationContext _context = new();
-    private static ApplicationContext _bakeContext = new();
+    private static ApplicationContext _startContext = new();
+    private static ApplicationContext _generateContext = new();
 
-    public static ApplicationContext ContextStatic => _context;
-    public static ApplicationContext BakeContextStatic => _bakeContext;
+    public static ApplicationContext StartContextStatic => _startContext;
+    public static ApplicationContext GenerateContextStatic => _generateContext;
 
-    public ApplicationContext Context => _context;
-    public ApplicationContext BakeContext => _bakeContext;
+    public ApplicationContext StartContext => _startContext;
+    public ApplicationContext GenerateContext => _generateContext;
 
     protected static void Init(Action<ApplicationDescriptor> describe) =>
-        new Bake(new Mock<IBanner>().Object, () => new(_context, _bakeContext: _bakeContext), _runFlags: RunFlags.Bake | RunFlags.Start)
+        new Bake(new Mock<IBanner>().Object, () => new(_startContext, _generateContext: _generateContext), _runFlags: RunFlags.Generate | RunFlags.Start)
             .Application(describe)
             .Run();
 
@@ -36,18 +36,18 @@ public abstract class Spec
         GiveMe = new(this);
         MockMe = new(this);
 
-        if (_context.Has<ITestRun>())
+        if (_startContext.Has<ITestRun>())
         {
-            _context.Get<ITestRun>().SetUp(this);
+            _startContext.Get<ITestRun>().SetUp(this);
         }
     }
 
     [TearDown]
     public virtual void TearDown()
     {
-        if (_context.Has<ITestRun>())
+        if (_startContext.Has<ITestRun>())
         {
-            _context.Get<ITestRun>().TearDown(this);
+            _startContext.Get<ITestRun>().TearDown(this);
         }
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Authentication/AuthenticationConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Authentication/AuthenticationConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Authentication;
 
-public class AuthenticationConfigurator { }
+public class AuthenticationConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/TagDescriptions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Business/DomainAssemblies/TagDescriptions.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Business.DomainAssemblies;
 
-public class TagDescriptions : Dictionary<string, string> { }
+public class TagDescriptions : Dictionary<string, string>;

--- a/src/recipe/Baked.Recipe.Service.Application/Caching/CachingConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Caching/CachingConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Caching;
 
-public class CachingConfigurator { }
+public class CachingConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationLayer.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodeGeneration/CodeGenerationLayer.cs
@@ -60,7 +60,7 @@ public class CodeGenerationLayer : LayerBase<GenerateCode, Compile, BuildConfigu
         return PhaseContext.Empty;
     }
 
-    protected override IEnumerable<IPhase> GetBakePhases()
+    protected override IEnumerable<IPhase> GetGeneratePhases()
     {
         yield return new GenerateCode(_location, _generatedAssemblies, _generatedFiles);
         yield return new Compile(_location);

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/CodingStyleConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/CodingStyleConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.CodingStyle;
 
-public class CodingStyleConfigurator { }
+public class CodingStyleConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/CommandPattern/PubliclyInitializableAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/CommandPattern/PubliclyInitializableAttribute.cs
@@ -1,4 +1,4 @@
 ﻿namespace Baked.CodingStyle.CommandPattern;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class PubliclyInitializableAttribute : Attribute { }
+public class PubliclyInitializableAttribute : Attribute;

--- a/src/recipe/Baked.Recipe.Service.Application/CodingStyle/SingleByUnique/RouteParameterIsNotValidException.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/CodingStyle/SingleByUnique/RouteParameterIsNotValidException.cs
@@ -5,5 +5,4 @@ namespace Baked.CodingStyle.SingleByUnique;
 public class RouteParameterIsNotValidException(string parameter, object? value)
     : HandledException($"'{value}' is not a valid {parameter}", null,
         extraData: new() { { "parameter", parameter }, { "value", value } }
-    )
-{ }
+    );

--- a/src/recipe/Baked.Recipe.Service.Application/Communication/CommunicationConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Communication/CommunicationConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Communication;
 
-public class CommunicationConfigurator { }
+public class CommunicationConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/Core/CoreConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Core/CoreConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Core;
 
-public class CoreConfigurator { }
+public class CoreConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/Core/Mock/FakeSettings.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Core/Mock/FakeSettings.cs
@@ -1,4 +1,3 @@
 ﻿namespace Baked.Core.Mock;
 
-public class FakeSettings : Dictionary<string, string>
-{ }
+public class FakeSettings : Dictionary<string, string>;

--- a/src/recipe/Baked.Recipe.Service.Application/Database/DatabaseConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Database/DatabaseConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Database;
 
-public class DatabaseConfigurator { }
+public class DatabaseConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/Database/NoTransactionAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Database/NoTransactionAttribute.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Database;
 
-public class NoTransactionAttribute : Attribute { }
+public class NoTransactionAttribute : Attribute;

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/DomainExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/DomainExtensions.cs
@@ -216,7 +216,7 @@ public static class DomainExtensions
 
     public static MethodModel TheMethod<T>(this Stubber giveMe, string name) =>
         giveMe
-            .Spec.BakeContext
+            .Spec.GenerateContext
             .GetDomainModel().Types[typeof(T)]
             .GetMembers().Methods[name];
 
@@ -256,7 +256,7 @@ public static class DomainExtensions
         string? parameter = default
     )
     {
-        var domainModel = giveMe.Spec.BakeContext.GetDomainModel();
+        var domainModel = giveMe.Spec.GenerateContext.GetDomainModel();
         var type = domainModel.Types[typeof(T)];
         if (!type.TryGetMembers(out var members)) { return null; }
 

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/DomainExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/DomainExtensions.cs
@@ -29,6 +29,9 @@ public static class DomainExtensions
         configurator.Configure(configuration);
 
     public static void ConfigureDomainServiceCollection(this LayerConfigurator configurator, Action<DomainServiceCollection> configuration) =>
+        configurator.ConfigureDomainServiceCollection((services, _) => configuration(services));
+
+    public static void ConfigureDomainServiceCollection(this LayerConfigurator configurator, Action<DomainServiceCollection, DomainModel> configuration) =>
         configurator.Configure(configuration);
 
     public static void UsingDomainModel(this LayerConfigurator configurator, Action<DomainModel> configuration) =>

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/DomainLayer.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/DomainLayer.cs
@@ -36,7 +36,7 @@ public class DomainLayer : LayerBase<AddDomainTypes, GenerateCode, AddServices>
         var domain = Context.GetDomainModel();
 
         return phase.CreateContextBuilder()
-            .Add(_domainServiceCollection)
+            .Add(_domainServiceCollection, domain)
             .OnDispose(() =>
             {
                 generatedAssemblies.Add(nameof(DomainLayer),

--- a/src/recipe/Baked.Recipe.Service.Application/Domain/DomainLayer.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Domain/DomainLayer.cs
@@ -57,7 +57,7 @@ public class DomainLayer : LayerBase<AddDomainTypes, GenerateCode, AddServices>
         return phase.CreateEmptyContext();
     }
 
-    protected override IEnumerable<IPhase> GetBakePhases()
+    protected override IEnumerable<IPhase> GetGeneratePhases()
     {
         yield return new AddDomainTypes(_domainTypes);
         yield return new BuildDomainModel(_builderOptions);

--- a/src/recipe/Baked.Recipe.Service.Application/ExceptionHandling/ExceptionHandlingConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/ExceptionHandling/ExceptionHandlingConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.ExceptionHandling;
 
-public class ExceptionHandlingConfigurator { }
+public class ExceptionHandlingConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/HttpServer/HttpServerLayer.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/HttpServer/HttpServerLayer.cs
@@ -78,7 +78,7 @@ public class HttpServerLayer : LayerBase<AddServices, Build>
             .Build();
     }
 
-    protected override IEnumerable<IPhase> GetPhases()
+    protected override IEnumerable<IPhase> GetStartPhases()
     {
         yield return new CreateBuilder();
         yield return new Build();

--- a/src/recipe/Baked.Recipe.Service.Application/Lifetime/LifetimeConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Lifetime/LifetimeConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Lifetime;
 
-public class LifetimeConfigurator { }
+public class LifetimeConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/Lifetime/Scoped/ScopedLifetimeFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Lifetime/Scoped/ScopedLifetimeFeature.cs
@@ -11,15 +11,12 @@ public class ScopedLifetimeFeature : IFeature<LifetimeConfigurator>
             builder.Index.Type.Add<ScopedAttribute>();
         });
 
-        configurator.ConfigureDomainServiceCollection(services =>
+        configurator.ConfigureDomainServiceCollection((services, domain) =>
         {
-            configurator.UsingDomainModel(domain =>
+            foreach (var scoped in domain.Types.Having<ScopedAttribute>())
             {
-                foreach (var scoped in domain.Types.Having<ScopedAttribute>())
-                {
-                    services.AddScoped(scoped, useFactory: true);
-                }
-            });
+                services.AddScoped(scoped, useFactory: true);
+            }
         });
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Lifetime/Singleton/SingletonLifetimeFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Lifetime/Singleton/SingletonLifetimeFeature.cs
@@ -11,15 +11,12 @@ public class SingletonLifetimeFeature : IFeature<LifetimeConfigurator>
             builder.Index.Type.Add<SingletonAttribute>();
         });
 
-        configurator.ConfigureDomainServiceCollection(services =>
+        configurator.ConfigureDomainServiceCollection((services, domain) =>
         {
-            configurator.UsingDomainModel(domain =>
+            foreach (var singleton in domain.Types.Having<SingletonAttribute>())
             {
-                foreach (var singleton in domain.Types.Having<SingletonAttribute>())
-                {
-                    services.AddSingleton(singleton, forward: true);
-                }
-            });
+                services.AddSingleton(singleton, forward: true);
+            }
         });
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Lifetime/Transient/TransientLifetimeFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Lifetime/Transient/TransientLifetimeFeature.cs
@@ -11,15 +11,12 @@ public class TransientLifetimeFeature : IFeature<LifetimeConfigurator>
             builder.Index.Type.Add<TransientAttribute>();
         });
 
-        configurator.ConfigureDomainServiceCollection(services =>
+        configurator.ConfigureDomainServiceCollection((services, domain) =>
         {
-            configurator.UsingDomainModel(domain =>
+            foreach (var transient in domain.Types.Having<TransientAttribute>())
             {
-                foreach (var transient in domain.Types.Having<TransientAttribute>())
-                {
-                    services.AddTransient(transient, useFactory: true);
-                }
-            });
+                services.AddTransient(transient, useFactory: true);
+            }
         });
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Logging/LoggingConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Logging/LoggingConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Logging;
 
-public class LoggingConfigurator { }
+public class LoggingConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/MockOverrider/MockOverriderConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/MockOverrider/MockOverriderConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.MockOverrider;
 
-public class MockOverriderConfigurator { }
+public class MockOverriderConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/Orm/OrmConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Orm/OrmConfigurator.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Orm;
 
-public class OrmConfigurator { }
+public class OrmConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/Orm/OrmExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Orm/OrmExtensions.cs
@@ -154,7 +154,7 @@ public static class OrmExtensions
 
     public static void ShouldBeDeleted(this object @object) =>
         Spec
-          .ContextStatic
+          .StartContextStatic
           .GetServiceProvider()
           .UsingCurrentScope()
           .GetRequiredService<ISession>()
@@ -163,7 +163,7 @@ public static class OrmExtensions
 
     public static void ShouldBeInserted(this object @object) =>
         Spec
-          .ContextStatic
+          .StartContextStatic
           .GetServiceProvider()
           .UsingCurrentScope()
           .GetRequiredService<ISession>()

--- a/src/recipe/Baked.Recipe.Service.Application/Reporting/ReportingConfigurator.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Reporting/ReportingConfigurator.cs
@@ -1,3 +1,3 @@
 namespace Baked.Reporting;
 
-public class ReportingConfigurator { }
+public class ReportingConfigurator;

--- a/src/recipe/Baked.Recipe.Service.Application/RestApi/Configuration/IApiModelConvention.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/RestApi/Configuration/IApiModelConvention.cs
@@ -1,6 +1,6 @@
 ﻿namespace Baked.RestApi.Configuration;
 
-public interface IApiModelConvention { }
+public interface IApiModelConvention;
 
 public interface IApiModelConvention<TContext> : IApiModelConvention
 {

--- a/src/recipe/Baked.Recipe.Service.Application/Runtime/ConfigurationRequiredException.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Runtime/ConfigurationRequiredException.cs
@@ -1,5 +1,4 @@
 ﻿namespace Baked.Runtime;
 
 public class ConfigurationRequiredException(string _key)
-    : Exception($"Configuration required for {_key}")
-{ }
+    : Exception($"Configuration required for {_key}");

--- a/src/recipe/Baked.Recipe.Service.Application/Runtime/RuntimeExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Runtime/RuntimeExtensions.cs
@@ -97,7 +97,7 @@ public static class RuntimeExtensions
         sp.GetRequiredService<ServiceProviderAccessor>().GetServiceProvider() ?? sp;
 
     public static IServiceProvider TheServiceProvider(this Stubber giveMe) =>
-        giveMe.Spec.Context.GetServiceProvider().UsingCurrentScope();
+        giveMe.Spec.StartContext.GetServiceProvider().UsingCurrentScope();
 
     public static T The<T>(this Stubber giveMe) where T : notnull =>
         giveMe.TheServiceProvider().GetRequiredService<T>();

--- a/src/recipe/Baked.Recipe.Service.Application/Runtime/RuntimeLayer.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Runtime/RuntimeLayer.cs
@@ -46,7 +46,7 @@ public class RuntimeLayer : LayerBase<BuildConfiguration, AddServices, PostBuild
     protected override PhaseContext GetContext(PostBuild phase) =>
         phase.CreateContext(Context.GetServiceProvider());
 
-    protected override IEnumerable<IPhase> GetPhases()
+    protected override IEnumerable<IPhase> GetStartPhases()
     {
         yield return new BuildConfiguration();
         yield return new AddServices(_services);

--- a/src/recipe/Baked.Recipe.Service.Application/Testing/TestingLayer.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Testing/TestingLayer.cs
@@ -42,7 +42,7 @@ public class TestingLayer : LayerBase<AddServices>
         );
     }
 
-    protected override IEnumerable<IPhase> GetPhases()
+    protected override IEnumerable<IPhase> GetStartPhases()
     {
         yield return new CreateConfigurationManager();
         yield return new Build(_run);

--- a/src/recipe/Baked.Recipe.Service/Authorization/AllowAnonymousAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service/Authorization/AllowAnonymousAttribute.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Authorization;
 
-public class AllowAnonymousAttribute : Attribute { }
+public class AllowAnonymousAttribute : Attribute;

--- a/src/recipe/Baked.Recipe.Service/Business/ApiInputAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service/Business/ApiInputAttribute.cs
@@ -1,4 +1,4 @@
 ﻿namespace Baked.Business;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum)]
-public class ApiInputAttribute : Attribute { }
+public class ApiInputAttribute : Attribute;

--- a/src/recipe/Baked.Recipe.Service/Business/ApiMethodAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service/Business/ApiMethodAttribute.cs
@@ -1,4 +1,4 @@
 ﻿namespace Baked.Business;
 
 [AttributeUsage(AttributeTargets.Method)]
-public class ApiMethodAttribute : Attribute { }
+public class ApiMethodAttribute : Attribute;

--- a/src/recipe/Baked.Recipe.Service/Business/ApiServiceAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service/Business/ApiServiceAttribute.cs
@@ -1,4 +1,4 @@
 ﻿namespace Baked.Business;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class ApiServiceAttribute : Attribute { }
+public class ApiServiceAttribute : Attribute;

--- a/src/recipe/Baked.Recipe.Service/Business/InitializerAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service/Business/InitializerAttribute.cs
@@ -1,4 +1,4 @@
 namespace Baked.Business;
 
 [AttributeUsage(AttributeTargets.Method)]
-public class InitializerAttribute : Attribute { }
+public class InitializerAttribute : Attribute;

--- a/src/recipe/Baked.Recipe.Service/Business/ServiceAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service/Business/ServiceAttribute.cs
@@ -1,4 +1,4 @@
 ﻿namespace Baked.Business;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class ServiceAttribute : Attribute { }
+public class ServiceAttribute : Attribute;

--- a/src/recipe/Baked.Recipe.Service/Lifetime/ScopedAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service/Lifetime/ScopedAttribute.cs
@@ -1,4 +1,4 @@
 ﻿namespace Baked.Lifetime;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class ScopedAttribute : Attribute { }
+public class ScopedAttribute : Attribute;

--- a/src/recipe/Baked.Recipe.Service/Lifetime/SingletonAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service/Lifetime/SingletonAttribute.cs
@@ -1,4 +1,4 @@
 ﻿namespace Baked.Lifetime;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class SingletonAttribute : Attribute { }
+public class SingletonAttribute : Attribute;

--- a/src/recipe/Baked.Recipe.Service/Lifetime/TransientAttribute.cs
+++ b/src/recipe/Baked.Recipe.Service/Lifetime/TransientAttribute.cs
@@ -1,4 +1,4 @@
 ﻿namespace Baked.Lifetime;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class TransientAttribute : Attribute { }
+public class TransientAttribute : Attribute;

--- a/test/core/Baked.Test.Architecture/Architecture/Application/RunningAnApplication.cs
+++ b/test/core/Baked.Test.Architecture/Architecture/Application/RunningAnApplication.cs
@@ -10,8 +10,8 @@ public class RunningAnApplication : ArchitectureSpec
         var phase1 = MockMe.APhase();
         var phase2 = MockMe.APhase();
         var phase3 = MockMe.APhase();
-        var layer1 = MockMe.ALayer(phases: [phase1, phase2]);
-        var layer2 = MockMe.ALayer(phase: phase3);
+        var layer1 = MockMe.ALayer(startPhases: [phase1, phase2]);
+        var layer2 = MockMe.ALayer(startPhase: phase3);
         var app = GiveMe.AnApplication(layers: [layer1, layer2]);
 
         app.Run();
@@ -22,14 +22,14 @@ public class RunningAnApplication : ArchitectureSpec
     }
 
     [Test]
-    public void Application_collects_only_bake_phases_when_specified()
+    public void Application_collects_only_generate_phases_when_specified()
     {
         var phase1 = MockMe.APhase();
         var phase2 = MockMe.APhase();
         var phase3 = MockMe.APhase();
-        var layer1 = MockMe.ALayer(bakePhases: [phase1, phase2]);
-        var layer2 = MockMe.ALayer(phase: phase3);
-        var app = GiveMe.AnApplication(layers: [layer1, layer2], runFlags: RunFlags.Bake);
+        var layer1 = MockMe.ALayer(generatePhases: [phase1, phase2]);
+        var layer2 = MockMe.ALayer(startPhase: phase3);
+        var app = GiveMe.AnApplication(layers: [layer1, layer2], runFlags: RunFlags.Generate);
 
         app.Run();
 
@@ -39,14 +39,14 @@ public class RunningAnApplication : ArchitectureSpec
     }
 
     [Test]
-    public void Application_collects_bake_and_start_phases_when_specified()
+    public void Application_collects_generate_and_start_phases_when_specified()
     {
         var phase1 = MockMe.APhase();
         var phase2 = MockMe.APhase();
         var phase3 = MockMe.APhase();
-        var layer1 = MockMe.ALayer(bakePhases: [phase1, phase2]);
-        var layer2 = MockMe.ALayer(phase: phase3);
-        var app = GiveMe.AnApplication(layers: [layer1, layer2], runFlags: RunFlags.Bake | RunFlags.Start);
+        var layer1 = MockMe.ALayer(generatePhases: [phase1, phase2]);
+        var layer2 = MockMe.ALayer(startPhase: phase3);
+        var app = GiveMe.AnApplication(layers: [layer1, layer2], runFlags: RunFlags.Generate | RunFlags.Start);
 
         app.Run();
 
@@ -61,7 +61,7 @@ public class RunningAnApplication : ArchitectureSpec
         var values = new List<string>();
 
         var phase = MockMe.APhase(onInitialize: () => values.Add("phase"));
-        var layer = MockMe.ALayer(phase: phase, onApplyPhase: () => values.Add("layer"));
+        var layer = MockMe.ALayer(startPhase: phase, onApplyPhase: () => values.Add("layer"));
         var app = GiveMe.AnApplication(layer: layer);
 
         app.Run();
@@ -75,8 +75,8 @@ public class RunningAnApplication : ArchitectureSpec
     {
         var phase1 = MockMe.APhase();
         var phase2 = MockMe.APhase();
-        var layer1 = MockMe.ALayer(phase: phase1);
-        var layer2 = MockMe.ALayer(phase: phase2);
+        var layer1 = MockMe.ALayer(startPhase: phase1);
+        var layer2 = MockMe.ALayer(startPhase: phase2);
 
         var app = GiveMe.AnApplication(layers: [layer1, layer2]);
 
@@ -106,11 +106,11 @@ public class RunningAnApplication : ArchitectureSpec
     public void Application_provides_phases_with_a_context()
     {
         var phase = MockMe.APhase();
-        var layer = MockMe.ALayer(phase: phase);
+        var layer = MockMe.ALayer(startPhase: phase);
 
         var context = GiveMe.AnApplicationContext();
         var app = GiveMe.AnApplication(
-            context: context,
+            startContext: context,
             layer: layer
         );
 
@@ -203,7 +203,7 @@ public class RunningAnApplication : ArchitectureSpec
         var phaseA = MockMe.APhase(onInitialize: () => phases.Add("phase a"), isReady: () => phases.Contains("phase b"));
         var phaseB = MockMe.APhase(onInitialize: () => phases.Add("phase b"), isReady: () => phases.Contains("phase c"));
         var phaseC = MockMe.APhase(onInitialize: () => phases.Add("phase c"));
-        var layer = MockMe.ALayer(phases: [phaseA, phaseB, phaseC]);
+        var layer = MockMe.ALayer(startPhases: [phaseA, phaseB, phaseC]);
 
         var app = GiveMe.AnApplication(layer: layer);
 
@@ -221,7 +221,7 @@ public class RunningAnApplication : ArchitectureSpec
 
         var phaseA = MockMe.APhase(onInitialize: () => phases.Add("phase a"), order: PhaseOrder.Late);
         var phaseB = MockMe.APhase(onInitialize: () => phases.Add("phase b"), order: PhaseOrder.Early);
-        var layer = MockMe.ALayer(phases: [phaseA, phaseB]);
+        var layer = MockMe.ALayer(startPhases: [phaseA, phaseB]);
 
         var app = GiveMe.AnApplication(layer: layer);
 
@@ -247,7 +247,7 @@ public class RunningAnApplication : ArchitectureSpec
     {
         var phaseA = MockMe.APhase(order: order);
         var phaseB = MockMe.APhase(order: order);
-        var layer = MockMe.ALayer(phases: [phaseA, phaseB]);
+        var layer = MockMe.ALayer(startPhases: [phaseA, phaseB]);
 
         var app = GiveMe.AnApplication(layer: layer);
         var action = () => app.Run();
@@ -259,7 +259,7 @@ public class RunningAnApplication : ArchitectureSpec
     public void When_a_phase_never_gets_ready_it_gives_error()
     {
         var phase = MockMe.APhase(isReady: () => false);
-        var layer = MockMe.ALayer(phase: phase);
+        var layer = MockMe.ALayer(startPhase: phase);
 
         var app = GiveMe.AnApplication(layer: layer);
         var action = () => app.Run();

--- a/test/core/Baked.Test.Architecture/Architecture/Feature/ConfiguringLayers.cs
+++ b/test/core/Baked.Test.Architecture/Architecture/Feature/ConfiguringLayers.cs
@@ -31,7 +31,7 @@ public class ConfiguringLayers : ArchitectureSpec
         configuration.Value.ShouldBe("test");
     }
 
-    public class FeatureConfigurator { }
+    public class FeatureConfigurator;
 
     [Test]
     public void EmptyFeature_does_not_configure_layers()

--- a/test/core/Baked.Test.Architecture/Architecture/Feature/CreatingAFeature.cs
+++ b/test/core/Baked.Test.Architecture/Architecture/Feature/CreatingAFeature.cs
@@ -4,7 +4,7 @@ namespace Baked.Test.Architecture.Feature;
 
 public class CreatingAFeature : ArchitectureSpec
 {
-    public class FeatureAConfigurator { }
+    public class FeatureAConfigurator;
 
     public class FeatureA : IFeature<FeatureAConfigurator>
     {
@@ -35,7 +35,7 @@ public class CreatingAFeature : ArchitectureSpec
         feature.Id.ShouldBe(nameof(FeatureA));
     }
 
-    public class FeatureBConfigurator { }
+    public class FeatureBConfigurator;
 
     public class FeatureB : IFeature<FeatureBConfigurator>
     {

--- a/test/core/Baked.Test.Architecture/Architecture/Layer/AddingPhases.cs
+++ b/test/core/Baked.Test.Architecture/Architecture/Layer/AddingPhases.cs
@@ -4,7 +4,7 @@ namespace Baked.Test.Architecture.Layer;
 
 public class AddingPhases : ArchitectureSpec
 {
-    class NoPhaseLayer : LayerBase { }
+    class NoPhaseLayer : LayerBase;
 
     [Test]
     public void Layer_returns_no_phases_by_default()
@@ -23,8 +23,8 @@ public class AddingPhases : ArchitectureSpec
             yield return new DoB();
         }
 
-        public class DoA : PhaseBase { }
-        public class DoB : PhaseBase { }
+        public class DoA : PhaseBase;
+        public class DoB : PhaseBase;
     }
 
     [Test]
@@ -51,8 +51,8 @@ public class AddingPhases : ArchitectureSpec
             yield return new GeneratePhase();
         }
 
-        public class GeneratePhase : PhaseBase { }
-        public class RuntimePhase : PhaseBase { }
+        public class GeneratePhase : PhaseBase;
+        public class RuntimePhase : PhaseBase;
     }
 
     [Test]
@@ -93,7 +93,7 @@ public class AddingPhases : ArchitectureSpec
         context.ShouldHave("test");
     }
 
-    public class Phase : PhaseBase { }
+    public class Phase : PhaseBase;
 
     [Test]
     public void Base_initialization_does_not_add_any_objects_to_application_context()
@@ -191,8 +191,7 @@ public class AddingPhases : ArchitectureSpec
     }
 
     public class OrderedPhase(PhaseOrder _order)
-        : PhaseBase(_order)
-    { }
+        : PhaseBase(_order);
 
     [TestCase(PhaseOrder.Early)]
     [TestCase(PhaseOrder.Late)]

--- a/test/core/Baked.Test.Architecture/Architecture/Layer/CreatingALayer.cs
+++ b/test/core/Baked.Test.Architecture/Architecture/Layer/CreatingALayer.cs
@@ -4,7 +4,7 @@ namespace Baked.Test.Architecture.Layer;
 
 public class CreatingALayer : ArchitectureSpec
 {
-    public class LayerA : LayerBase { }
+    public class LayerA : LayerBase;
 
     [Test]
     public void A_layer_is_created_by_extending_LayerBase()

--- a/test/core/Baked.Test.Architecture/Architecture/Layer/ProvidingConfiguration.cs
+++ b/test/core/Baked.Test.Architecture/Architecture/Layer/ProvidingConfiguration.cs
@@ -14,7 +14,7 @@ public class ProvidingConfiguration : ArchitectureSpec
     {
         protected override PhaseContext GetContext(DoA phase) => phase.CreateContext(new LayerXConfigurationA());
 
-        public class DoA : PhaseBase { }
+        public class DoA : PhaseBase;
     }
 
     public record LayerYConfigurationA();
@@ -25,7 +25,7 @@ public class ProvidingConfiguration : ArchitectureSpec
         protected override PhaseContext GetContext(DoA phase) => phase.CreateContext(new LayerYConfigurationA());
         protected override PhaseContext GetContext(DoB phase) => phase.CreateContext(new LayerYConfigurationB());
 
-        public class DoB : PhaseBase { }
+        public class DoB : PhaseBase;
     }
 
     public record LayerZConfigurationA();
@@ -38,7 +38,7 @@ public class ProvidingConfiguration : ArchitectureSpec
         protected override PhaseContext GetContext(DoB phase) => phase.CreateContext(new LayerZConfigurationB());
         protected override PhaseContext GetContext(DoC phase) => phase.CreateContext(new LayerZConfigurationC());
 
-        public class DoC : PhaseBase { }
+        public class DoC : PhaseBase;
     }
 
     [Test]

--- a/test/core/Baked.Test.Architecture/Extensions/ApplicationExtensions.cs
+++ b/test/core/Baked.Test.Architecture/Extensions/ApplicationExtensions.cs
@@ -12,15 +12,15 @@ public static class ApplicationExtensions
         ILayer[]? layers = default,
         IFeature? feature = default,
         IFeature[]? features = default,
-        ApplicationContext? bakeContext = default,
-        ApplicationContext? context = default,
+        ApplicationContext? generateContext = default,
+        ApplicationContext? startContext = default,
         RunFlags runFlags = RunFlags.Start
     )
     {
-        layers ??= [layer ?? giveMe.Spec.MockMe.ALayer(phase: phase, phases: phases)];
+        layers ??= [layer ?? giveMe.Spec.MockMe.ALayer(startPhase: phase, startPhases: phases)];
         features ??= [feature ?? giveMe.Spec.MockMe.AFeature()];
 
-        return giveMe.ABake(context: context, bakeContext: bakeContext, runflags: runFlags).Application(app =>
+        return giveMe.ABake(startContext: startContext, generateContext: generateContext, runflags: runFlags).Application(app =>
         {
             app.Layers.AddRange(layers);
             app.Features.AddRange(features);

--- a/test/core/Baked.Test.Architecture/Extensions/BakeExtensions.cs
+++ b/test/core/Baked.Test.Architecture/Extensions/BakeExtensions.cs
@@ -8,14 +8,14 @@ public static class BakeExtensions
 {
     public static Bake ABake(this Stubber giveMe,
         IBanner? banner = default,
-        ApplicationContext? context = default,
-        ApplicationContext? bakeContext = default,
+        ApplicationContext? startContext = default,
+        ApplicationContext? generateContext = default,
         RunFlags runflags = RunFlags.Start
     )
     {
         banner ??= giveMe.Spec.MockMe.ABanner();
-        context ??= new();
+        startContext ??= new();
 
-        return new(banner, () => new(context, bakeContext), runflags);
+        return new(banner, () => new(startContext, generateContext), runflags);
     }
 }

--- a/test/core/Baked.Test.Architecture/Extensions/LayerExtensions.cs
+++ b/test/core/Baked.Test.Architecture/Extensions/LayerExtensions.cs
@@ -10,19 +10,19 @@ public static class LayerExtensions
         object? target = default,
         object[]? targets = default,
         PhaseContext? phaseContext = default,
-        IPhase? phase = default,
-        IPhase[]? phases = default,
+        IPhase? startPhase = default,
+        IPhase[]? startPhases = default,
         Action? onApplyPhase = default,
-        IPhase[]? bakePhases = default
+        IPhase[]? generatePhases = default
     )
     {
         phaseContext ??= mockMe.Spec.GiveMe.APhaseContext(target: target, targets: targets);
-        phases ??= [phase ?? mockMe.APhase()];
-        bakePhases ??= [];
+        startPhases ??= [startPhase ?? mockMe.APhase()];
+        generatePhases ??= [];
 
         var result = new Mock<ILayer>();
-        result.Setup(l => l.GetPhases()).Returns(phases);
-        result.Setup(l => l.GetBakePhases()).Returns(bakePhases);
+        result.Setup(l => l.GetStartPhases()).Returns(startPhases);
+        result.Setup(l => l.GetGeneratePhases()).Returns(generatePhases);
         result.Setup(l => l.Id).Returns(id ?? $"{Guid.NewGuid()}");
 
         var setupGetContext = result
@@ -38,7 +38,7 @@ public static class LayerExtensions
     }
 
     public static void VerifyInitialized(this ILayer layer) =>
-        Mock.Get(layer).Verify(l => l.GetPhases());
+        Mock.Get(layer).Verify(l => l.GetStartPhases());
 
     public static void VerifyApplied(this ILayer layer, IPhase phase) =>
         Mock.Get(layer)

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Extensions/DomainModelExtensions.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Extensions/DomainModelExtensions.cs
@@ -6,5 +6,5 @@ namespace Baked.Test;
 public static class DomainModelExtensions
 {
     public static DomainModel TheDomainModel(this Stubber giveMe) =>
-        giveMe.Spec.BakeContext.GetDomainModel();
+        giveMe.Spec.GenerateContext.GetDomainModel();
 }

--- a/test/recipe/Baked.Test.Recipe.Service/Business/Casting/ClassB.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/Casting/ClassB.cs
@@ -1,3 +1,3 @@
 namespace Baked.Test.Business.Casting;
 
-public class ClassB { }
+public class ClassB;

--- a/test/recipe/Baked.Test.Recipe.Service/Business/CustomAttribute.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/CustomAttribute.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Test.Business;
 
-public class CustomAttribute : Attribute { }
+public class CustomAttribute : Attribute;

--- a/test/recipe/Baked.Test.Recipe.Service/Business/CustomDictionary.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/CustomDictionary.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Test.Business;
 
-public class CustomDictionary : Dictionary<string, object> { }
+public class CustomDictionary : Dictionary<string, object>;

--- a/test/recipe/Baked.Test.Recipe.Service/Business/CustomList.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/CustomList.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Test.Business;
 
-public class CustomList : List<object> { }
+public class CustomList : List<object>;

--- a/test/recipe/Baked.Test.Recipe.Service/Business/IInterfaceWithNoImplementation.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/IInterfaceWithNoImplementation.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Test.Business;
 
-public interface IInterfaceWithNoImplementation { }
+public interface IInterfaceWithNoImplementation;

--- a/test/recipe/Baked.Test.Recipe.Service/Business/Internal.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Business/Internal.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Test.Business;
 
-internal class Internal { }
+internal class Internal;

--- a/test/recipe/Baked.Test.Recipe.Service/ExceptionHandling/SampleException.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/ExceptionHandling/SampleException.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Test.ExceptionHandling;
 
-public class SampleException : Exception { }
+public class SampleException : Exception;

--- a/test/recipe/Baked.Test.Recipe.Service/ExceptionHandling/TestServiceHandledException.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/ExceptionHandling/TestServiceHandledException.cs
@@ -3,5 +3,4 @@
 namespace Baked.Test.ExceptionHandling;
 
 public class TestServiceHandledException(string message)
-    : HandledException(message)
-{ }
+    : HandledException(message);

--- a/test/recipe/Baked.Test.Recipe.Service/Lifetime/ISingletonInterface.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Lifetime/ISingletonInterface.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Test.Lifetime;
 
-public interface ISingletonInterface { }
+public interface ISingletonInterface;

--- a/test/recipe/Baked.Test.Recipe.Service/Lifetime/ITransientInterface.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Lifetime/ITransientInterface.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Test.Lifetime;
 
-public interface ITransientInterface { }
+public interface ITransientInterface;

--- a/test/recipe/Baked.Test.Recipe.Service/Lifetime/ScopedContext.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Lifetime/ScopedContext.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Test.Lifetime;
 
-public class ScopedContext { }
+public class ScopedContext;

--- a/test/recipe/Baked.Test.Recipe.Service/Lifetime/Singleton.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Lifetime/Singleton.cs
@@ -1,3 +1,3 @@
 ﻿namespace Baked.Test.Lifetime;
 
-public class Singleton : ISingletonInterface { }
+public class Singleton : ISingletonInterface;

--- a/test/recipe/Baked.Test.Recipe.Service/Orm/MustBeUniqueException.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Orm/MustBeUniqueException.cs
@@ -3,5 +3,4 @@ using Baked.ExceptionHandling;
 namespace Baked.Test.Orm;
 
 public class MustBeUniqueException(string propertyName)
-    : HandledException($"{propertyName} should be unique")
-{ }
+    : HandledException($"{propertyName} should be unique");

--- a/test/recipe/Baked.Test.Recipe.Service/Orm/NotMyChildException.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Orm/NotMyChildException.cs
@@ -3,5 +3,4 @@
 namespace Baked.Test.Orm;
 
 public class NotMyChildException(Child child)
-    : HandledException($"Child#{child.Id} does not belong this parent")
-{ }
+    : HandledException($"Child#{child.Id} does not belong this parent");

--- a/unreleased.md
+++ b/unreleased.md
@@ -38,20 +38,20 @@ projects.
 - `Application` now provies `Bake` and `Start` modes which can be run both
   together or individually with distinct `ApplicationContext`'s.
   - `RunFlags` is introduced for configuring application mode
-- `LayerBase` now provies `GetBakePhases()` method to enable registering
-  specific phases to run at `Bake` mode
-- `Service` and `Data Source` recipies now triggers `Bake` mode run at post
+- `LayerBase` now provies `GetGeneratePhases()` method to enable registering
+  specific phases to run at `Generate` mode
+- `Service` and `Data Source` recipies now triggers `Generate` mode run at post
   build
 - `Domain` layer's `AddDomainTypes` and `BuildDomainModel` phases now only runs
-  in `Bake` mode
+  in `Generate` mode
 - `CodeGeneration` layer's `GenerateCode` and `Compile` phases now only runs
-  in `Bake` mode
+  in `Generate` mode
 - `CodeGeneration` layer now introduces `IGeneratedFileCollection` which enables
-  generating data files in `Bake` mode
+  generating data files in `Generate` mode
 - `CodeGeneration` layer now introduces `GeneratedContext` at `BuildConfiguration`
   phase which provides access to generated assemblies and files in `Start` mode
 - `Domain` layer now provides a `DomainServicesCollection` configuration target in 
-  `Bake` mode which will then be used to generate `IServiceAdder` implementation 
+  `Generate` mode which will then be used to generate `IServiceAdder` implementation 
 
 ## Improvements
 
@@ -62,13 +62,13 @@ projects.
   implementations and
   - `TagDescriptor`
   - `RequestResponseExample`
-  json files in `Bake` mode
+  json files in `Generate` mode
 - `AutoMapOrm` feature now generates `IServiceAdder` implementations from
-  `DomainModel` in `Bake` mode
+  `DomainModel` in `Generate` mode
 - `GiveMe.PropertyOf<T>` helper is renamed to `ThePropertyOf<T>`
 - `GiveMe.MethodOf<T>` helper is renamed to `TheMethodOf<T>`
 - Following features now use `DomainServicesModel` target to register services
-  in `Bake` mode
+  in `Generate` mode
   - `Transient`
   - `Scoped`
   - `Singleton`

--- a/unreleased.md
+++ b/unreleased.md
@@ -35,7 +35,7 @@ projects.
 
 ## Features
 
-- `Application` now provies `Bake` and `Start` modes which can be run both
+- `Application` now provies `Generate` and `Start` modes which can be run both
   together or individually with distinct `ApplicationContext`'s.
   - `RunFlags` is introduced for configuring application mode
 - `LayerBase` now provies `GetGeneratePhases()` method to enable registering

--- a/unreleased.md
+++ b/unreleased.md
@@ -12,7 +12,7 @@ projects.
   - [ ] in GitHub workflows
 - [ ] Upgrade Baked version
 - [ ] You can use `GeneratedRegex`es in properties instead of methods
-- [ ] If `Base64` encoded information is carried in the url, use `Base64Url`.
+- [ ] If `Base64` encoded information is carried in the url, use `Base64Url`
 - [ ] `params` arguments should be converted from arrays to `IEnumerable`
 - [ ] Use the new linQ extensions(`CountBy`, `AggregateBy`,
   `Index<TSource>(IEnumerable<TSource>))`.
@@ -47,12 +47,14 @@ projects.
   in `Generate` mode
 - `CodeGeneration` layer's `GenerateCode` and `Compile` phases now only runs
   in `Generate` mode
-- `CodeGeneration` layer now introduces `IGeneratedFileCollection` which enables
-  generating data files in `Generate` mode
-- `CodeGeneration` layer now introduces `GeneratedContext` at `BuildConfiguration`
-  phase which provides access to generated assemblies and files in `Start` mode
-- `Domain` layer now provides a `DomainServicesCollection` configuration target in 
-  `Generate` mode which will then be used to generate `IServiceAdder` implementation 
+- `CodeGeneration` layer now introduces `IGeneratedFileCollection` which 
+  enables generating data files in `Generate` mode
+- `CodeGeneration` layer now introduces `GeneratedContext` at 
+  `BuildConfiguration` phase which provides access to generated assemblies and 
+  files in `Start` mode
+- `Domain` layer now provides a `DomainServicesCollection` configuration target
+  in `Generate` mode which will then be used to generate `IServiceAdder` 
+  implementation 
 
 ## Improvements
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -24,6 +24,7 @@ projects.
   - `FromMilliseconds`
   - `FromMicroseconds`
 - [ ] Use Keyed Services in Middlewares.
+- [ ] Use semicolon instead of curly braces for empty class declarations
 ```
 
 ### Upgrade .NET and C# versions


### PR DESCRIPTION
Rename `GetPhases` as `GetStartPhases` in code, specs and docs for consistent
naming and use name `Generate` instead of `Bake` for generation mode

## Tasks

- [x] rename `GetPhases` to `GetStartPhases`
- [x] rename context for start phases to `StartContext`
- [x] rename `GetBakePhases` to `GetGeneratePhases`
- [x] rename command arg to `--generate`
- [x] rename `BakeContext` to `GeneratedContext`
- [x] rename flag `Bake` to `Generate`
- [x] update documentation

## Additional Tasks

- [x] add `DomainModel` parameter to `ConfigureDomainServiceCollection` helper
  - provide `DomainModel` to phase context in `DomainLayer`
- [x] use semicolon instead of curly braces for empty class declarations 
