### PR TITLE
Issue / Reselect Default

### DIFF
--- a/src/recipe/Baked.Recipe.Service.Application/Caching/CachingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Caching/CachingExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Baked.Architecture;
 using Baked.Caching;
+using Microsoft.Extensions.Caching.Memory;
+using Shouldly;
 
 namespace Baked;
 
@@ -7,4 +9,7 @@ public static class CachingExtensions
 {
     public static void AddCachings(this List<IFeature> features, IEnumerable<Func<CachingConfigurator, IFeature<CachingConfigurator>>> configures) =>
         features.AddRange(configures.Select(configure => configure(new())));
+
+    public static void ShouldHaveCount(this IMemoryCache memoryCache, int count) =>
+        ((MemoryCache)memoryCache).Count.ShouldBe(count);
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Caching/InMemory/InMemoryCachingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Caching/InMemory/InMemoryCachingExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using Baked.Caching;
 using Baked.Caching.InMemory;
 using Baked.Runtime;
+using Baked.Testing;
 using Microsoft.Extensions.Caching.Memory;
+using NUnit.Framework;
 
 namespace Baked;
 
@@ -11,4 +13,20 @@ public static class InMemoryCachingExtensions
         Action<MemoryCacheOptions>? options = default,
         Setting<TimeSpan>? clientExpiration = default
     ) => new(options ?? (_ => { }), clientExpiration ?? TimeSpan.FromHours(1));
+
+    public static IMemoryCache TheMemoryCache(this Stubber giveMe,
+        bool clear = false
+    )
+    {
+        var memoryCache = giveMe.The<IMemoryCache>();
+
+        if (clear)
+        {
+            if (memoryCache is not MemoryCache concreteMemoryCache) { throw new AssertionException("Cache cannot be cleared because it is not a `MemoryCache` instance"); }
+
+            concreteMemoryCache.Clear();
+        }
+
+        return memoryCache;
+    }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Caching/InMemory/InMemoryCachingFeature.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Caching/InMemory/InMemoryCachingFeature.cs
@@ -21,5 +21,13 @@ public class InMemoryCachingFeature(Action<MemoryCacheOptions> _options, Setting
                 new CacheApplicationPlugin { ExpirationInMinutes = (int)clientExpiration.GetValue().TotalMinutes }
             );
         });
+
+        configurator.ConfigureTestConfiguration(test =>
+        {
+            test.TearDowns.Add(spec =>
+            {
+                spec.GiveMe.TheMemoryCache(clear: true);
+            });
+        });
     }
 }

--- a/src/recipe/Baked.Recipe.Service.Application/Caching/ScopedMemory/ScopedMemoryCachingExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Caching/ScopedMemory/ScopedMemoryCachingExtensions.cs
@@ -3,7 +3,7 @@ using Baked.Caching.ScopedMemory;
 using Baked.Runtime;
 using Baked.Testing;
 using Microsoft.Extensions.Caching.Memory;
-using Shouldly;
+using NUnit.Framework;
 
 namespace Baked;
 
@@ -22,12 +22,11 @@ public static class ScopedMemoryCachingExtensions
 
         if (clear)
         {
-            (memoryCache as MemoryCache)?.Clear();
+            if (memoryCache is not MemoryCache concreteMemoryCache) { throw new AssertionException("Cache cannot be cleared because it is not a `MemoryCache` instance"); }
+
+            concreteMemoryCache.Clear();
         }
 
         return memoryCache;
     }
-
-    public static void ShouldHaveCount(this IMemoryCache memoryCache, int count) =>
-        ((MemoryCache)memoryCache).Count.ShouldBe(count);
 }

--- a/src/recipe/admin/src/module.ts
+++ b/src/recipe/admin/src/module.ts
@@ -54,13 +54,13 @@ export default defineNuxtModule<ModuleOptions>({
     const resolver = createResolver(import.meta.url);
     const entryProjectResolver = createResolver(_nuxt.options.rootDir);
 
-    let _app = _options.app;
-    if (!_app) {
+    let { app } = _options;
+    if (!app) {
       try {
-        _app = require(`${_nuxt.options.rootDir}/.baked/app.json`);
+        app = require(`${_nuxt.options.rootDir}/.baked/app.json`);
       } catch {
         try {
-          _app = require(`${_nuxt.options.rootDir}/app.json`);
+          app = require(`${_nuxt.options.rootDir}/app.json`);
         } catch (e) {
           console.warn('[baked-recipe-admin] Could not auto-load app.json:', e);
         }
@@ -68,7 +68,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     // passing module's options to runtime config for further access
-    _nuxt.options.runtimeConfig.public.error = _app?.error;
+    _nuxt.options.runtimeConfig.public.error = app?.error;
     _nuxt.options.runtimeConfig.public.primevue = _options.primevue;
     _nuxt.options.runtimeConfig.public.components = _options.components;
     _nuxt.options.runtimeConfig.public.composables = _options.composables;
@@ -90,7 +90,7 @@ export default defineNuxtModule<ModuleOptions>({
     addImportsDir(resolver.resolve("./runtime/composables"));
 
     // plugins that comes through the app descriptor
-    for(const plugin of _app?.plugins ?? []) {
+    for(const plugin of app?.plugins ?? []) {
       _nuxt.options.runtimeConfig.public[plugin.name] = plugin;
       addPlugin(resolver.resolve(`./runtime/plugins/${plugin.name}`));
     }
@@ -107,10 +107,10 @@ export default defineNuxtModule<ModuleOptions>({
       vueI18n: entryProjectResolver.resolve("./i18n.config.ts"),
       langDir: entryProjectResolver.resolve("./"),
       strategy: "no_prefix",
-      locales: _app?.i18n?.supportedLanguages?.map((i: any) => {
+      locales: app?.i18n?.supportedLanguages?.map((i: any) => {
         const files = [
           entryProjectResolver.resolve(`.baked/locale.${i.code}.json`),
-          entryProjectResolver.resolve(`./locales/locale.${i.code}.json`)
+          entryProjectResolver.resolve(`locales/locale.${i.code}.json`)
         ];
 
         return {
@@ -119,7 +119,7 @@ export default defineNuxtModule<ModuleOptions>({
           files
         }
       }),
-      defaultLocale: _app?.i18n?.defaultLanguage?.code,
+      defaultLocale: app?.i18n?.defaultLanguage?.code,
       detectBrowserLanguage: {
         useCookie: true,
         cookieKey: 'i18n_cookie'

--- a/src/recipe/admin/src/module.ts
+++ b/src/recipe/admin/src/module.ts
@@ -59,11 +59,7 @@ export default defineNuxtModule<ModuleOptions>({
       try {
         app = require(`${_nuxt.options.rootDir}/.baked/app.json`);
       } catch {
-        try {
-          app = require(`${_nuxt.options.rootDir}/app.json`);
-        } catch (e) {
-          console.warn('[baked-recipe-admin] Could not auto-load app.json:', e);
-        }
+        console.warn('[baked-recipe-admin] Could not auto-load app.json');
       }
     }
 

--- a/src/recipe/admin/src/runtime/components/Layout.vue
+++ b/src/recipe/admin/src/runtime/components/Layout.vue
@@ -20,9 +20,15 @@ const layouts = useLayouts();
 const pages = usePages();
 
 const descriptor = ref(await findLayout(route.params.baked?.[0]));
-watch(() => route.params.baked?.[0], async newPageName => {
-  descriptor.value = await findLayout(newPageName);
-});
+watch(
+  () => route.params.baked?.[0],
+  async(newPageName, oldPageName) => {
+    if(newPageName !== oldPageName) {
+      descriptor.value = await findLayout(newPageName);
+    }
+  },
+  { immediate: true }
+);
 
 async function findLayout(pageName) {
   const pageDescriptor = await pages.fetch(pageName || "index", { throwNotFound: false });

--- a/src/recipe/admin/src/runtime/components/MenuPage.vue
+++ b/src/recipe/admin/src/runtime/components/MenuPage.vue
@@ -66,17 +66,28 @@ const sectionsData = ref(sections);
 const page = context.page();
 // Listen in context if any filter is applied
 if(filterPageContextKey) {
-  watch(() => page[filterPageContextKey], (newValue, _) => {
-    // Apply filter to links
-    const sectionsWithFilteredLinks = sections.map(section => ({
-      title: section.title,
-      links: section.links.filter(link =>
-        l(link.title)?.toLocaleLowerCase(locale).startsWith(newValue.toLocaleLowerCase(locale))
-      )
-    }));
+  watch(
+    () => page[filterPageContextKey],
+    (newValue, oldValue) => {
+      if(newValue === oldValue || newValue === undefined) { return; }
 
-    // If there are no links left in the sections after filter, filter the section too
-    sectionsData.value = sectionsWithFilteredLinks.filter(section => section.links.length > 0);
-  });
+      if(!newValue.trim()) {
+        sectionsData.value = sections;
+        return;
+      }
+
+      const searchTerm = newValue.toLocaleLowerCase(locale);
+      const sectionsWithFilteredLinks = sections.map(section => ({
+        title: section.title,
+        links: section.links.filter(link => {
+          const title = l(link.title);
+          return title?.toLocaleLowerCase(locale).startsWith(searchTerm);
+        })
+      }));
+
+      sectionsData.value = sectionsWithFilteredLinks.filter(section => section.links.length > 0);
+    },
+    { immediate: true }
+  );
 }
 </script>

--- a/src/recipe/admin/src/runtime/components/Parameters.vue
+++ b/src/recipe/admin/src/runtime/components/Parameters.vue
@@ -49,10 +49,11 @@ emitReady();
 
 // when any of the parameter values changed from input components, it emits
 // ready and changed
+// be sure value has changed?
 watch(Object.values(values), async() => {
   emitChanged();
   emitReady();
-});
+}, { deep: true } );
 
 function emitReady() {
   emit("ready",

--- a/src/recipe/admin/src/runtime/components/Parameters.vue
+++ b/src/recipe/admin/src/runtime/components/Parameters.vue
@@ -49,11 +49,10 @@ emitReady();
 
 // when any of the parameter values changed from input components, it emits
 // ready and changed
-// be sure value has changed?
 watch(Object.values(values), async() => {
   emitChanged();
   emitReady();
-}, { deep: true } );
+});
 
 function emitReady() {
   emit("ready",

--- a/src/recipe/admin/src/runtime/components/QueryParameters.vue
+++ b/src/recipe/admin/src/runtime/components/QueryParameters.vue
@@ -100,12 +100,6 @@ watch(Object.values(values).map(p => p.model), async newValues => {
 });
 
 async function setDefaults() {
-  if(parameters
-    .filter(p => p.required)
-    .map(p => values[p.name].query)
-    .every(q => q.value)
-  ) { return; }
-
   const query = { };
   for(const p of parameters ) {
     query[p.name] = values[p.name].query.value;

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Caching/UsingInMemory.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Caching/UsingInMemory.cs
@@ -7,7 +7,7 @@ public class UsingInMemory : TestServiceSpec
     [Test]
     public void Objects_can_be_cached_in_memory()
     {
-        var cache = GiveMe.The<IMemoryCache>();
+        var cache = GiveMe.TheMemoryCache();
         var expected = cache.GetOrCreate<object>("key", _ => new());
 
         var actual = cache.GetOrCreate<object>("key", _ => new());

--- a/test/recipe/admin/components/Input.vue
+++ b/test/recipe/admin/components/Input.vue
@@ -8,7 +8,7 @@
 </template>
 <script setup>
 import { InputText } from "primevue";
-import { onMounted, watch } from "vue";
+import { watch } from "vue";
 
 const { schema } = defineProps({
   schema: { type: null, required: true }
@@ -17,17 +17,15 @@ const model = defineModel({ type: null, required: true });
 
 const { testId, defaultValue } = schema;
 
-if(defaultValue) {
-  onMounted(() => {
-    if(!model.value) {
-      model.value = defaultValue;
-    }
-  });
-
-  watch(model, newValue => {
-    if(!newValue) {
-      model.value = defaultValue;
-    }
-  });
+if(defaultValue !== undefined) {
+  watch(
+    model,
+    newValue => {
+      if(newValue == null) {
+        model.value = defaultValue;
+      }
+    },
+    { immediate: true }
+  );
 }
 </script>

--- a/test/recipe/admin/components/UiSpec.vue
+++ b/test/recipe/admin/components/UiSpec.vue
@@ -83,9 +83,12 @@
   </div>
 </template>
 <script setup>
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, reactive, ref } from "vue";
 import { useContext, usePages } from "#imports";
 import { Divider } from "primevue";
+
+const context = useContext();
+const pages = usePages();
 
 const { title, variants, noLoadingVariant } = defineProps({
   title: { type: String, required: true },
@@ -98,12 +101,10 @@ const { title, variants, noLoadingVariant } = defineProps({
   variantClass: { type: String, default: "inline-block" }
 });
 
-const pages = usePages();
-const context = useContext();
-const page = context.page();
+const page = reactive({});
 const description = ref();
 const loaded = ref(false);
-
+const models = variants.map(v => v.model);
 const allVariants = computed(() => {
   if(noLoadingVariant) { return variants; }
   if(variants.length === 0) { return variants; }
@@ -120,7 +121,7 @@ const allVariants = computed(() => {
   return result;
 });
 
-const models = variants.map(v => v.model);
+context.setPage(page);
 
 onMounted(async() => {
   const specs = await pages.fetch("specs");

--- a/test/recipe/admin/nuxt.config.ts
+++ b/test/recipe/admin/nuxt.config.ts
@@ -1,6 +1,5 @@
 import Aura from "@primeuix/themes/aura";
 import { definePreset } from "@primeuix/themes";
-import app from "./.baked/app.json" assert { type: "json" };
 
 const Mouseless = definePreset(Aura, {
   semantic: {
@@ -23,7 +22,6 @@ const Mouseless = definePreset(Aura, {
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   baked: {
-    app: app,
     components: {
       Page: {
         title: "Baked Admin"

--- a/test/recipe/admin/pages/specs/report-page.spec.js
+++ b/test/recipe/admin/pages/specs/report-page.spec.js
@@ -105,6 +105,26 @@ test.describe("Narrow", () => {
   });
 });
 
+test.describe("Show When", () => {
+  const id = "Show When";
+
+  test("tab 2 is hidden when showTab2 is false", async({page}) => {
+    const component = page.getByTestId(id);
+    await expect(component.getByTestId("icon 2")).toBeVisible();
+    await expect(component.getByTestId("tab-2-content")).not.toBeVisible();
+    await expect(component.getByTestId("tab-1-content")).toHaveText("CONTENT 1");
+  });
+
+  test("tab 2 is shown when showTab2 is true", async({page}) => {
+    const component = page.getByTestId(id);
+    await component.locator("[data-testid=\"icon 2\"]").click();
+    await expect(component.getByTestId("icon 1")).toBeVisible();
+    await expect(component.getByTestId("tab-2-content")).toBeVisible();
+    await expect(component.getByTestId("tab-2-content")).toHaveText("CONTENT 2");
+    await expect(component.getByTestId("tab-1-content")).not.toBeVisible();
+  });
+});
+
 test.describe("Query Parameters", () => {
   const id = "Query Parameters";
 

--- a/test/recipe/admin/pages/specs/report-page.spec.js
+++ b/test/recipe/admin/pages/specs/report-page.spec.js
@@ -108,20 +108,54 @@ test.describe("Narrow", () => {
 test.describe("Show When", () => {
   const id = "Show When";
 
-  test("tab 2 is hidden when showTab2 is false", async({page}) => {
+  test("tab is hidden when there is no selection", async({page}) => {
     const component = page.getByTestId(id);
-    await expect(component.getByTestId("icon 2")).toBeVisible();
-    await expect(component.getByTestId("tab-2-content")).not.toBeVisible();
-    await expect(component.getByTestId("tab-1-content")).toHaveText("CONTENT 1");
+
+    await expect(component.getByTestId("content-2")).not.toBeAttached();
   });
 
-  test("tab 2 is shown when showTab2 is true", async({page}) => {
+  test("tab content is hidden when there is no selection", async({page}) => {
     const component = page.getByTestId(id);
-    await component.locator("[data-testid=\"icon 2\"]").click();
-    await expect(component.getByTestId("icon 1")).toBeVisible();
-    await expect(component.getByTestId("tab-2-content")).toBeVisible();
-    await expect(component.getByTestId("tab-2-content")).toHaveText("CONTENT 2");
-    await expect(component.getByTestId("tab-1-content")).not.toBeVisible();
+
+    await expect(component.getByTestId("content-1")).not.toBeAttached();
+  });
+
+  test("tab content is shown when selection is SHOW", async({page}) => {
+    const component = page.getByTestId(id);
+
+    await component.locator("button").nth(0).click(); // toggle
+
+    await expect(component.getByTestId("content-1")).toHaveText("CONTENT 1");
+  });
+
+  test("tab is shown when selection is SHOW", async({page}) => {
+    const component = page.getByTestId(id);
+
+    await component.locator("button").nth(0).click(); // toggle
+    await component.locator(".b--tab-2").click(); // click Tab 2
+
+    await expect(component.getByTestId("content-2")).toHaveText("CONTENT 2");
+  });
+
+  test("when tab gets hidden, first shown tab is selected ", async({page}) => {
+    const component = page.getByTestId(id);
+
+    await component.locator("button").nth(0).click(); // toggle
+    await component.locator(".b--tab-2").click(); // click Tab 2
+    await component.locator("button").nth(0).click(); // toggle
+
+    await expect(component.locator(".p-tab-active")).toHaveText("Tab 1");
+  });
+
+  test("when hidden tab gets shown again, it is automatically selected", async({page}) => {
+    const component = page.getByTestId(id);
+
+    await component.locator("button").nth(0).click(); // toggle
+    await component.locator(".b--tab-2").click(); // click Tab 2
+    await component.locator("button").nth(0).click(); // toggle
+    await component.locator("button").nth(0).click(); // toggle
+
+    await expect(component.locator(".p-tab-active")).toHaveText("Tab 2");
   });
 });
 

--- a/test/recipe/admin/pages/specs/report-page.vue
+++ b/test/recipe/admin/pages/specs/report-page.vue
@@ -46,6 +46,36 @@ const variants = [
     })
   },
   {
+    name: "Show When",
+    descriptor: giveMe.aReportPage({
+      data: {
+        showTab2: false
+      },
+      tabs: [
+        giveMe.aReportPageTab({
+          id: "tab-1",
+          title: "Spec: Tab 1",
+          icon: giveMe.anExpected({ testId: "icon 1", value: "I." }),
+          contents: [
+            giveMe.aReportPageTabContent({
+              component: giveMe.anExpected({ testId: "tab-1-content", value: "CONTENT 1" })
+            })
+          ]
+        }),
+        giveMe.aReportPageTab({
+          id: "tab-2",
+          title: "Spec: Tab 2",
+          icon: giveMe.anExpected({ testId: "icon 2", value: "II." }),
+          contents: [
+            giveMe.aReportPageTabContent({
+              component: giveMe.anExpected({ testId: "tab-2-content", value: "CONTENT 2" })
+            })
+          ]
+        })
+      ]
+    })
+  },
+  {
     name: "Single Tab",
     descriptor: giveMe.aReportPage({
       tabs: [

--- a/test/recipe/admin/pages/specs/report-page.vue
+++ b/test/recipe/admin/pages/specs/report-page.vue
@@ -48,27 +48,35 @@ const variants = [
   {
     name: "Show When",
     descriptor: giveMe.aReportPage({
-      data: {
-        showTab2: false
-      },
+      queryParameters: [
+        giveMe.aParameter({
+          component: giveMe.aSelectButton({
+            data: ["SHOW"],
+            selectionPageContextKey: "selection-is",
+            allowEmpty: true
+          })
+        })
+      ],
       tabs: [
         giveMe.aReportPageTab({
           id: "tab-1",
           title: "Spec: Tab 1",
-          icon: giveMe.anExpected({ testId: "icon 1", value: "I." }),
           contents: [
+            giveMe.aReportPageTabContent(),
             giveMe.aReportPageTabContent({
-              component: giveMe.anExpected({ testId: "tab-1-content", value: "CONTENT 1" })
+              component: giveMe.anExpected({ testId: "content-1", value: "CONTENT 1" }),
+              showWhen: "selection-is:SHOW"
             })
           ]
         }),
         giveMe.aReportPageTab({
           id: "tab-2",
           title: "Spec: Tab 2",
-          icon: giveMe.anExpected({ testId: "icon 2", value: "II." }),
+          showWhen: "selection-is:SHOW",
           contents: [
             giveMe.aReportPageTabContent({
-              component: giveMe.anExpected({ testId: "tab-2-content", value: "CONTENT 2" })
+              component: giveMe.anExpected({ testId: "content-2", value: "CONTENT 2" }),
+              showWhen: "selection-is:SHOW"
             })
           ]
         })

--- a/test/recipe/admin/pages/specs/select-button.vue
+++ b/test/recipe/admin/pages/specs/select-button.vue
@@ -7,12 +7,8 @@
   />
 </template>
 <script setup>
-import { ref, reactive } from "vue";
+import { ref } from "vue";
 import giveMe from "~/utils/giveMe";
-import { useContext } from "#imports";
-
-const context = useContext();
-context.setPage(reactive({}));
 
 const variants = [
   {

--- a/test/recipe/admin/pages/specs/select.vue
+++ b/test/recipe/admin/pages/specs/select.vue
@@ -6,12 +6,8 @@
   />
 </template>
 <script setup>
-import { ref, reactive } from "vue";
+import { ref } from "vue";
 import giveMe from "~/utils/giveMe";
-import { useContext } from "#imports";
-
-const context = useContext();
-context.setPage(reactive({}));
 
 const variants = [
   {

--- a/test/recipe/admin/utils/giveMe.js
+++ b/test/recipe/admin/utils/giveMe.js
@@ -369,22 +369,24 @@ export default {
     };
   },
 
-  aReportPageTab({ id, title, contents, fullScreen, icon, overflow } = {}) {
+  aReportPageTab({ id, title, contents, fullScreen, icon, overflow, showWhen } = {}) {
     id = $(id, "test-tab");
     title = $(title, "Test Tab");
     contents = $(contents, [this.aReportPageTabContent()]);
     fullScreen = $(fullScreen, false);
     icon = $(icon, this.anIcon());
     overflow = $(overflow, false);
+    showWhen = $(showWhen, undefined);
 
-    return { id, title, contents, fullScreen, icon, overflow };
+    return { id, title, contents, fullScreen, icon, overflow, showWhen };
   },
 
-  aReportPageTabContent({ component, narrow } = {}) {
+  aReportPageTabContent({ component, narrow, showWhen } = {}) {
     component = $(component, this.anExpected({ value: "Test content is given for testing purposes" }));
     narrow = $(narrow, false);
+    showWhen = $(showWhen, undefined);
 
-    return { component, narrow };
+    return { component, narrow, showWhen };
   },
 
   aSelect({ label, localizeLabel, optionLabel, optionValue, showClear, selectionPageContextKey, stateful, data, inline } = {}) {

--- a/unreleased.md
+++ b/unreleased.md
@@ -11,10 +11,9 @@
 - `DataTable.vue` now includes parameter values in export file names
 - `RemoteData.Options` has changed to `RemoteData.Attribute` to avoid confusion
   with `ofetch`'s options parameter
-- The select input on the cache page was not working properly, improved.
-
-- The QueryParameters component setDefaults is not working properly, improved.
-- The `app.json` file is now automatically added to module.ts. improved 
-- Added missing spec for `showWhen` feature in `ReportPage`
-- Added clear cache feature on `InMemoryCachingFeature`, improved
-- Improved `Layout`, `Input`, `MenuPage`, `ReportPage`, `QueryParameters`, `Parameters` components watchers. (immediate, deep and value conditions)
+- The select input on the cache page was not working properly, improved
+- The QueryParameters component setDefaults was not working properly, improved
+- The `app.json` file is now automatically added to module.ts
+- Clear cache on teardown was missing for `InMemoryCachingFeature`, fixed
+- Improved `Layout`, `Input`, `MenuPage`, `ReportPage`, `QueryParameters`,
+  `Parameters` components watchers

--- a/unreleased.md
+++ b/unreleased.md
@@ -11,3 +11,5 @@
 - `DataTable.vue` now includes parameter values in export file names
 - `RemoteData.Options` has changed to `RemoteData.Attribute` to avoid confusion
   with `ofetch`'s options parameter
+- The select input on the cache page was not working properly, improved.
+

--- a/unreleased.md
+++ b/unreleased.md
@@ -13,3 +13,8 @@
   with `ofetch`'s options parameter
 - The select input on the cache page was not working properly, improved.
 
+- The QueryParameters component setDefaults is not working properly, improved.
+- The `app.json` file is now automatically added to module.ts. improved 
+- Added missing spec for `showWhen` feature in `ReportPage`
+- Added clear cache feature on `InMemoryCachingFeature`, improved
+- Improved `Layout`, `Input`, `MenuPage`, `ReportPage`, `QueryParameters`, `Parameters` components watchers. (immediate, deep and value conditions)


### PR DESCRIPTION
On cache test page, clicking on left menu or breadcrumb doesn't cause Select
component to set its default. it must set the default.

## Tasks

- [x] Implement correct Select way on Cache page

## Additional Tasks

- [x] should import `app.json` automatically, eliminating the need for this
  extra code in projects
- [x] missing report page test case: showWhen option of tab and content
- [x] remove duplication in vue components using watch[immediate] where setup
  and watch does the same thing (discover all vue component used `watch`)
  - [x] Layout, Input, MenuPage, ReportPage, QueryParameters, Parameters
- [x] add cache clear to in memory cached feature (implement
  `InMemoryCachingFeature` like `ScopedMemoryCachingFeature`) and refactor in
  `ScopedMemoryCachingExtensions`
