### PR TITLE
Issue / UI Conventions / Merge from `main`

### DIFF
--- a/docs/features/ux.md
+++ b/docs/features/ux.md
@@ -43,12 +43,12 @@ c => c.ActionsAsDataPanels()
 
 ## Designated String Properties are Label
 
+Marks selected string properties as labels to have a better display in
+`DataTable` columns.
+
 ```csharp
 c => c.DesignatedStringPropertiesAreLabel(propertyNames: [...])
 ```
-
-Marks selected string properties as labels to have a better display in
-`DataTable` columns.
 
 - Properties with matching names are given `LabelAttribute`
 - Label columns in a `DataTable` are frozen and have minimum width
@@ -60,11 +60,11 @@ Marks selected string properties as labels to have a better display in
 
 ## Enum Parameter is Select
 
+Renders enum parameters as `Select` by default.
+
 ```csharp
 c => c.EnumParameterIsSelect(maxMemberCountForSelectButton: ...)
 ```
-
-Renders enum parameters as `Select` by default.
 
 - By default, enum parameters are shown as a `Select` dropdown
 - When the number of enum members is less than or equal to the given limit, it
@@ -78,23 +78,23 @@ Renders enum parameters as `Select` by default.
 
 ## Initializer Parameters are in Page Title
 
+Adds initializer parameters of a report class to the page title area of a
+`ReportPage`.
+
 ```csharp
 c => c.InitializerParametersAreInPageTitle()
 ```
-
-Adds initializer parameters of a report class to the page title area of a
-`ReportPage`.
 
 - Adds initializer parameters as query parameters of the page
 - Works for types marked with `TransientAttribute`
 
 ## List is Data Table
 
+Shows list results of controller actions as a `DataTable` inside a `DataPanel`.
+
 ```csharp
 c => c.ListDataTable()
 ```
-
-Shows list results of controller actions as a `DataTable` inside a `DataPanel`.
 
 - Methods with `ActionModelAttribute` that return a list are rendered as
   `DataTable`
@@ -103,11 +103,11 @@ Shows list results of controller actions as a `DataTable` inside a `DataPanel`.
 
 ## Numeric Values are Formatted
 
+Right-aligns numeric columns and uses suitable components for each numeric type.
+
 ```csharp
 c => c.NumericValuesAreFormatted()
 ```
-
-Right-aligns numeric columns and uses suitable components for each numeric type.
 
 - `int` properties render with `Number`
 - `decimal` properties render with `Money`
@@ -116,11 +116,11 @@ Right-aligns numeric columns and uses suitable components for each numeric type.
 
 ## Object with List is Data Table
 
+Shows list data from an object result as a `DataTable` inside a `DataPanel`.
+
 ```csharp
 c => c.ObjectWithListIsDataTable()
 ```
-
-Shows list data from an object result as a `DataTable` inside a `DataPanel`.
 
 - Methods with `ActionModelAttribute` that return an object containing a visible
   list property are rendered as `DataTable`
@@ -138,12 +138,12 @@ Shows list data from an object result as a `DataTable` inside a `DataPanel`.
 
 ## Panel Parameters are Stateful
 
+Keeps parameter selections inside a `DataPanel` when the panel reloads.
+Parameters rendered with `Select` and `SelectButton` are marked as stateful.
+
 ```csharp
 c => c.PanelParametersAreStateful()
 ```
-
-Keeps parameter selections inside a `DataPanel` when the panel reloads.
-Parameters rendered with `Select` and `SelectButton` are marked as stateful.
 
 > [!WARNING]
 >
@@ -154,11 +154,11 @@ Parameters rendered with `Select` and `SelectButton` are marked as stateful.
 
 ## Type with Only `GET` is Report Page
 
+Creates a `ReportPage` for controller types that only have `GET` actions.
+
 ```csharp
 c => c.TypeWithOnlyGetIsReportPage()
 ```
-
-Creates a `ReportPage` for controller types that only have `GET` actions.
 
 - Applies to types marked with `ControllerModelAttribute`
 - If all actions are `GET` methods, the type is rendered as a `ReportPage`

--- a/src/recipe/Baked.Recipe.Service.Application/Theme/ThemeExtensions.cs
+++ b/src/recipe/Baked.Recipe.Service.Application/Theme/ThemeExtensions.cs
@@ -214,7 +214,7 @@ public static class ThemeExtensions
     {
         whenType ??= c => true;
         whenComponent ??= c => true;
-        order += RestApiLayer.MaxConventionOrder;
+        order += RestApiLayer.MaxConventionOrder * 2;
 
         conventions.AddTypeMetadata(
             attribute: c => new DescriptorBuilderAttribute<TSchema>()
@@ -257,7 +257,7 @@ public static class ThemeExtensions
     {
         whenProperty ??= c => true;
         whenComponent ??= c => true;
-        order += RestApiLayer.MaxConventionOrder;
+        order += RestApiLayer.MaxConventionOrder * 2;
 
         conventions.AddPropertyMetadata(
             attribute: c => new DescriptorBuilderAttribute<TSchema>()
@@ -300,7 +300,7 @@ public static class ThemeExtensions
     {
         whenMethod ??= c => true;
         whenComponent ??= c => true;
-        order += RestApiLayer.MaxConventionOrder;
+        order += RestApiLayer.MaxConventionOrder * 2;
 
         conventions.AddMethodMetadata(
             attribute: c => new DescriptorBuilderAttribute<TSchema>()
@@ -343,7 +343,7 @@ public static class ThemeExtensions
     {
         whenParameter ??= c => true;
         whenComponent ??= c => true;
-        order += RestApiLayer.MaxConventionOrder;
+        order += RestApiLayer.MaxConventionOrder * 2;
 
         conventions.AddParameterMetadata(
             attribute: c => new DescriptorBuilderAttribute<TSchema>()
@@ -581,7 +581,7 @@ public static class ThemeExtensions
     {
         whenType ??= c => true;
         whenComponent ??= c => true;
-        order += RestApiLayer.MaxConventionOrder;
+        order += RestApiLayer.MaxConventionOrder * 2;
 
         conventions.AddTypeMetadata(
             apply: (c, add) =>
@@ -633,7 +633,7 @@ public static class ThemeExtensions
     {
         whenProperty ??= c => true;
         whenComponent ??= c => true;
-        order += RestApiLayer.MaxConventionOrder;
+        order += RestApiLayer.MaxConventionOrder * 2;
 
         conventions.AddPropertyMetadata(
             apply: (c, add) =>
@@ -685,7 +685,7 @@ public static class ThemeExtensions
     {
         whenMethod ??= c => true;
         whenComponent ??= c => true;
-        order += RestApiLayer.MaxConventionOrder;
+        order += RestApiLayer.MaxConventionOrder * 2;
 
         conventions.AddMethodMetadata(
             apply: (c, add) =>
@@ -737,7 +737,7 @@ public static class ThemeExtensions
     {
         whenParameter ??= c => true;
         whenComponent ??= c => true;
-        order += RestApiLayer.MaxConventionOrder;
+        order += RestApiLayer.MaxConventionOrder * 2;
 
         conventions.AddParameterMetadata(
             apply: (c, add) =>

--- a/test/recipe/admin/pages/specs/toast.vue
+++ b/test/recipe/admin/pages/specs/toast.vue
@@ -2,7 +2,7 @@
   <UiSpec title="Toast">
     <Message severity="info">
       <span class="text-xl">
-        ⬆️   Check if page has a success toast at top center ⬆️
+        ⬆️  Check if page has a success toast at top center ⬆️
       </span>
     </Message>
   </UiSpec>

--- a/unreleased.md
+++ b/unreleased.md
@@ -6,6 +6,8 @@
   - Introducing UI Conventions: `UiLayer` and `ThemeFeature` now provides
     several conventions and extension methods to allow you to build your page
     descriptors via conventions instead of configuring them one by one
+  - Introducing UX Features: many `UxFeature` implementations are provided to
+    deliver built-in user experiences that leverage the new UI convention system
 
 ## Improvements
 


### PR DESCRIPTION
Merge main into epic.

## Tasks

- [ ] Merge it

## Additional Tasks

- [x] In UX docs, first description paragraph of each feature should be placed
  before sample code
- [x] UI conventions should use its `RestApiLayer.MaxConventionOrder * 2` for
  the point zero, or its own center point constant (better)
  - this is because when we pass `-10` to a convention, it falls behind rest api
    layer
- [x] `toast.vue` has an extra whitespace, fix that
- [x] Revise relese notes
