### PR TITLE
Issue / Include Parent in `InjectedData`

### DIFF
--- a/src/recipe/Baked.Recipe.Service.Application/Ui/Datas.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Ui/Datas.cs
@@ -9,9 +9,15 @@ public static class Datas
         new(composable) { Args = [.. args] };
 
     public static InjectedData Injected(
-        InjectedData.DataKey key = InjectedData.DataKey.Custom,
+        bool? custom = default,
+        bool? parentData = default,
         string? prop = default
-    ) => new(key) { Prop = prop };
+    ) => new(
+        custom == true ? InjectedData.DataKey.Custom :
+        parentData == true ? InjectedData.DataKey.ParentData :
+        InjectedData.DataKey.Custom
+    )
+    { Prop = prop };
 
     public static InlineData Inline(object value) =>
         new(value);

--- a/src/recipe/Baked.Recipe.Service.Application/Ui/Datas.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Ui/Datas.cs
@@ -8,8 +8,10 @@ public static class Datas
     public static ComputedData Computed(string composable, params IEnumerable<object> args) =>
         new(composable) { Args = [.. args] };
 
-    public static InjectedData Injected() =>
-        new();
+    public static InjectedData Injected(
+        InjectedData.DataKey key = InjectedData.DataKey.Custom,
+        string? prop = default
+    ) => new(key) { Prop = prop };
 
     public static InlineData Inline(object value) =>
         new(value);

--- a/src/recipe/Baked.Recipe.Service.Application/Ui/InjectedData.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Ui/InjectedData.cs
@@ -1,7 +1,15 @@
 namespace Baked.Ui;
 
-public record InjectedData()
+public record InjectedData(InjectedData.DataKey Key)
     : IData
 {
     public string Type => "Injected";
+    public DataKey Key { get; set; } = Key;
+    public string? Prop { get; set; }
+
+    public enum DataKey
+    {
+        Custom,
+        ParentData
+    }
 }

--- a/src/recipe/admin/src/runtime/components/Bake.vue
+++ b/src/recipe/admin/src/runtime/components/Bake.vue
@@ -29,7 +29,10 @@ const is = componentResolver.resolve(descriptor.type, "None");
 const shouldLoad = dataFetcher.shouldLoad(descriptor.data?.type);
 const data = ref(dataFetcher.get(descriptor.data));
 const loading = ref(shouldLoad);
-context.setLoading(loading);
+
+if(shouldLoad) {
+  context.setLoading(loading);
+}
 
 onMounted(async() => {
   if(!shouldLoad) { return; }

--- a/src/recipe/admin/src/runtime/components/Bake.vue
+++ b/src/recipe/admin/src/runtime/components/Bake.vue
@@ -3,7 +3,7 @@
     :is="is"
     v-model="model"
     :schema="descriptor.schema"
-    :data="data"
+    :data
   >
     <slot v-if="$slots.default" />
   </component>
@@ -24,11 +24,13 @@ const model = defineModel({ type: null, required: false });
 
 context.add(name);
 
-const injectedData = context.injectedData();
 const is = componentResolver.resolve(descriptor.type, "None");
+const injectedData = context.injectedData();
+const data = ref(dataFetcher.get({ data: descriptor.data, injectedData }));
 const shouldLoad = dataFetcher.shouldLoad(descriptor.data?.type);
-const data = ref(dataFetcher.get(descriptor.data));
 const loading = ref(shouldLoad);
+
+context.setInjectedData(data, "ParentData");
 
 if(shouldLoad) {
   context.setLoading(loading);

--- a/src/recipe/admin/src/runtime/components/DataPanel.vue
+++ b/src/recipe/admin/src/runtime/components/DataPanel.vue
@@ -60,6 +60,7 @@ const { schema } = defineProps({
 
 const { collapsed, content, parameters, title: titleData } = schema;
 
+const injectedData = context.injectedData();
 const path = context.path();
 const collapsedState = computed(() => panelStates[path] ?? collapsed);
 const loaded = ref(!collapsedState.value);
@@ -68,18 +69,15 @@ const uniqueKey = ref("");
 
 const values = ref({});
 if(parameters.length > 0) {
-  context.setInjectedData(values);
+  context.setInjectedData(values, "Custom");
 }
 
+const title = ref(dataFetcher.get({ data: titleData, injectedData }));
 const shouldLoadTitle = dataFetcher.shouldLoad(titleData.type);
-const title = ref(dataFetcher.get(titleData));
 
 onMounted(async() => {
   if(shouldLoadTitle) {
-    title.value = await dataFetcher.fetch({
-      data: titleData,
-      injectedData: values
-    });
+    title.value = await dataFetcher.fetch({ data: titleData, injectedData });
   }
 });
 

--- a/src/recipe/admin/src/runtime/components/Parameters.vue
+++ b/src/recipe/admin/src/runtime/components/Parameters.vue
@@ -32,17 +32,14 @@ const emit = defineEmits(["ready", "changed"]);
 const injectedData = context.injectedData();
 const values = {};
 for(const parameter of parameters) {
-  values[parameter.name] = ref(dataFetcher.get(parameter.default));
+  values[parameter.name] = ref(dataFetcher.get({ data: parameter.default, injectedData }));
 }
 
 onMounted(async() => {
   for(const parameter of parameters) {
     if(!dataFetcher.shouldLoad(parameter.default?.type)) { continue; }
 
-    values[parameter.name].value = await dataFetcher.fetch({
-      data: parameter.default,
-      injectedData
-    });
+    values[parameter.name].value = await dataFetcher.fetch({ data: parameter.default, injectedData });
   }
 });
 

--- a/src/recipe/admin/src/runtime/composables/useContext.js
+++ b/src/recipe/admin/src/runtime/composables/useContext.js
@@ -11,11 +11,14 @@ export default function() {
   }
 
   function injectedData() {
-    return inject("__bake_injected_data", null);
+    return {
+      ParentData: inject("__bake_injected_data:ParentData", null),
+      Custom: inject("__bake_injected_data:Custom", null)
+    };
   }
 
-  function setInjectedData(value) {
-    provide("__bake_injected_data", value);
+  function setInjectedData(value, key) {
+    provide(`__bake_injected_data:${key}`, value);
   }
 
   function loading() {

--- a/src/recipe/admin/src/runtime/composables/useContext.js
+++ b/src/recipe/admin/src/runtime/composables/useContext.js
@@ -1,4 +1,4 @@
-import { inject, provide } from "vue";
+import { inject, provide, ref } from "vue";
 
 export default function() {
   function add(name) {
@@ -19,7 +19,7 @@ export default function() {
   }
 
   function loading() {
-    return inject("__bake_loading");
+    return inject("__bake_loading", ref(false));
   }
 
   function setLoading(page) {

--- a/src/recipe/admin/src/runtime/composables/useDataFetcher.js
+++ b/src/recipe/admin/src/runtime/composables/useDataFetcher.js
@@ -1,9 +1,9 @@
+import { computed } from "vue";
 import { useRuntimeConfig } from "#app";
-import { useComposableResolver, useContext, useUnref } from "#imports";
+import { useComposableResolver, useUnref } from "#imports";
 
 export default function() {
   const composableResolver = useComposableResolver();
-  const context = useContext();
   const unref = useUnref();
   const { public: { composables } } = useRuntimeConfig();
 
@@ -11,79 +11,89 @@ export default function() {
     return dataType === "Remote" || dataType === "Computed" || dataType == "Composite";
   }
 
-  function get(data) {
-    return data?.type === "Inline" ? data.value :
-      data?.type === "Injected" ? context.injectedData() :
+  function get({ data, injectedData }) {
+    return data?.type === "Inline" ? inline({ data }) :
+      data?.type === "Injected" ? injected({ data, injectedData }) :
         null;
   }
 
   async function fetch({ baseURL, data, injectedData }) {
     baseURL = baseURL || composables.useDataFetcher.baseURL;
 
-    if(data?.type === "Composite") {
-      const result = {};
+    if(data?.type === "Composite") { return await composite({ baseURL, data, injectedData }); }
+    if(data?.type === "Computed") { return await computed({ data }); }
+    if(data?.type === "Injected") { return injected({ data, injectedData }); }
+    if(data?.type === "Inline") { return inline({ data }); }
+    if(data?.type === "Remote") { return await remote({ baseURL, data, injectedData }); }
 
-      for(const part of data.parts) {
-        Object.assign(
-          result,
-          unref.deepUnref(await fetch({ baseURL, data: part, injectedData }))
-        );
-      }
+    throw new Error(`${data?.type} is not a valid data type`);
+  }
 
-      return result;
-    }
+  async function composite({ baseURL, data, injectedData }) {
+    const result = {};
 
-    if(data?.type === "Computed") {
-      const composable = (await composableResolver.resolve(data.composable)).default();
-
-      if(composable.compute) {
-        return composable.compute(...(data.args || []));
-      }
-
-      if(composable.computeAsync) {
-        return await composable.computeAsync(...(data.args || []));
-      }
-
-      throw new Error("Data composable should have either `compute` or `computeAsync`");
-    }
-
-    if(data?.type === "Injected") {
-      return injectedData;
-    }
-
-    if(data?.type === "Inline") {
-      return data.value;
-    }
-
-    if(data?.type === "Remote") {
-      const headers = data.headers
-        ? unref.deepUnref(await fetch({ baseURL, data: data.headers, injectedData }))
-        : { };
-
-      const query = data.query
-        ? unref.deepUnref(await fetch({ baseURL, data: data.query, injectedData }))
-        : { };
-
-      const options = composables?.useDataFetcher?.retryFetch
-        ? {
-          retry: Number.MAX_VALUE,
-          retryDelay: 200,
-          retryStatusCodes: [500]
-        }
-        : { };
-
-      return await $fetch(
-        data.path,
-        {
-          ...options ?? { },
-          baseURL,
-          headers: headers,
-          query: query
-        }
+    for(const part of data.parts) {
+      Object.assign(
+        result,
+        unref.deepUnref(await fetch({ baseURL, data: part, injectedData }))
       );
     }
 
-    throw new Error(`${data?.type} is not a valid data type`);
+    return result;
+  }
+
+  async function computed({ data }) {
+    const composable = (await composableResolver.resolve(data.composable)).default();
+
+    if(composable.compute) {
+      return composable.compute(...(data.args || []));
+    }
+
+    if(composable.computeAsync) {
+      return await composable.computeAsync(...(data.args || []));
+    }
+
+    throw new Error("Data composable should have either `compute` or `computeAsync`");
+  }
+
+  function injected({ data, injectedData }) {
+    const result = injectedData[data.key];
+
+    if(!data.prop) { return result; }
+
+    return result.value[data.prop];
+  }
+
+  function inline({ data }) {
+    return data.value;
+  }
+
+  async function remote({ baseURL, data, injectedData }) {
+    const headers = data.headers
+      ? unref.deepUnref(await fetch({ baseURL, data: data.headers, injectedData }))
+      : { };
+
+    const query = data.query
+      ? unref.deepUnref(await fetch({ baseURL, data: data.query, injectedData }))
+      : { };
+
+    const options = composables?.useDataFetcher?.retryFetch
+      ? {
+        retry: Number.MAX_VALUE,
+        retryDelay: 200,
+        retryStatusCodes: [500]
+      }
+      : { };
+
+    return await $fetch(
+      data.path,
+      {
+        ...options ?? { },
+        baseURL,
+        headers: headers,
+        query: query
+      }
+    );
   }
 
   function format(formatString, args) {

--- a/test/recipe/Baked.Test.Recipe.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/ConfigurationOverrider/ConfigurationOverriderFeature.cs
@@ -108,6 +108,7 @@ public class ConfigurationOverriderFeature : IFeature
         var specs = new[]
         {
             new { Title = "Auth", Description = "A plugin for authorized routing and client" },
+            new { Title = "Bake", Description = "The core component that renders a dynamic component using given descriptor" },
             new { Title = "Card Link", Description = "A component that renders a link as a big card-like button" },
             new { Title = "Custom CSS", Description = "Allow custom configuration to define custom css and more" },
             new { Title = "Data Panel", Description = "A component to lazy load and view a data within a panel" },

--- a/test/recipe/Baked.Test.Recipe.Service.Application/Program.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Application/Program.cs
@@ -46,7 +46,7 @@ Bake.New
             .Sqlite()
             .ForProduction(c.PostgreSql()),
         exceptionHandling: c => c.ProblemDetails(typeUrlFormat: "https://baked.mouseless.codes/errors/{0}"),
-        theme: c => c.Admin(componentExports: ["Expected", "Input", "Login", "PageWithRoute"]),
+        theme: c => c.Admin(componentExports: ["Container", "Expected", "Input", "Login", "PageWithRoute"]),
         configure: app =>
         {
             app.Features.AddReporting(c => c

--- a/test/recipe/admin/components/Container.vue
+++ b/test/recipe/admin/components/Container.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="flex gap-4">
+    <Bake
+      v-for="(content, i) in contents"
+      :key="`contents/${i}`"
+      :name="`contents/${i}`"
+      :descriptor="content"
+    />
+  </div>
+</template>
+<script setup>
+import { Bake } from "#components";
+
+const { schema } = defineProps({
+  schema: { type: null, required: true },
+  data: { type: null, required: true }
+});
+defineModel({ type: null, required: false });
+
+const { contents } = schema;
+</script>

--- a/test/recipe/admin/pages/specs/bake.spec.js
+++ b/test/recipe/admin/pages/specs/bake.spec.js
@@ -1,0 +1,15 @@
+import { expect, test } from "@nuxt/test-utils/playwright";
+
+test.beforeEach(async({goto}) => {
+  await goto("/specs/card-link", { waitUntil: "hydration" });
+});
+
+test.describe("Base", () => {
+  const id = "Base";
+
+  test("route", async({page}) => {
+    const component = page.getByTestId(id);
+
+    await expect(component.locator("a")).toHaveAttribute("href", "/some-route");
+  });
+});

--- a/test/recipe/admin/pages/specs/bake.spec.js
+++ b/test/recipe/admin/pages/specs/bake.spec.js
@@ -1,15 +1,36 @@
 import { expect, test } from "@nuxt/test-utils/playwright";
 
 test.beforeEach(async({goto}) => {
-  await goto("/specs/card-link", { waitUntil: "hydration" });
+  await goto("/specs/bake", { waitUntil: "hydration" });
 });
 
 test.describe("Base", () => {
   const id = "Base";
 
-  test("route", async({page}) => {
+  test("component render", async({page}) => {
     const component = page.getByTestId(id);
 
-    await expect(component.locator("a")).toHaveAttribute("href", "/some-route");
+    await expect(component).toHaveText("TEST");
+  });
+});
+
+test.describe("Parent Data", () => {
+  const id = "Parent Data";
+
+  test("reads data from parent", async({page}) => {
+    const component = page.getByTestId(id);
+
+    await expect(component.getByTestId("child-root"))
+      .toHaveText(`
+        {
+          "child": "CHILD VALUE"
+        }`
+      );
+  });
+
+  test("reads data from parent using given prop", async({page}) => {
+    const component = page.getByTestId(id);
+
+    await expect(component.getByTestId("child-prop")).toHaveText("CHILD VALUE");
   });
 });

--- a/test/recipe/admin/pages/specs/bake.vue
+++ b/test/recipe/admin/pages/specs/bake.vue
@@ -11,6 +11,22 @@ const variants = [
   {
     name: "Base",
     descriptor: giveMe.aString({ value: "TEST" })
+  },
+  {
+    name: "Parent Data",
+    descriptor: giveMe.aContainer({
+      contents: [
+        giveMe.anExpected({
+          testId: "child-root",
+          data: { type: "Injected", key: "ParentData" }
+        }),
+        giveMe.anExpected({
+          testId: "child-prop",
+          data: { type: "Injected", key: "ParentData", prop: "child" }
+        })
+      ],
+      data: { type: "Inline", value: { child: "CHILD VALUE" } }
+    })
   }
 ];
 </script>

--- a/test/recipe/admin/pages/specs/bake.vue
+++ b/test/recipe/admin/pages/specs/bake.vue
@@ -1,0 +1,16 @@
+<template>
+  <UiSpec
+    title="Bake"
+    :variants="variants"
+  />
+</template>
+<script setup>
+import giveMe from "~/utils/giveMe";
+
+const variants = [
+  {
+    name: "Base",
+    descriptor: giveMe.aString({ value: "TEST" })
+  }
+];
+</script>

--- a/test/recipe/admin/utils/giveMe.js
+++ b/test/recipe/admin/utils/giveMe.js
@@ -25,6 +25,18 @@ export default {
     };
   },
 
+  aContainer({ content, contents, data }) {
+    content = $(content, this.anExpected());
+    contents = $(contents, [content]);
+    data = $(data, { type: "Inline", value: "Test value" });
+
+    return {
+      type: "Container",
+      schema: { contents },
+      data
+    };
+  },
+
   aDataPanel({ title, collapsed, parameters, content } = {}) {
     title = $(title, { type: "Inline", value: "Test Title" });
     collapsed = $(collapsed, false);
@@ -160,7 +172,8 @@ export default {
 
   theInjectedData() {
     return {
-      type: "Injected"
+      type: "Injected",
+      key: "Custom"
     };
   },
 

--- a/test/recipe/admin/utils/giveMe.js
+++ b/test/recipe/admin/utils/giveMe.js
@@ -324,6 +324,16 @@ export default {
     return { route, icon, title, disabled };
   },
 
+  aString({ value, data } = {}) {
+    value = $(value, "Test string");
+    data = $(data, { type: "Inline", value });
+
+    return {
+      type: "String",
+      data
+    };
+  },
+
   aToken({ accessExpired } = {}) {
     accessExpired = $(accessExpired, false);
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -6,3 +6,6 @@
   depending on a row value
 - `primevue` is bundled again to solve dev mode style issue
 - `Bake.vue` now provides `loading` instead of passing it via props
+- `Bake.vue` now provides fetched data in `InjectedData`
+- `InjectedData` now supports `prop` to inject part of the data instead of the
+  whole object


### PR DESCRIPTION
Provide parent data from `Bake` to be used from child `Bake` components. Also
allow to define `prop` for child to get a prop value of parent data.

## Tasks

- [x] add parent as injected
- [x] add prop support for injected data

## Additional Tasks

- [x] loading should be provided when data load will use `await fetch` instead
  of `get`
