### PR TITLE
Issue / `app.json` Windows

### DIFF
--- a/src/recipe/admin/src/module.ts
+++ b/src/recipe/admin/src/module.ts
@@ -1,5 +1,6 @@
 import { defineNuxtModule, addComponentsDir, addImportsDir, addPlugin, createResolver, installModule } from "@nuxt/kit";
 import type { NuxtI18nOptions } from "@nuxtjs/i18n";
+import { pathToFileURL } from "url";
 
 export interface ModuleOptions {
   components?: Components,
@@ -55,8 +56,8 @@ export default defineNuxtModule<ModuleOptions>({
     const resolver = createResolver(import.meta.url);
     const entryProjectResolver = createResolver(_nuxt.options.rootDir);
 
-    const appJsonPath = entryProjectResolver.resolve(`./.baked/app.json`);
-    const app = (await import(appJsonPath, { with: { type: "json" } })).default;
+    const appJsonPath = pathToFileURL(entryProjectResolver.resolve(`./.baked/app.json`));
+    const app = (await import(appJsonPath.href, { with: { type: "json" } })).default;
 
     // passing module's options to runtime config for further access
     _nuxt.options.runtimeConfig.public.error = app?.error;

--- a/unreleased.md
+++ b/unreleased.md
@@ -2,4 +2,4 @@
 
 ## Improvements
 
-- The path of the `app.json` file cannot be resolved in the Windows, fixed
+- Failure to import `app.json` file with absolute path in Windows, fixed


### PR DESCRIPTION
`app.json` cannot be read in windows due to wrong file read in `module.ts`

## Tasks

- [x] give `app.json` path as file path to import