### PR TITLE
Issue / Allow Nuxt  Config Override

### DIFF
--- a/src/recipe/admin/src/module.ts
+++ b/src/recipe/admin/src/module.ts
@@ -28,13 +28,15 @@ export default defineNuxtModule<ModuleOptions>({
   async setup(_options, _nuxt) {
     const resolver = createResolver(import.meta.url);
 
-    _nuxt.options.css = ["primeicons/primeicons.css"];
-    _nuxt.options.devtools.enabled = false;
-    _nuxt.options.experimental.payloadExtraction = false;
-    _nuxt.options.features.inlineStyles = false;
+    // this setup runs after `defineNuxtConfig` so it should set only if config
+    // is undefined to allow developers override these defaults
+    _nuxt.options.css.push("primeicons/primeicons.css");
+    _nuxt.options.devtools.enabled ||= false;
+    _nuxt.options.experimental.payloadExtraction ||= false;
+    _nuxt.options.features.inlineStyles ||= false;
     _nuxt.options.runtimeConfig.public.theme = _options.theme;
     _nuxt.options.runtimeConfig.public.components = _options.components;
-    _nuxt.options.ssr = false;
+    _nuxt.options.ssr ||= false;
 
     addComponentsDir({
       path: resolver.resolve("./runtime/components"),

--- a/src/recipe/admin/src/module.ts
+++ b/src/recipe/admin/src/module.ts
@@ -30,6 +30,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // this setup runs after `defineNuxtConfig` so it should set only if config
     // is undefined to allow developers override these defaults
+    // if not set, arrays and objects are always not-null and empty
     _nuxt.options.css.push("primeicons/primeicons.css");
     _nuxt.options.devtools.enabled ||= false;
     _nuxt.options.experimental.payloadExtraction ||= false;

--- a/test/recipe/Baked.Test.Recipe.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
@@ -129,6 +129,7 @@ public class ConfigurationOverriderFeature : IFeature
                             HeaderItem($"/{rtwdRoute}", title: rtwdPageDetail.Title),
                             HeaderItem("/specs", icon: "pi pi-list-check", title: "Specs"),
                             HeaderItem("/specs/card-link", title: "Card Link", parentRoute: "/specs"),
+                            HeaderItem("/specs/custom-css", title: "Custom CSS", parentRoute: "/specs"),
                             HeaderItem("/specs/detail-page", title: "Detail Page", parentRoute: "/specs"),
                             HeaderItem("/specs/header", title: "Header", parentRoute: "/specs"),
                             HeaderItem("/specs/menu-page", title: "Menu Page", parentRoute: "/specs"),
@@ -172,6 +173,10 @@ public class ConfigurationOverriderFeature : IFeature
                     CardLink("/specs/card-link", "Card Link",
                         icon: "pi pi-microchip",
                         description: "A big card link component to render links in menu-like pages"
+                    ),
+                    CardLink("/specs/custom-css", "Custom CSS",
+                        icon: "pi pi-microchip",
+                        description: "Allow custom configuration to define custom css and more"
                     ),
                     CardLink("/specs/detail-page", "Detail Page",
                         icon: "pi pi-microchip",

--- a/test/recipe/admin/assets/styles.scss
+++ b/test/recipe/admin/assets/styles.scss
@@ -1,0 +1,7 @@
+.custom-css-visible {
+  display: block;
+}
+
+.custom-css-hidden {
+  display: none;
+}

--- a/test/recipe/admin/components/ComponentSpec.vue
+++ b/test/recipe/admin/components/ComponentSpec.vue
@@ -34,6 +34,7 @@
           <Bake :descriptor="variant.descriptor" />
         </div>
       </div>
+      <slot v-if="$slots.default" name="default" />
     </div>
   </div>
 </template>

--- a/test/recipe/admin/nuxt.config.ts
+++ b/test/recipe/admin/nuxt.config.ts
@@ -37,6 +37,7 @@ export default defineNuxtConfig({
   components: {
     dirs: ["~/components"]
   },
+  css: [ "~/assets/styles.scss" ],
   // Do NOT remove this line, auto imports are disabled for consistency
   // between local and published package behaviour
   imports: { autoImport: false },

--- a/test/recipe/admin/pages/specs/custom-css.spec.js
+++ b/test/recipe/admin/pages/specs/custom-css.spec.js
@@ -1,0 +1,19 @@
+import { expect, test } from "@nuxt/test-utils/playwright";
+
+test.beforeEach(async({goto}) => {
+  await goto("/specs/custom-css", { waitUntil: "hydration" });
+});
+
+const id = "test";
+
+test("custom css hides", async({page}) => {
+  const component = page.getByTestId(id);
+
+  await expect(component.locator(".custom-css-visible")).toBeVisible();
+});
+
+test("custom css shows", async({page}) => {
+  const component = page.getByTestId(id);
+
+  await expect(component.locator(".custom-css-hidden")).not.toBeVisible();
+});

--- a/test/recipe/admin/pages/specs/custom-css.vue
+++ b/test/recipe/admin/pages/specs/custom-css.vue
@@ -1,0 +1,16 @@
+<template>
+  <ComponentSpec title="Custom CSS" :variants="[]">
+    <Message severity="info">
+      <span class="text-xl">
+        ⬇️  Check if there is only `VISIBLE` below ⬇️
+      </span>
+    </Message>
+    <div class="border-4 border-gray-500 rounded p-4" data-testid="test">
+      <div class="hidden custom-css-visible">VISIBLE</div>
+      <div class="visible custom-css-hidden">HIDDEN</div>
+    </div>
+  </ComponentSpec>
+</template>
+<script setup>
+import { Message } from "primevue";
+</script>

--- a/test/recipe/admin/pages/specs/toast.vue
+++ b/test/recipe/admin/pages/specs/toast.vue
@@ -1,8 +1,15 @@
 <template>
-  <div />
+  <ComponentSpec title="Toast" :variants="[]">
+    <Message severity="info">
+      <span class="text-xl">
+        ↗️  Check if page has a success toast at top right ↗️
+      </span>
+    </Message>
+  </ComponentSpec>
 </template>
 <script setup>
 import { onMounted } from "vue";
+import { Message } from "primevue";
 import { useToast } from "#imports";
 
 const toast = useToast();

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+## Improvements
+
+- Overriding baked defaults in `nuxt.config.ts` was not possible, fixed


### PR DESCRIPTION
Overriding nuxt config defaults that come from baked is not possible.

## Tasks

- [x] Reproduce the error via a ui test
- [x] Fix the issue for all config overrides
