### PR TITLE
Issue / Copy Component Descriptors

### DIFF
--- a/src/recipe/Baked.Recipe.Service.Application/Baked.Recipe.Service.Application.targets
+++ b/src/recipe/Baked.Recipe.Service.Application/Baked.Recipe.Service.Application.targets
@@ -1,5 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <CopyComponentDescriptors>false</CopyComponentDescriptors>
+  </PropertyGroup>  
+    
   <ItemGroup>
     <Using Include="Baked" />
   </ItemGroup>

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+## Bugfixes
+
+- `CopyComponentDescriptors` property was causing error when not set, fixed

--- a/unreleased.md
+++ b/unreleased.md
@@ -3,7 +3,4 @@
 ## Improvements
 
 - Overriding baked defaults in `nuxt.config.ts` was not possible, fixed
-
-## Bugfixes
-
 - `CopyComponentDescriptors` property was causing error when not set, fixed


### PR DESCRIPTION
fix error when `CopyComponentDescriptors` is not set in explicitly
referenced projects

## Tasks

- [x] edit targets to allow null `CopyComponentDescriptors` value
