### PR TITLE
Issue / Null Report Parameter

### DIFF
--- a/src/recipe/Baked.Recipe.Service.Application/Reporting/NativeSql/ReportContext.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Reporting/NativeSql/ReportContext.cs
@@ -24,7 +24,7 @@ public class ReportContext(IFileProvider _fileProvider, Func<IStatelessSession> 
                 continue;
             }
 
-            query.SetParameter(name, value ?? string.Empty);
+            query.SetParameter(name, value);
         }
 
         var result = await query.ListAsync();

--- a/src/recipe/Baked.Recipe.Service.Application/Reporting/NativeSql/ReportContext.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Reporting/NativeSql/ReportContext.cs
@@ -1,8 +1,9 @@
 using Microsoft.Extensions.FileProviders;
+using NHibernate;
 
 namespace Baked.Reporting.NativeSql;
 
-public class ReportContext(IFileProvider _fileProvider, Func<NHibernate.IStatelessSession> _getStatelessSession, ReportOptions _options)
+public class ReportContext(IFileProvider _fileProvider, Func<IStatelessSession> _getStatelessSession, ReportOptions _options)
     : IReportContext
 {
     public async Task<object?[][]> Execute(string queryName, Dictionary<string, object?> parameters)
@@ -17,6 +18,12 @@ public class ReportContext(IFileProvider _fileProvider, Func<NHibernate.IStatele
         var query = _getStatelessSession().CreateSQLQuery(queryString);
         foreach (var (name, value) in parameters)
         {
+            if (value is null)
+            {
+                query.SetParameter(name, null, NHibernateUtil.String);
+                continue;
+            }
+
             query.SetParameter(name, value ?? string.Empty);
         }
 

--- a/src/recipe/Baked.Recipe.Service.Application/Reporting/NativeSql/ReportContext.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Reporting/NativeSql/ReportContext.cs
@@ -17,7 +17,7 @@ public class ReportContext(IFileProvider _fileProvider, Func<NHibernate.IStatele
         var query = _getStatelessSession().CreateSQLQuery(queryString);
         foreach (var (name, value) in parameters)
         {
-            query.SetParameter(name, value);
+            query.SetParameter(name, value ?? string.Empty);
         }
 
         var result = await query.ListAsync();

--- a/test/recipe/Baked.Test.Recipe.Service/Theme/Report.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Theme/Report.cs
@@ -22,7 +22,6 @@ public class Report
     public string GetWide() =>
         $"WIDE: {Value}";
 
-
     public string GetLeft() =>
         $"LEFT: {Value}";
 

--- a/test/recipe/Baked.Test.Recipe.Service/Theme/Report.cs
+++ b/test/recipe/Baked.Test.Recipe.Service/Theme/Report.cs
@@ -22,6 +22,7 @@ public class Report
     public string GetWide() =>
         $"WIDE: {Value}";
 
+
     public string GetLeft() =>
         $"LEFT: {Value}";
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -11,5 +11,6 @@
   - `ReportPage` was rendering only first tab content when a tab is full-screen,
     now it renders all contents
 - `DefaultLayout` overflow was not hidden causing unintended scrolls, fixed
-- `DataTable` now has `virtualScrollerOptions` property for increasing 
+- `DataTable` now has `virtualScrollerOptions` property for increasing
   performance when handling large amount of data
+- `null` parameters now supported.

--- a/unreleased.md
+++ b/unreleased.md
@@ -2,4 +2,4 @@
 
 ## Improvements
 
-- Error when `null` value is given in query parameters, fixed.
+- `ReportContext` was throwing error for `null` query parameters, fixed.

--- a/unreleased.md
+++ b/unreleased.md
@@ -2,4 +2,4 @@
 
 ## Improvements
 
-- `null` parameters now supported.
+- Error when `null` value is given in query parameters, fixed.


### PR DESCRIPTION
Null parameter cannot be resolved by NHibernate with The `IType` can not be
guessed for a `null` value message.

## Tasks

- [x] reproduce error
- [x] find a better type for adding a null parameter to query
