### PR TITLE
Epic / UI Conventions

### DIFF
--- a/unreleased.md
+++ b/unreleased.md
@@ -1,1 +1,26 @@
 # Unreleased
+
+## Features
+
+- Beta features are available in `Baked.Recipe.Service.Application`;
+  - Introducing UI Conventions: `UiLayer` and `ThemeFeature` now provides
+    several conventions and extension methods to allow you to build your page
+    descriptors via conventions instead of configuring them one by one
+
+## Improvements
+
+- Component initializers now have a `schema:` and optionall `data:` function
+  parameter, minimizing the need to duplicate schema properties in component
+  initializers
+- `Rate`, `Money`, `Number` now have a component schema even if the schemas
+  don't have any property
+- `ComponentDescriptor` is removed, all components must have a schema now
+- `ClientCache` is now automatically mapped to `RemoteData` attributes
+- Add/remove metadata extensions are now available property, method and
+  parameter as well
+- Domain model now respects `AllowMultiple` property of an attrbute, allowing an
+  attribute to be overriden when it is single instance attribute
+  - `Add/Remove{..}Metadata` now only works for the attributes that have
+    `AllowMultiple` set to `true`
+  - `Set{..}Metadata` is now introduced to setting (or overriding) a single
+    instance for the attributes that have `AllowMultiple` set to `false`


### PR DESCRIPTION
Design a convention system for UI schemas like we did in APIs.

## Notes

Three steps to create page descriptors;

1. context based component attribute to define which component suits which ui
   context using conventions
2. list of component descriptors on a domain model (class or method etc) to hold
   the conversion of a model to a component descriptor
   1. also a list of component descriptor builders
   2. also a descriptor and a descriptor builder attribute to attach non schema
      records to a model
3. get descriptor and get component descriptor extension methods to find or
   build the descriptor (or component descriptor) from a model

- :thinking: component descriptor, and descriptor, attribute should have an
  `Init` method to be called after metadata conventions, just like api model
  metadata conventions, to get initalized after api models are initialized
  - a convention should go through all attributes and initialize all of them
  - this will require a non-generic interface or base class for these attributes
    in order to be called where `TSchema`, or `TSchemaPart`, is unknown

## Tasks

- [x] Design #311
- [ ] Add configure function parameter to all components
  - this will remove duplicate declaration of every attribute of a component
- [ ] Schema conventions for `ComponentDescriptorAttribute`
  - type, property, method and parameter extensions
  - set schema should be public
- [ ] Descriptor and descriptor builder attribute and conventions
- [ ] ContextBasedComponentAttribute
  - this is required because get component descriptor doesn't know component
    type, it is polymorphic
- [ ] Component descriptor builder and conventions
  - component descriptor and builders should have `AppliesTo` to enable
    selection between multiple descriptors according to context
- [ ] Provide extensions for (component)descriptor(builder)s
  - these conventions gets a `Action<TSchema>` to change property(s) of an
    existing schema
  - when the schema comes from a descriptor attribute, it gets the schema and
    passes it to action
  - when the schema is built using a builder, convention replaces existing
    builder with a builder function that first calls `Func<TSchema>` of the
    attribute, and then calls given action, and returns the result
    - this will allow to create a chain of builders, where it will be possible
      to change a specific property of a schema
  - :information_source: without this we need to rebuild the entire schema just
    to override one property
- [ ] Create system to make sure a UI convention runs after API conventions
  - :thinking: max order for API, and min order for UI
- [ ] Implement mark system for type, property, method and parameter
- [ ] Base setup in Admin Theme
  - add data and marks metadata
  - make admin extendible
  - add page context and component context
- [ ] Add domain components for all components
  - all components should have a corresponding domain component
  - every domain component should be fully customizable by introducing a
    configure function parameter as in components (no overload should be
    required)
- [ ] Implement a tab system and conventions
- [ ] Add domain datas for all datas
  - action remote should use conventions through descriptor or descriptor
    builder attribute
- [ ] Migrate existing demo pages to ui conventions
- [ ] Final touches
  - improve developer experience
  - :thinking: consider a testing system for ui conventions

## Additional Tasks

- [ ] Attribute collection should not use hash set, it should use list to
  preserve the order attributes are added to the list
- [ ] Add remove metadata for other custom attributes models
- [ ] Respect allow multiple of attribute in add metadata convention and don't
  add when it already has an attribute
  - allow overriding, in this case it will replace existing attribute
- [ ] Add schema for all components, e.g., `Number`
  - update components to have schema, even if it is empty
  - remove `ComponentDescriptor`
- [ ] Recognize client cache attribute and add `client-cache={type}` to remote
  data
