### PR TITLE
Issue / Localization Issues

### DIFF
--- a/docs/.theme/.npmrc
+++ b/docs/.theme/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false

--- a/src/recipe/admin/.npmrc
+++ b/src/recipe/admin/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false

--- a/test/recipe/admin/.npmrc
+++ b/test/recipe/admin/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,13 @@
 # Unreleased
+
+## Improvements
+
+- `useFormat` wasn't using locale info from i18n, fixed
+- `locale.en.restext` format wasn't supported for default language when
+  generating missing keys, fixed
+  - `locale.en.{restext|json}` is now the standard format for locale files, do
+    NOT use `locale.restext` in backend
+- `ServiceSpec` and `DataSourceSpec` were missing localization feature, fixed
+- `ILocalizer` interface was removed, `Baked.Service.Application` now depend on
+  `Microsoft.AspNetCore.Localization` and may use `IStringLocalizer` directly
+- `ExceptionHandler` wasn't setting details when there is no localizer, fixed


### PR DESCRIPTION
The issues about localization feature we spotted in production usage.

## Tasks

- [ ] `Filter("Filter")` -> `Filter(l("Filter"))`
- [ ] `useFormat` should use locale from i18n, and get suffices from locale file
- [ ] data table export file name localization?
- [ ] `locale.restext` is not self-describing, should expect `locale.en.restext`
  even if it is the default language
  - frontend behaves like this, looks like backend doesn't copy missing keys
    from `locale.en.restext` 👉 `LocalizedTexts.cs:13`
- [ ] `ServiceSpec` and `DataSourceSpec` doesn't include localization feature
- [ ] `service.md` and `data-source.md` doesn't document localization feature
- [ ] remove `ILocalizer` and `LocalizationAdapter` and reference to
  `Microsoft.AspNetCore.Localization` from `Baked.Service.Recipe` and migrate to
  `IStringLocalizer`
- [ ] localization keys should be straight english with parameters `{0:name}`
  format in the backend
- [ ] migrate localization keys in the front-end as well
  - specs may keep a prefix, e.g., `Spec: Access Denied`
- [ ] `ExceptionHandler` should set body to details when there is no localizer

## Additional Tasks

- [ ] rename `setupBaked` to match plugin naming conventions
  - this is like a method name, but plugins are nouns
- [ ] in v0-17.md,
  - [ ] library upgrades is h3, but it should be h2
  - [ ] fix release notes v0.17.0: it says `UsingLocaleDictionary` and
    `UsingNewLocale`, they have been renamed. also check localization docs and
    see if they are up to date.
- [ ] remove `TypeModelTypeSource.cs`
- [ ] fix indentation in `TypeModelTypeSourceTemplate.cs`: base class should be on
  the next line
