### PR TITLE
Issue / Style Customization

### DIFF
--- a/src/recipe/admin/src/runtime/components/Bake.vue
+++ b/src/recipe/admin/src/runtime/components/Bake.vue
@@ -5,17 +5,19 @@
     v-model="model"
     :schema="descriptor.schema"
     :data
+    :class="classes"
   >
     <slot v-if="$slots.default" />
   </component>
 </template>
 <script setup>
 import { onMounted, ref } from "vue";
-import { useComponentResolver, useContext, useDataFetcher } from "#imports";
+import { useComponentResolver, useContext, useDataFetcher, useFormat } from "#imports";
 
 const componentResolver = useComponentResolver();
 const context = useContext();
 const dataFetcher = useDataFetcher();
+const { asClasses } = useFormat();
 
 const { name, descriptor } = defineProps({
   name: { type: String, required: true },
@@ -30,6 +32,7 @@ const injectedData = context.injectedData();
 const data = ref(dataFetcher.get({ data: descriptor.data, injectedData }));
 const shouldLoad = dataFetcher.shouldLoad(descriptor.data?.type);
 const loading = ref(shouldLoad);
+const classes = [`b-component--${descriptor.type}`, ...asClasses(name)];
 
 context.setInjectedData(data, "ParentData");
 

--- a/src/recipe/admin/src/runtime/components/MenuPage.vue
+++ b/src/recipe/admin/src/runtime/components/MenuPage.vue
@@ -16,8 +16,8 @@
         <h2
           v-if="section.title"
           class="
-            text-zinc-500 dark:text-zinc-500
-            text-sm font-bold
+            text-zinc-400 dark:text-zinc-600
+            text-xs font-bold
           "
         >
           {{ section.title?.toLocaleUpperCase(locale) }}

--- a/src/recipe/admin/src/runtime/components/Page.vue
+++ b/src/recipe/admin/src/runtime/components/Page.vue
@@ -2,15 +2,17 @@
   <Bake
     name="page"
     :descriptor="descriptor"
+    :class="classes"
   />
 </template>
 <script setup>
 import { reactive } from "vue";
 import { useRoute, useRuntimeConfig } from "#app";
-import { useContext, useHead, usePages } from "#imports";
+import { useContext, useFormat, useHead, usePages } from "#imports";
 import { Bake } from "#components";
 
 const context = useContext();
+const { asClasses } = useFormat();
 const pages = usePages();
 const route = useRoute();
 const { public: { components } } = useRuntimeConfig();
@@ -20,4 +22,5 @@ useHead({ title: components?.Page?.title });
 context.setPage(reactive({}));
 const name = route.params?.baked === "" ? "index" : route.params?.baked.join("/");
 const descriptor = await pages.fetch(name);
+const classes = asClasses(name, "b-route--");
 </script>

--- a/src/recipe/admin/src/runtime/components/PageTitle.vue
+++ b/src/recipe/admin/src/runtime/components/PageTitle.vue
@@ -10,9 +10,15 @@
         </h1>
         <div
           data-testid="description"
-          class="text-sm text-gray-600 dark:text-gray-400"
+          class="
+            text-sm text-gray-600 dark:text-gray-400
+            text-nowrap overflow-hidden
+          "
         >
-          {{ description || "&nbsp;" }}
+          <String
+            :schema="{ maxLength: 125 }"
+            :data="description || '&nbsp;'"
+          />
         </div>
       </div>
       <div
@@ -37,7 +43,7 @@
 <script setup>
 import { onMounted } from "vue";
 import { useRuntimeConfig } from "#app";
-import { Bake } from "#components";
+import { Bake, String } from "#components";
 import { useHead } from "#imports";
 
 const { public: { components } } = useRuntimeConfig();

--- a/src/recipe/admin/src/runtime/components/String.vue
+++ b/src/recipe/admin/src/runtime/components/String.vue
@@ -18,15 +18,22 @@ const context = useContext();
 const { truncate } = useFormat();
 
 const { schema, data } = defineProps({
-  schema: { type: null, default: null },
+  schema: { type: null, default: { } },
   data: { type: null, required: true }
 });
 
+const { maxLength } = schema;
+
 const loading = context.loading();
-const lengthIsExceeded = computed(() => schema.maxLength && data.length > schema.maxLength);
-const text = computed(() => lengthIsExceeded.value ? truncate(data, schema.maxLength): data);
+const lengthIsExceeded = computed(() => maxLength && data.length > maxLength);
+const text = computed(() => lengthIsExceeded.value ? truncate(data, maxLength): data);
 const tooltip = computed(() => ({
   value: `${data}`,
-  disabled: !lengthIsExceeded.value
+  disabled: !lengthIsExceeded.value,
+  pt: {
+    root: {
+      style: maxLength ? `min-width: ${maxLength/4}rem;` : ""
+    }
+  }
 }));
 </script>

--- a/src/recipe/admin/src/runtime/composables/useFormat.js
+++ b/src/recipe/admin/src/runtime/composables/useFormat.js
@@ -14,6 +14,14 @@ export default function() {
     { threshold: Number.MIN_VALUE, divisor: 1, suffix: "", fraction: false }
   ];
 
+  function asClasses(path,
+    prefix = "b--"
+  ) {
+    return path.split("/")
+      .filter(item => item.length > 0)
+      .map(item => `${prefix}${item}`);
+  }
+
   function asCurrency(value,
     { shorten, shortenThousands } = { }
   ) {
@@ -80,6 +88,7 @@ export default function() {
   }
 
   return {
+    asClasses,
     asCurrency,
     asDecimal,
     asMonth,

--- a/test/recipe/admin/assets/styles.scss
+++ b/test/recipe/admin/assets/styles.scss
@@ -5,3 +5,19 @@
 .custom-css-hidden {
   display: none;
 }
+
+.b-route--data-table {
+  .b--tabs.b--contents.b--0 {
+    .b-component--DataTable {
+      th:last-child {
+        .flex {
+          @apply gap-24;
+        }
+
+        .p-button {
+          @apply px-5 border border-zinc-200 dark:border-zinc-700 rounded;
+        }
+      }
+    }
+  }
+}

--- a/test/recipe/admin/pages/specs/bake.spec.js
+++ b/test/recipe/admin/pages/specs/bake.spec.js
@@ -12,6 +12,18 @@ test.describe("Base", () => {
 
     await expect(component).toHaveText("TEST");
   });
+
+  test("component has marker class for bake path", async({page}) => {
+    const component = page.getByTestId(id);
+
+    await expect(component.locator(".b--variants.b--base")).toBeAttached();
+  });
+
+  test("component has marker class for component type", async({page}) => {
+    const component = page.getByTestId(id);
+
+    await expect(component.locator(".b-component--String")).toBeAttached();
+  });
 });
 
 test.describe("Parent Data", () => {

--- a/test/recipe/admin/pages/specs/non-component.spec.js
+++ b/test/recipe/admin/pages/specs/non-component.spec.js
@@ -1,0 +1,29 @@
+import { expect, test } from "@nuxt/test-utils/playwright";
+
+test.beforeEach(async({goto}) => {
+  await goto("/", { waitUntil: "hydration" });
+});
+
+test.describe("Layout", () => {
+  test("has path marker class", async({page}) => {
+    await expect(page.locator(".b--root")).toBeAttached();
+  });
+
+  test("has component type marker class", async({page}) => {
+    await expect(page.locator(".b-component--DefaultLayout")).toBeAttached();
+  });
+});
+
+test.describe("Page", () => {
+  test("has path marker class", async({page}) => {
+    await expect(page.locator(".b--page")).toBeAttached();
+  });
+
+  test("has component type marker class", async({page}) => {
+    await expect(page.locator(".b-component--MenuPage")).toBeAttached();
+  });
+
+  test("has route marker class", async({page}) => {
+    await expect(page.locator(".b-route--index")).toBeAttached();
+  });
+});

--- a/test/recipe/admin/pages/specs/page-title.vue
+++ b/test/recipe/admin/pages/specs/page-title.vue
@@ -31,6 +31,12 @@ const variants = [
       title: "PAGE TITLE",
       description: null
     })
+  },
+  {
+    name: "Long Description",
+    descriptor: giveMe.aPageTitle({
+      description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    })
   }
 ];
 </script>

--- a/unreleased.md
+++ b/unreleased.md
@@ -3,3 +3,8 @@
 ## Improvements
 
 - `ReportContext` was throwing error for `null` query parameters, fixed.
+- UI components now have context aware css marker classes to enable
+  customization
+- Component descriptors now have class property to be applied to the root
+  component of a component for class based customization from descriptors
+- `PageTitle` had a margin issue when description is mutline, fixed

--- a/unreleased.md
+++ b/unreleased.md
@@ -5,6 +5,4 @@
 - `ReportContext` was throwing error for `null` query parameters, fixed.
 - UI components now have context aware css marker classes to enable
   customization
-- Component descriptors now have class property to be applied to the root
-  component of a component for class based customization from descriptors
 - `PageTitle` had a margin issue when description is mutline, fixed


### PR DESCRIPTION
Add css classes to every component under `Bake.vue`, `Page.vue` and
`Layout.vue`. This will allow custom styling to any component on the page.

## Tasks

- [x] add name as kebab-case class using `b--` prefix
- [x] add for `tabs/contents/0` -> `b--tabs b--contents b--0`
  - name is split by `/` and added using `b-` prefix
  - selector becomes `.b--tabs.b--contents.b--0`
- [x] page name is added as class name using `b-route--` prefix
- [x] component type is added as class name using `b-component--` prefix
- ~~allow css classes to be added from descriptors~~
  - tailwind `@apply` usage looks sufficient
- [x] write a ui test under `Bake` spec
  - check page and layout classes as well

## Additional Tasks

- [x] page title multiline margin glitch
- [x] smaller menu section name
