### PR TITLE
Issue / DataTable Virtual Scroll

### DIFF
--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,8 @@
 # Unreleased
+
+## Improvements
+
+- `DataTable` now has 
+  - `virtualScroll` property for increasing performance when handling large 
+    amount of data
+  - `scrollable` toggle which can be configured seperate from `scrollHeight`


### PR DESCRIPTION
Enable virtual scroll in `DataTable`

## Tasks

- [ ] add property to `DataTable` schema for configuring virtual scroll
- [ ] update `DataTable.vue` component
- [ ] update test specs if necessary

## Additional Tasks

- [ ] add `scrollable` property to `DataTable` schema and update component
