### PR TITLE
Issue/ UI Conventions / Respect Allow Multiple

### DIFF
--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/BuildingNonDomainTypes.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/BuildingNonDomainTypes.cs
@@ -3,7 +3,7 @@ using Baked.Orm;
 using Baked.Test.Lifetime;
 using Baked.Test.Orm;
 
-namespace Baked.Test.Domain;
+namespace Baked.Test.Business;
 
 public class BuildingNonDomainTypes : TestServiceSpec
 {

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Business/OverridingActions.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Business/OverridingActions.cs
@@ -46,7 +46,7 @@ public class OverridingActions : TestServiceNfr
         response = await Client.PostAsync("override-samples/request-class", new StringContent(mediaType: new("application/json"), content: """
         {
            "text": "text",
-            "numeric": 1            
+            "numeric": 1
         }
         """));
         response.StatusCode.ShouldBe(HttpStatusCode.OK);

--- a/test/recipe/Baked.Test.Recipe.Service.Test/Domain/RespectingAllowMultiple.cs
+++ b/test/recipe/Baked.Test.Recipe.Service.Test/Domain/RespectingAllowMultiple.cs
@@ -1,0 +1,8 @@
+namespace Baked.Test.Domain;
+
+public class RespectingAllowMultiple : TestServiceSpec
+{
+    [Test]
+    [Ignore("todo")]
+    public void Writing_tests() => this.ShouldFail();
+}


### PR DESCRIPTION
Respect allow multiple setting of an attribute when adding to domain model

> [!NOTE]
>
> Tasks to be listed in detail

## Tasks

- [ ] Respect allow multiple of attribute in add metadata convention and don't
  add when it already has an attribute
  - allow overriding, in this case it will replace existing attribute

## Additional Tasks

- [ ] Add remove metadata for other custom attributes models
