### PR TITLE
Conventions as Configuration Target

### DIFF
--- a/core/playground/Baked.Playground.Application/Override/Domain/AuthenticationSamplesDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/AuthenticationSamplesDomainOverrideFeature.cs
@@ -7,7 +7,7 @@ public class AuthenticationSamplesDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddConfigureAction<AuthenticationSamples>(nameof(AuthenticationSamples.FormPostAuthenticate), useForm: true);
         });

--- a/core/playground/Baked.Playground.Application/Override/Domain/AuthenticationSamplesDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/AuthenticationSamplesDomainOverrideFeature.cs
@@ -7,9 +7,9 @@ public class AuthenticationSamplesDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddConfigureAction<AuthenticationSamples>(nameof(AuthenticationSamples.FormPostAuthenticate), useForm: true);
+            conventions.AddConfigureAction<AuthenticationSamples>(nameof(AuthenticationSamples.FormPostAuthenticate), useForm: true);
         });
     }
 }

--- a/core/playground/Baked.Playground.Application/Override/Domain/CacheSamplesDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/CacheSamplesDomainOverrideFeature.cs
@@ -8,7 +8,7 @@ public class CacheSamplesDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddTypeComponentConfiguration<TabbedPage>(
                 when: c => c.Type.Is<CacheSamples>(),

--- a/core/playground/Baked.Playground.Application/Override/Domain/CacheSamplesDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/CacheSamplesDomainOverrideFeature.cs
@@ -8,9 +8,9 @@ public class CacheSamplesDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddTypeComponentConfiguration<TabbedPage>(
+            conventions.AddTypeComponentConfiguration<TabbedPage>(
                 when: c => c.Type.Is<CacheSamples>(),
                 component: tp =>
                 {

--- a/core/playground/Baked.Playground.Application/Override/Domain/ChildDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/ChildDomainOverrideFeature.cs
@@ -9,7 +9,7 @@ public class ChildDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddLocateAction<Child>();
 

--- a/core/playground/Baked.Playground.Application/Override/Domain/ChildDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/ChildDomainOverrideFeature.cs
@@ -9,16 +9,16 @@ public class ChildDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddLocateAction<Child>();
+            conventions.AddLocateAction<Child>();
 
-            builder.Conventions.AddPropertyAttributeConfiguration<DataAttribute>(
+            conventions.AddPropertyAttributeConfiguration<DataAttribute>(
                 when: c => c.Type.Is<Child>() && c.Property.PropertyType.Is<ParentWrapper>() || c.Property.PropertyType.Is<IParentInterface>(),
                 attribute: data => data.Visible = false
             );
 
-            builder.Conventions.RemoveMethodAttribute<ActionAttribute>(
+            conventions.RemoveMethodAttribute<ActionAttribute>(
                 when: c => c.Type.Is<Child>(),
                 order: RestApiLayer.MaxConventionOrder + 15
             );

--- a/core/playground/Baked.Playground.Application/Override/Domain/CustomAttributeDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/CustomAttributeDomainOverrideFeature.cs
@@ -7,51 +7,51 @@ public class CustomAttributeDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: () => new CustomAttribute(),
                 when: c => c.Type.Is<Class>()
             );
-            builder.Conventions.AddTypeAttributeConfiguration<CustomAttribute>(
+            conventions.AddTypeAttributeConfiguration<CustomAttribute>(
                 attribute: attr => attr.Value = "FROM CONVENTION",
                 when: c => c.Type.Is<Class>()
             );
 
-            builder.Conventions.SetPropertyAttribute(
+            conventions.SetPropertyAttribute(
                 attribute: () => new CustomAttribute(),
                 when: c =>
                     c.Type.Is<Record>() &&
                     c.Property.Name == nameof(Record.Text)
             );
-            builder.Conventions.AddPropertyAttributeConfiguration<CustomAttribute>(
+            conventions.AddPropertyAttributeConfiguration<CustomAttribute>(
                 attribute: attr => attr.Value = "FROM CONVENTION",
                 when: c =>
                     c.Type.Is<Record>() &&
                     c.Property.Name == nameof(Record.Text)
             );
 
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 attribute: () => new CustomAttribute(),
                 when: c =>
                     c.Type.Is<Class>() &&
                     c.Method.Name == nameof(Class.Method)
             );
-            builder.Conventions.AddMethodAttributeConfiguration<CustomAttribute>(
+            conventions.AddMethodAttributeConfiguration<CustomAttribute>(
                 attribute: attr => attr.Value = "FROM CONVENTION",
                 when: c =>
                     c.Type.Is<Class>() &&
                     c.Method.Name == nameof(Class.Method)
             );
 
-            builder.Conventions.SetParameterAttribute(
+            conventions.SetParameterAttribute(
                 attribute: () => new CustomAttribute(),
                 when: c =>
                     c.Type.Is<MethodSamples>() &&
                     c.Method.Name == nameof(MethodSamples.PrimitiveParameters) &&
                     c.Parameter.Name == "string"
             );
-            builder.Conventions.AddParameterAttributeConfiguration<CustomAttribute>(
+            conventions.AddParameterAttributeConfiguration<CustomAttribute>(
                 attribute: attr => attr.Value = "FROM CONVENTION",
                 when: c =>
                     c.Type.Is<MethodSamples>() &&

--- a/core/playground/Baked.Playground.Application/Override/Domain/CustomAttributeDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/CustomAttributeDomainOverrideFeature.cs
@@ -7,7 +7,7 @@ public class CustomAttributeDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 attribute: () => new CustomAttribute(),

--- a/core/playground/Baked.Playground.Application/Override/Domain/DocumentationSamplesDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/DocumentationSamplesDomainOverrideFeature.cs
@@ -8,7 +8,7 @@ public class DocumentationSamplesDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddConfigureAction<DocumentationSamples>(nameof(DocumentationSamples.Route), parameter: p =>
             {

--- a/core/playground/Baked.Playground.Application/Override/Domain/DocumentationSamplesDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/DocumentationSamplesDomainOverrideFeature.cs
@@ -8,9 +8,9 @@ public class DocumentationSamplesDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddConfigureAction<DocumentationSamples>(nameof(DocumentationSamples.Route), parameter: p =>
+            conventions.AddConfigureAction<DocumentationSamples>(nameof(DocumentationSamples.Route), parameter: p =>
             {
                 p["route"].From = ParameterModelFrom.Route;
                 p["route"].RoutePosition = 2;

--- a/core/playground/Baked.Playground.Application/Override/Domain/EntityDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/EntityDomainOverrideFeature.cs
@@ -7,7 +7,7 @@ public class EntityDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddLocateAction<Entity>();
         });

--- a/core/playground/Baked.Playground.Application/Override/Domain/EntityDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/EntityDomainOverrideFeature.cs
@@ -7,9 +7,9 @@ public class EntityDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddLocateAction<Entity>();
+            conventions.AddLocateAction<Entity>();
         });
     }
 }

--- a/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAssignedGuidIdDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAssignedGuidIdDomainOverrideFeature.cs
@@ -8,7 +8,7 @@ public class EntityWithAssignedGuidIdDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddPropertyAttributeConfiguration<IdAttribute>(
                 when: c => c.Type.Is<EntityWithAssignedGuidId>(),

--- a/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAssignedGuidIdDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAssignedGuidIdDomainOverrideFeature.cs
@@ -8,9 +8,9 @@ public class EntityWithAssignedGuidIdDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddPropertyAttributeConfiguration<IdAttribute>(
+            conventions.AddPropertyAttributeConfiguration<IdAttribute>(
                 when: c => c.Type.Is<EntityWithAssignedGuidId>(),
                 attribute: id => id.AssignedGuid()
             );

--- a/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAssignedIdDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAssignedIdDomainOverrideFeature.cs
@@ -8,9 +8,9 @@ public class EntityWithAssignedIdDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddPropertyAttributeConfiguration<IdAttribute>(
+            conventions.AddPropertyAttributeConfiguration<IdAttribute>(
                 when: c => c.Type.Is<EntityWithAssignedId>(),
                 attribute: id => id.Assigned()
             );

--- a/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAssignedIdDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAssignedIdDomainOverrideFeature.cs
@@ -8,7 +8,7 @@ public class EntityWithAssignedIdDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddPropertyAttributeConfiguration<IdAttribute>(
                 when: c => c.Type.Is<EntityWithAssignedId>(),

--- a/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAutoIncrementIdDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAutoIncrementIdDomainOverrideFeature.cs
@@ -8,9 +8,9 @@ public class EntityWithAutoIncrementIdDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddPropertyAttributeConfiguration<IdAttribute>(
+            conventions.AddPropertyAttributeConfiguration<IdAttribute>(
                 when: c => c.Type.Is<EntityWithAutoIncrementId>(),
                 attribute: id => id.AutoIncrement()
             );

--- a/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAutoIncrementIdDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/EntityWithAutoIncrementIdDomainOverrideFeature.cs
@@ -8,7 +8,7 @@ public class EntityWithAutoIncrementIdDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddPropertyAttributeConfiguration<IdAttribute>(
                 when: c => c.Type.Is<EntityWithAutoIncrementId>(),

--- a/core/playground/Baked.Playground.Application/Override/Domain/ExceptionSamplesDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/ExceptionSamplesDomainOverrideFeature.cs
@@ -8,9 +8,9 @@ public class ExceptionSamplesDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddConfigureAction<ExceptionSamples>(nameof(ExceptionSamples.Throw), parameter: p => p["handled"].From = ParameterModelFrom.Query);
+            conventions.AddConfigureAction<ExceptionSamples>(nameof(ExceptionSamples.Throw), parameter: p => p["handled"].From = ParameterModelFrom.Query);
         });
     }
 }

--- a/core/playground/Baked.Playground.Application/Override/Domain/ExceptionSamplesDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/ExceptionSamplesDomainOverrideFeature.cs
@@ -8,7 +8,7 @@ public class ExceptionSamplesDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddConfigureAction<ExceptionSamples>(nameof(ExceptionSamples.Throw), parameter: p => p["handled"].From = ParameterModelFrom.Query);
         });

--- a/core/playground/Baked.Playground.Application/Override/Domain/FormSampleDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/FormSampleDomainOverrideFeature.cs
@@ -14,7 +14,7 @@ public class FormSampleDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddMethodAttributeConfiguration<ActionAttribute>(
                 when: c => c.Type.Is<FormSample>() && c.Method.Name == nameof(FormSample.NewParent),

--- a/core/playground/Baked.Playground.Application/Override/Domain/FormSampleDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/FormSampleDomainOverrideFeature.cs
@@ -14,24 +14,24 @@ public class FormSampleDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddMethodAttributeConfiguration<ActionAttribute>(
+            conventions.AddMethodAttributeConfiguration<ActionAttribute>(
                 when: c => c.Type.Is<FormSample>() && c.Method.Name == nameof(FormSample.NewParent),
                 attribute: (a, c) => a.RoutePathBack = "/form-sample"
             );
 
-            builder.Conventions.AddMethodAttributeConfiguration<ActionAttribute>(
+            conventions.AddMethodAttributeConfiguration<ActionAttribute>(
                 when: c => c.Type.Is<Parent>() && c.Method.Name.Contains("Child"),
                 attribute: a => a.HideInLists = true
             );
 
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 when: c => c.Type.Is<FormSample>() && c.Method.Name == nameof(FormSample.GetParents),
                 attribute: () => new QueryMethodAttribute()
             );
 
-            builder.Conventions.AddMethodComponentConfiguration<FormPage>(
+            conventions.AddMethodComponentConfiguration<FormPage>(
                 when: c => c.Type.Is<FormSample>() && c.Method.Name == nameof(FormSample.NewParent),
                 component: fp =>
                 {
@@ -41,7 +41,7 @@ public class FormSampleDomainOverrideFeature : IFeature
             );
 
             // Properties
-            builder.Conventions.AddPropertyComponent(
+            conventions.AddPropertyComponent(
                 when: c => c.Property.PropertyType.SkipNullable().IsEnum,
                 where: cc => cc.Path.StartsWith(nameof(Page), nameof(FormSample)),
                 component: () => B.Text()

--- a/core/playground/Baked.Playground.Application/Override/Domain/ILocatableDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/ILocatableDomainOverrideFeature.cs
@@ -8,7 +8,7 @@ public class ILocatableDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c => c.Type.Is<ILocatable>(),

--- a/core/playground/Baked.Playground.Application/Override/Domain/ILocatableDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/ILocatableDomainOverrideFeature.cs
@@ -8,9 +8,9 @@ public class ILocatableDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Is<ILocatable>(),
                 attribute: () => new LocatableAttribute()
             );

--- a/core/playground/Baked.Playground.Application/Override/Domain/OverrideSamplesDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/OverrideSamplesDomainOverrideFeature.cs
@@ -8,13 +8,13 @@ public class OverrideSamplesDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddOverrideAction<OverrideSamples>(nameof(OverrideSamples.UpdateRoute),
+            conventions.AddOverrideAction<OverrideSamples>(nameof(OverrideSamples.UpdateRoute),
                 routeParts: ["override-samples", "override", "update-route"],
                 method: HttpMethod.Post
             );
-            builder.Conventions.AddOverrideAction<OverrideSamples>(nameof(OverrideSamples.Parameter),
+            conventions.AddOverrideAction<OverrideSamples>(nameof(OverrideSamples.Parameter),
                 parameter: parameter =>
                 {
                     parameter["parameter"].Name = "id";
@@ -22,7 +22,7 @@ public class OverrideSamplesDomainOverrideFeature : IFeature
                     parameter["parameter"].RoutePosition = 2;
                 }
             );
-            builder.Conventions.AddOverrideAction<OverrideSamples>(nameof(OverrideSamples.RequestClass),
+            conventions.AddOverrideAction<OverrideSamples>(nameof(OverrideSamples.RequestClass),
                 useRequestClassForBody: false
             );
         });

--- a/core/playground/Baked.Playground.Application/Override/Domain/OverrideSamplesDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/OverrideSamplesDomainOverrideFeature.cs
@@ -8,7 +8,7 @@ public class OverrideSamplesDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddOverrideAction<OverrideSamples>(nameof(OverrideSamples.UpdateRoute),
                 routeParts: ["override-samples", "override", "update-route"],

--- a/core/playground/Baked.Playground.Application/Override/Domain/ParentDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/ParentDomainOverrideFeature.cs
@@ -13,24 +13,24 @@ public class ParentDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddLocateAction<Parent>();
-            builder.Conventions.AddEntityRemoteData<Parent>();
+            conventions.AddLocateAction<Parent>();
+            conventions.AddEntityRemoteData<Parent>();
 
-            builder.Conventions.SetPropertyAttribute(
+            conventions.SetPropertyAttribute(
                 when: c => c.Type.Is<Parent>() && c.Property.Name == nameof(Parent.Surname),
                 attribute: () => new LabelAttribute()
             );
 
-            builder.Conventions.RemoveMethodAttribute<ActionAttribute>(
+            conventions.RemoveMethodAttribute<ActionAttribute>(
                 when: c => c.Type.Is<Parent>() && c.Method.Name == nameof(Parent.RemoveChild),
                 order: RestApiLayer.MaxConventionOrder + 15
             );
 
             // Move `AddChild` action to contents
             {
-                builder.Conventions.AddTypeComponentConfiguration<PageTitle>(
+                conventions.AddTypeComponentConfiguration<PageTitle>(
                     when: c => c.Type.Is<Parent>(),
                     component: (pt, c) =>
                     {
@@ -41,7 +41,7 @@ public class ParentDomainOverrideFeature : IFeature
                     }
                 );
 
-                builder.Conventions.AddTypeComponentConfiguration<SimplePage>(
+                conventions.AddTypeComponentConfiguration<SimplePage>(
                     when: c => c.Type.Is<Parent>(),
                     component: (dp, c, cc) =>
                     {
@@ -54,17 +54,17 @@ public class ParentDomainOverrideFeature : IFeature
                 );
             }
 
-            builder.Conventions.AddMethodSchemaConfiguration<Content>(
+            conventions.AddMethodSchemaConfiguration<Content>(
                 when: c => c.Type.Is<Parent>() && c.Method.Name == nameof(Parent.AddChild),
                 schema: s => s.Side = true
             );
 
-            builder.Conventions.AddTypeComponentConfiguration<Fieldset>(
+            conventions.AddTypeComponentConfiguration<Fieldset>(
                 when: c => c.Type.Is<Parent>(),
                 component: dt => dt.ReloadOn(nameof(Parent.Update).Kebaberize())
             );
 
-            builder.Conventions.AddMethodComponentConfiguration<DataTable>(
+            conventions.AddMethodComponentConfiguration<DataTable>(
                 when: c => c.Type.Is<Parent>() && c.Method.Name == nameof(Parent.GetChildren),
                 component: dt => dt.ReloadOn(nameof(Parent.AddChild).Kebaberize())
             );

--- a/core/playground/Baked.Playground.Application/Override/Domain/ParentDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/ParentDomainOverrideFeature.cs
@@ -13,7 +13,7 @@ public class ParentDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddLocateAction<Parent>();
             conventions.AddEntityRemoteData<Parent>();

--- a/core/playground/Baked.Playground.Application/Override/Domain/ReportPageSampleDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/ReportPageSampleDomainOverrideFeature.cs
@@ -14,7 +14,7 @@ public class ReportPageSampleDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             // Tabs
             conventions.AddMethodAttributeConfiguration<GroupAttribute>(

--- a/core/playground/Baked.Playground.Application/Override/Domain/ReportPageSampleDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/ReportPageSampleDomainOverrideFeature.cs
@@ -14,46 +14,46 @@ public class ReportPageSampleDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
             // Tabs
-            builder.Conventions.AddMethodAttributeConfiguration<GroupAttribute>(
+            conventions.AddMethodAttributeConfiguration<GroupAttribute>(
                 when: c => c.Type.Is<ReportPageSample>() && c.Method.DefaultOverload.ReturnType.SkipTask().Is<string>(),
                 attribute: group => group.TabName = "SingleValue"
             );
-            builder.Conventions.AddMethodAttributeConfiguration<GroupAttribute>(
+            conventions.AddMethodAttributeConfiguration<GroupAttribute>(
                 when: c => c.Type.Is<ReportPageSample>() && c.Method.DefaultOverload.ReturnsList(),
                 attribute: group => group.TabName = "DataTable"
             );
-            builder.Conventions.AddTypeComponent(
+            conventions.AddTypeComponent(
                 when: c => c.Type.Is<ReportPageSample>(),
                 where: cc => cc.Path.EndsWith("SingleValue", nameof(Tab.Icon)),
                 component: () => B.Icon("pi-box")
             );
-            builder.Conventions.AddTypeComponent(
+            conventions.AddTypeComponent(
                 when: c => c.Type.Is<ReportPageSample>(),
                 where: cc => cc.Path.EndsWith("DataTable", nameof(Tab.Icon)),
                 component: () => B.Icon("pi-table")
             );
 
             // Allowing admin token for report api
-            builder.Conventions.AddMethodSchemaConfiguration<RemoteData>(
+            conventions.AddMethodSchemaConfiguration<RemoteData>(
                 when: c => c.Type.Is<ReportPageSample>(),
                 schema: rd => rd.Headers = Inline(new { Authorization = "token-admin-ui" })
             );
 
             // Parameter overrides
-            builder.Conventions.AddParameterComponent(
+            conventions.AddParameterComponent(
                 when: c => c.Type.Is<ReportPageSample>() && c.Method.Name == nameof(ReportPageSample.With) && !c.Parameter.IsNullable,
                 component: (c, cc) => ParameterSelect(c.Parameter, cc)
             );
-            builder.Conventions.AddParameterComponent(
+            conventions.AddParameterComponent(
                 when: c => c.Type.Is<ReportPageSample>() && c.Method.Name == nameof(ReportPageSample.GetFirst) && c.Parameter.Name == "count",
                 component: (c, cc) => ParameterSelect(c.Parameter, cc)
             );
 
             // Page overrides
-            builder.Conventions.AddTypeComponentConfiguration<TabbedPage>(
+            conventions.AddTypeComponentConfiguration<TabbedPage>(
                 when: c => c.Type.Is<ReportPageSample>(),
                 component: tp =>
                 {

--- a/core/playground/Baked.Playground.Application/Override/Domain/RouteSampleDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/RouteSampleDomainOverrideFeature.cs
@@ -7,7 +7,7 @@ public class RouteSampleDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddLocateAction<RouteSample>();
         });

--- a/core/playground/Baked.Playground.Application/Override/Domain/RouteSampleDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/RouteSampleDomainOverrideFeature.cs
@@ -7,9 +7,9 @@ public class RouteSampleDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddLocateAction<RouteSample>();
+            conventions.AddLocateAction<RouteSample>();
         });
     }
 }

--- a/core/playground/Baked.Playground.Application/Override/Domain/TestPageDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/TestPageDomainOverrideFeature.cs
@@ -14,25 +14,25 @@ public class TestPageDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddTypeComponent(
+            conventions.AddTypeComponent(
                 when: c => c.Type.Is<TestPage>(),
                 where: cc => cc.Path.EndsWith(nameof(Page)),
                 component: () => B.TabbedPage("test-page", B.PageTitle("Test Page"))
             );
-            builder.Conventions.AddTypeComponentConfiguration<TabbedPage>(
+            conventions.AddTypeComponentConfiguration<TabbedPage>(
                 when: c => c.Type.Is<TestPage>(),
                 component: (tp, c, cc) => tp.Schema.Tabs.AddRange(
                     c.Type.GenerateSchemas<Tab>(cc.Drill(nameof(TabbedPage.Tabs)))
                 )
             );
-            builder.Conventions.AddTypeSchema(
+            conventions.AddTypeSchema(
                 when: c => c.Type.Is<TestPage>(),
                 where: cc => cc.Path.EndsWith(nameof(TabbedPage.Tabs)),
                 schema: (c, cc) => B.Tab("default")
             );
-            builder.Conventions.AddTypeSchemaConfiguration<Tab>(
+            conventions.AddTypeSchemaConfiguration<Tab>(
                 when: c => c.Type.Is<TestPage>(),
                 schema: (t, c, cc) => t.Contents.Add(
                     c.Type
@@ -41,21 +41,21 @@ public class TestPageDomainOverrideFeature : IFeature
                 )
             );
 
-            builder.Conventions.AddMethodSchema(
+            conventions.AddMethodSchema(
                 when: c => c.Type.Is<TestPage>() && c.Method.Name == nameof(TestPage.GetData),
                 where: cc => cc.Path.EndsWith(nameof(Tab.Contents), 0),
                 schema: (c, cc) => B.Content(component: c.Method.GenerateRequiredComponent(cc.Drill(nameof(Content.Component))), c.Method.Name.Kebaberize())
             );
-            builder.Conventions.AddMethodSchemaConfiguration<Content>(
+            conventions.AddMethodSchemaConfiguration<Content>(
                 when: c => c.Type.Is<TestPage>() && c.Method.Name == nameof(TestPage.GetData),
                 schema: tabContent => tabContent.Narrow = true
             );
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c => c.Type.Is<TestPage>() && c.Method.Name == nameof(TestPage.GetData),
                 where: cc => cc.Path.EndsWith(nameof(Content.Component)),
                 component: (c, cc) => MethodText(c.Method, cc)
             );
-            builder.Conventions.AddMethodComponentConfiguration<Text>(
+            conventions.AddMethodComponentConfiguration<Text>(
                 when: c => c.Type.Is<TestPage>() && c.Method.Name == nameof(TestPage.GetData),
                 component: t => t.Schema.MaxLength = 20
             );

--- a/core/playground/Baked.Playground.Application/Override/Domain/TestPageDomainOverrideFeature.cs
+++ b/core/playground/Baked.Playground.Application/Override/Domain/TestPageDomainOverrideFeature.cs
@@ -14,7 +14,7 @@ public class TestPageDomainOverrideFeature : IFeature
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddTypeComponent(
                 when: c => c.Type.Is<TestPage>(),

--- a/core/playground/Baked.Playground.Application/Theme/Custom/CustomThemeFeature.cs
+++ b/core/playground/Baked.Playground.Application/Theme/Custom/CustomThemeFeature.cs
@@ -32,10 +32,10 @@ public class CustomThemeFeature(IEnumerable<Func<Router, Route>> routes)
     {
         base.Configure(configurator);
 
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
             // Custom theme CSV formatter settings
-            builder.Conventions.AddMethodSchemaConfiguration<DataTable.Export>(
+            conventions.AddMethodSchemaConfiguration<DataTable.Export>(
                 schema: (dte, _, cc) =>
                 {
                     var (_, l) = cc;
@@ -49,18 +49,18 @@ public class CustomThemeFeature(IEnumerable<Func<Router, Route>> routes)
             );
 
             // String api rendering
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c => c.Method.DefaultOverload.ReturnType.Is<string>(),
                 where: cc => cc.Path.EndsWith(nameof(DataPanel), nameof(DataPanel.Content)),
                 component: (c, cc) => MethodText(c.Method, cc)
             );
-            builder.Conventions.AddMethodComponentConfiguration<Text>(
+            conventions.AddMethodComponentConfiguration<Text>(
                 component: t => t.Override(C.MyText())
             );
-            builder.Conventions.AddMethodComponentConfiguration<Text>(
+            conventions.AddMethodComponentConfiguration<Text>(
                 component: t => t.Schema.MaxLength = 100
             );
-            builder.Conventions.AddMethodComponentConfiguration<Text>(
+            conventions.AddMethodComponentConfiguration<Text>(
                 component: t =>
                 {
                     if (t.Schema is not MyText mt) { return; }
@@ -70,14 +70,14 @@ public class CustomThemeFeature(IEnumerable<Func<Router, Route>> routes)
             );
 
             // Non-localized enums
-            builder.Conventions.AddTypeSchema(
+            conventions.AddTypeSchema(
                 schema: (c, cc) => EnumInline(c.Type, cc, requireLocalization: false),
                 when: c => c.Type.Is<CacheKey>() || c.Type.Is<RowCount>()
             );
 
             // Custom routes
-            builder.Conventions.SetTypeRoute<Parent>("/parents/[id]");
-            builder.Conventions.SetMethodRoute<FormSample>(nameof(FormSample.NewParent), "/form-sample/parents/new");
+            conventions.SetTypeRoute<Parent>("/parents/[id]");
+            conventions.SetMethodRoute<FormSample>(nameof(FormSample.NewParent), "/form-sample/parents/new");
         });
 
         configurator.Ui.ConfigureComponentExports(c =>

--- a/core/playground/Baked.Playground.Application/Theme/Custom/CustomThemeFeature.cs
+++ b/core/playground/Baked.Playground.Application/Theme/Custom/CustomThemeFeature.cs
@@ -32,7 +32,7 @@ public class CustomThemeFeature(IEnumerable<Func<Router, Route>> routes)
     {
         base.Configure(configurator);
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             // Custom theme CSV formatter settings
             conventions.AddMethodSchemaConfiguration<DataTable.Export>(

--- a/core/src/Baked/Authorization/ClaimBased/ClaimBasedAuthorizationFeature.cs
+++ b/core/src/Baked/Authorization/ClaimBased/ClaimBasedAuthorizationFeature.cs
@@ -12,21 +12,21 @@ public class ClaimBasedAuthorizationFeature(IEnumerable<string> _claims, IEnumer
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 when: c => !c.Method.Has<RequireUserAttribute>() && c.Type.Has<AllowAnonymousAttribute>(),
                 attribute: c => c.Type.Get<AllowAnonymousAttribute>()
             );
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 when: c => !c.Method.Has<RequireUserAttribute>() && c.Type.Has<RequireUserAttribute>(),
                 attribute: c => c.Type.Get<RequireUserAttribute>()
             );
 
-            builder.Conventions.Add(new AllowAnonymousIsAllowAnonymousConvention(), order: RestApiLayer.MaxConventionOrder - 10);
-            builder.Conventions.Add(new RequireUserIsAuthorizeConvention(), order: RestApiLayer.MaxConventionOrder - 10);
-            builder.Conventions.Add(new AddBaseClaimsAsAuthorizePolicyConvention(_baseClaims), order: RestApiLayer.MaxConventionOrder - 10);
-            builder.Conventions.Add(new AddRequireUserClaimsAsAuthorizePolicyConvention(), order: RestApiLayer.MaxConventionOrder - 10);
+            conventions.Add(new AllowAnonymousIsAllowAnonymousConvention(), order: RestApiLayer.MaxConventionOrder - 10);
+            conventions.Add(new RequireUserIsAuthorizeConvention(), order: RestApiLayer.MaxConventionOrder - 10);
+            conventions.Add(new AddBaseClaimsAsAuthorizePolicyConvention(_baseClaims), order: RestApiLayer.MaxConventionOrder - 10);
+            conventions.Add(new AddRequireUserClaimsAsAuthorizePolicyConvention(), order: RestApiLayer.MaxConventionOrder - 10);
         });
 
         configurator.Domain.ConfigureExportConfigurations(exports =>

--- a/core/src/Baked/Authorization/ClaimBased/ClaimBasedAuthorizationFeature.cs
+++ b/core/src/Baked/Authorization/ClaimBased/ClaimBasedAuthorizationFeature.cs
@@ -12,7 +12,7 @@ public class ClaimBasedAuthorizationFeature(IEnumerable<string> _claims, IEnumer
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetMethodAttribute(
                 when: c => !c.Method.Has<RequireUserAttribute>() && c.Type.Has<AllowAnonymousAttribute>(),

--- a/core/src/Baked/Binding/Rest/RestBindingFeature.cs
+++ b/core/src/Baked/Binding/Rest/RestBindingFeature.cs
@@ -23,9 +23,12 @@ public class RestBindingFeature : IFeature<BindingConfigurator>
             builder.Index.Type.Add<ApiInputAttribute>();
             builder.Index.Method.Add<ActionModelAttribute>();
             builder.Index.Parameter.Add<ParameterModelAttribute>();
+        });
 
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
             // domain attribute mutations
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: c => new ControllerModelAttribute(),
                 when: c =>
                   c.Type.Has<ServiceAttribute>() &&
@@ -36,7 +39,7 @@ public class RestBindingFeature : IFeature<BindingConfigurator>
                   members.Methods.Any(m => m.DefaultOverload.IsPublicInstanceWithNoSpecialName),
               order: 10
             );
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 attribute: c => new ActionModelAttribute(),
                 when: c =>
                     !c.Method.Has<ExternalAttribute>() &&
@@ -45,15 +48,15 @@ public class RestBindingFeature : IFeature<BindingConfigurator>
                     c.Method.DefaultOverload.AllParametersAreApiInput(),
                 order: RestApiLayer.MaxConventionOrder
             );
-            builder.Conventions.SetParameterAttribute(
+            conventions.SetParameterAttribute(
                 attribute: c => new ParameterModelAttribute(),
                 when: c => c.Parameter.IsApiInput,
                 order: RestApiLayer.MaxConventionOrder
             );
 
             // init before any domain convention
-            builder.Conventions.Add(new InitApiModelConvention(), order: int.MinValue);
-            builder.Conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(
+            conventions.Add(new InitApiModelConvention(), order: int.MinValue);
+            conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(
                 attribute: (action, context) =>
                     action.Parameter[ParameterModelAttribute.TargetParameterName] =
                         new(ParameterModelAttribute.TargetParameterName, context.Type.CSharpFriendlyFullName, ParameterModelFrom.Services),
@@ -61,28 +64,28 @@ public class RestBindingFeature : IFeature<BindingConfigurator>
             );
 
             // rest api conventions
-            builder.Conventions.Add(new AutoHttpMethodConvention([
+            conventions.Add(new AutoHttpMethodConvention([
                 (Regexes.StartsWithGet, HttpMethod.Get),
                 (Regexes.IsUpdateChangeOrSet, HttpMethod.Put),
                 (Regexes.StartsWithUpdateChangeOrSet, HttpMethod.Patch),
                 (Regexes.StartsWithDeleteRemoveOrClear, HttpMethod.Delete)
             ]));
-            builder.Conventions.Add(new GetAndDeleteAcceptsOnlyQueryConvention());
-            builder.Conventions.Add(new RemoveFromRouteConvention(["Get"]));
-            builder.Conventions.Add(new RemoveFromRouteConvention(["Update", "Change", "Set"]));
-            builder.Conventions.Add(new RemoveFromRouteConvention(["Delete", "Remove", "Clear"]));
-            builder.Conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(
+            conventions.Add(new GetAndDeleteAcceptsOnlyQueryConvention());
+            conventions.Add(new RemoveFromRouteConvention(["Get"]));
+            conventions.Add(new RemoveFromRouteConvention(["Update", "Change", "Set"]));
+            conventions.Add(new RemoveFromRouteConvention(["Delete", "Remove", "Clear"]));
+            conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(
                 attribute: action => action.AdditionalAttributes.Add("Consumes(\"application/json\")"),
                 when: (_, action) => action.HasBody,
                 order: 10
             );
-            builder.Conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(
+            conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(
                 attribute: action => action.AdditionalAttributes.Add("Produces(\"application/json\")"),
                 when: (_, action) => !action.ReturnIsVoid,
                 order: 10
             );
-            builder.Conventions.Add(new UseDocumentationAsDescriptionConvention(_tagDescriptions, _examples), order: 10);
-            builder.Conventions.AddMethodAttributeConfiguration<ActionModelAttribute>((action, context) =>
+            conventions.Add(new UseDocumentationAsDescriptionConvention(_tagDescriptions, _examples), order: 10);
+            conventions.AddMethodAttributeConfiguration<ActionModelAttribute>((action, context) =>
                 action.AdditionalAttributes.Add($"{typeof(MappedMethodAttribute).FullName}(\"{context.Type.FullName}\", \"{context.Method.Name}\")")
             );
         });

--- a/core/src/Baked/Binding/Rest/RestBindingFeature.cs
+++ b/core/src/Baked/Binding/Rest/RestBindingFeature.cs
@@ -16,7 +16,7 @@ public class RestBindingFeature : IFeature<BindingConfigurator>
 
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             // domain attribute indices
             builder.Index.Type.Add<ControllerModelAttribute>();

--- a/core/src/Baked/Binding/Rest/RestBindingFeature.cs
+++ b/core/src/Baked/Binding/Rest/RestBindingFeature.cs
@@ -25,7 +25,7 @@ public class RestBindingFeature : IFeature<BindingConfigurator>
             builder.Index.Parameter.Add<ParameterModelAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             // domain attribute mutations
             conventions.SetTypeAttribute(

--- a/core/src/Baked/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
+++ b/core/src/Baked/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
@@ -67,29 +67,32 @@ public class DomainAssembliesBusinessFeature(
             builder.Index.Method.Add<InitializerAttribute>();
             builder.Index.Property.Add<IdAttribute>();
             builder.Index.Property.Add<LabelAttribute>();
+        });
 
-            builder.Conventions.SetTypeAttribute(
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            conventions.SetTypeAttribute(
                 when: _ => true,
                 attribute: () => new GroupAttribute(),
                 order: int.MinValue + 10
             );
-            builder.Conventions.SetPropertyAttribute(
+            conventions.SetPropertyAttribute(
                 when: _ => true,
                 attribute: () => new GroupAttribute(),
                 order: int.MinValue + 10
             );
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 when: _ => true,
                 attribute: () => new GroupAttribute(),
                 order: int.MinValue + 10
             );
-            builder.Conventions.SetParameterAttribute(
+            conventions.SetParameterAttribute(
                 when: _ => true,
                 attribute: () => new GroupAttribute(),
                 order: int.MinValue + 10
             );
 
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: context =>
                 {
                     var @namespace = context.Type.Namespace ?? string.Empty;
@@ -107,7 +110,7 @@ public class DomainAssembliesBusinessFeature(
                 },
                 when: c => setNamespaceWhen(c.Type)
             );
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: () => new ServiceAttribute(),
                 when: c =>
                     c.Type.IsPublic &&
@@ -120,7 +123,7 @@ public class DomainAssembliesBusinessFeature(
                     !members.Methods.Contains("<Clone>$") // if type is record
             );
 
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 attribute: () => new ExternalAttribute(),
                 when: c =>
                     c.Method.DefaultOverload.DeclaringType is not null &&
@@ -128,7 +131,7 @@ public class DomainAssembliesBusinessFeature(
                     !metadata.Has<ServiceAttribute>()
             );
 
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 attribute: () => new ExternalAttribute(),
                 when: c =>
                     c.Method.DefaultOverload.BaseDefinition is not null &&
@@ -137,7 +140,7 @@ public class DomainAssembliesBusinessFeature(
                     !metadata.Has<ServiceAttribute>()
             );
 
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: () => new CasterAttribute(),
                 when: c => c.Type.IsClass && !c.Type.IsAbstract && c.Type.IsAssignableTo(typeof(ICasts<,>))
             );

--- a/core/src/Baked/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
+++ b/core/src/Baked/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
@@ -49,7 +49,7 @@ public class DomainAssembliesBusinessFeature(
             """);
         });
 
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.BindingFlags.Constructor = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
             builder.BindingFlags.Method = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;

--- a/core/src/Baked/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
+++ b/core/src/Baked/Business/DomainAssemblies/DomainAssembliesBusinessFeature.cs
@@ -69,7 +69,7 @@ public class DomainAssembliesBusinessFeature(
             builder.Index.Property.Add<LabelAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: _ => true,

--- a/core/src/Baked/Caching/InMemory/InMemoryCachingFeature.cs
+++ b/core/src/Baked/Caching/InMemory/InMemoryCachingFeature.cs
@@ -11,7 +11,7 @@ public class InMemoryCachingFeature(Action<MemoryCacheOptions> _options, Setting
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddMethodSchemaConfiguration<RemoteData>(
                 schema: rd => rd.SetAttribute("client-cache", "application"),

--- a/core/src/Baked/Caching/InMemory/InMemoryCachingFeature.cs
+++ b/core/src/Baked/Caching/InMemory/InMemoryCachingFeature.cs
@@ -11,9 +11,9 @@ public class InMemoryCachingFeature(Action<MemoryCacheOptions> _options, Setting
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddMethodSchemaConfiguration<RemoteData>(
+            conventions.AddMethodSchemaConfiguration<RemoteData>(
                 schema: rd => rd.SetAttribute("client-cache", "application"),
                 when: c => c.Method.TryGet<ClientCacheAttribute>(out var clientCache) && clientCache.Type == "application"
             );

--- a/core/src/Baked/Caching/ScopedMemory/ScopedMemoryCachingFeature.cs
+++ b/core/src/Baked/Caching/ScopedMemory/ScopedMemoryCachingFeature.cs
@@ -11,7 +11,7 @@ public class ScopedMemoryCachingFeature(Setting<TimeSpan> clientExpiration)
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddMethodSchemaConfiguration<RemoteData>(
                 schema: rd => rd.SetAttribute("client-cache", "user"),

--- a/core/src/Baked/Caching/ScopedMemory/ScopedMemoryCachingFeature.cs
+++ b/core/src/Baked/Caching/ScopedMemory/ScopedMemoryCachingFeature.cs
@@ -11,9 +11,9 @@ public class ScopedMemoryCachingFeature(Setting<TimeSpan> clientExpiration)
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddMethodSchemaConfiguration<RemoteData>(
+            conventions.AddMethodSchemaConfiguration<RemoteData>(
                 schema: rd => rd.SetAttribute("client-cache", "user"),
                 when: c => c.Method.TryGet<ClientCacheAttribute>(out var clientCache) && clientCache.Type == "user"
             );

--- a/core/src/Baked/CodingStyle/AddRemoveChild/AddRemoveChildCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/AddRemoveChild/AddRemoveChildCodingStyleFeature.cs
@@ -10,9 +10,9 @@ public class AddRemoveChildCodingStyleFeature : IFeature<CodingStyleConfigurator
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(
+            conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(
                 attribute: action =>
                 {
                     var newName = action.Name.Pluralize();
@@ -23,8 +23,8 @@ public class AddRemoveChildCodingStyleFeature : IFeature<CodingStyleConfigurator
                     (action.Method == HttpMethod.Delete && action.RouteParts.Count >= 2) ||
                     (action.Method == HttpMethod.Post && Regexes.StartsWithAddCreateOrNew.IsMatch(action.Name) && action.RouteParts.Count >= 2)
             );
-            builder.Conventions.Add(new OnlyLocatableParameterIsInRouteForDeleteChildConvention());
-            builder.Conventions.Add(new RemoveFromRouteConvention(["Add", "Create", "New"]));
+            conventions.Add(new OnlyLocatableParameterIsInRouteForDeleteChildConvention());
+            conventions.Add(new RemoveFromRouteConvention(["Add", "Create", "New"]));
         });
     }
 }

--- a/core/src/Baked/CodingStyle/AddRemoveChild/AddRemoveChildCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/AddRemoveChild/AddRemoveChildCodingStyleFeature.cs
@@ -10,7 +10,7 @@ public class AddRemoveChildCodingStyleFeature : IFeature<CodingStyleConfigurator
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(
                 attribute: action =>

--- a/core/src/Baked/CodingStyle/Client/ClientCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Client/ClientCodingStyleFeature.cs
@@ -13,7 +13,7 @@ public class ClientCodingStyleFeature : IFeature<CodingStyleConfigurator>
             builder.Index.Type.Add<ClientAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c => c.Type.IsInterface && c.Type.Name.EndsWith("Client"),

--- a/core/src/Baked/CodingStyle/Client/ClientCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Client/ClientCodingStyleFeature.cs
@@ -11,12 +11,15 @@ public class ClientCodingStyleFeature : IFeature<CodingStyleConfigurator>
         configurator.Domain.ConfigureDomainModelBuilder(builder =>
         {
             builder.Index.Type.Add<ClientAttribute>();
+        });
 
-            builder.Conventions.SetTypeAttribute(
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            conventions.SetTypeAttribute(
                 when: c => c.Type.IsInterface && c.Type.Name.EndsWith("Client"),
                 attribute: () => new ClientAttribute()
             );
-            builder.Conventions.RemoveTypeAttribute<ControllerModelAttribute>(
+            conventions.RemoveTypeAttribute<ControllerModelAttribute>(
                 when: c => c.Type.Name.EndsWith("Client"),
                 order: RestApiLayer.MaxConventionOrder - 10
             );

--- a/core/src/Baked/CodingStyle/Client/ClientCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Client/ClientCodingStyleFeature.cs
@@ -8,7 +8,7 @@ public class ClientCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add<ClientAttribute>();
         });

--- a/core/src/Baked/CodingStyle/CommandPattern/CommandPatternCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/CommandPattern/CommandPatternCodingStyleFeature.cs
@@ -13,9 +13,9 @@ public class CommandPatternCodingStyleFeature(IEnumerable<string> _methodNames)
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: () => new PubliclyInitializableAttribute(),
                 when: c =>
                     c.Type.TryGetMembers(out var members) &&
@@ -28,7 +28,7 @@ public class CommandPatternCodingStyleFeature(IEnumerable<string> _methodNames)
                     ),
                 order: 40
             );
-            builder.Conventions.RemoveTypeAttribute<ControllerModelAttribute>(
+            conventions.RemoveTypeAttribute<ControllerModelAttribute>(
                 when: c =>
                     c.Type.Has<TransientAttribute>() &&
                     !c.Type.Has<LocatableAttribute>() &&
@@ -36,18 +36,18 @@ public class CommandPatternCodingStyleFeature(IEnumerable<string> _methodNames)
                 order: 40
             );
 
-            builder.Conventions.Add(new IncludeClassDocsForActionNamesConvention(_methodNames), order: -10);
-            builder.Conventions.Add(new UseClassNameInsteadOfActionNamesConvention(_methodNames), order: -10);
-            builder.Conventions.Add(new RemoveFromRouteConvention(_methodNames));
-            builder.Conventions.Add(new RemoveFromRouteConvention(["Sync", "Create"]));
-            builder.Conventions.Add(new UseRootPathAsGroupNameForSingleMethodNonLocatablesConvention());
+            conventions.Add(new IncludeClassDocsForActionNamesConvention(_methodNames), order: -10);
+            conventions.Add(new UseClassNameInsteadOfActionNamesConvention(_methodNames), order: -10);
+            conventions.Add(new RemoveFromRouteConvention(_methodNames));
+            conventions.Add(new RemoveFromRouteConvention(["Sync", "Create"]));
+            conventions.Add(new UseRootPathAsGroupNameForSingleMethodNonLocatablesConvention());
 
-            builder.Conventions.Add(new NoRequestBodyForSingleEnumerableParametersConvention(
+            conventions.Add(new NoRequestBodyForSingleEnumerableParametersConvention(
                 _when: action => action.Name.StartsWith("Sync"),
                 _method: HttpMethod.Put
             ), order: -10);
 
-            builder.Conventions.Add(new NoRequestBodyForSingleEnumerableParametersConvention(
+            conventions.Add(new NoRequestBodyForSingleEnumerableParametersConvention(
                 _when: action => action.Name.StartsWith("Create"),
                 _method: HttpMethod.Patch
             ), order: -10);

--- a/core/src/Baked/CodingStyle/CommandPattern/CommandPatternCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/CommandPattern/CommandPatternCodingStyleFeature.cs
@@ -13,7 +13,7 @@ public class CommandPatternCodingStyleFeature(IEnumerable<string> _methodNames)
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 attribute: () => new PubliclyInitializableAttribute(),

--- a/core/src/Baked/CodingStyle/EntitySubclass/EntitySubclassCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/EntitySubclass/EntitySubclassCodingStyleFeature.cs
@@ -15,7 +15,7 @@ public class EntitySubclassCodingStyleFeature : IFeature<CodingStyleConfigurator
             builder.Index.Type.Add<EntitySubclassAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c =>

--- a/core/src/Baked/CodingStyle/EntitySubclass/EntitySubclassCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/EntitySubclass/EntitySubclassCodingStyleFeature.cs
@@ -13,8 +13,11 @@ public class EntitySubclassCodingStyleFeature : IFeature<CodingStyleConfigurator
         configurator.Domain.ConfigureDomainModelBuilder(builder =>
         {
             builder.Index.Type.Add<EntitySubclassAttribute>();
+        });
 
-            builder.Conventions.SetTypeAttribute(
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            conventions.SetTypeAttribute(
                 when: c =>
                     c.Type.IsClass &&
                     !c.Type.IsAbstract &&
@@ -31,7 +34,7 @@ public class EntitySubclassCodingStyleFeature : IFeature<CodingStyleConfigurator
                 },
                 order: 10
             );
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Has<EntitySubclassAttribute>(),
                 apply: (c, set) =>
                 {
@@ -53,7 +56,7 @@ public class EntitySubclassCodingStyleFeature : IFeature<CodingStyleConfigurator
                 },
                 order: 40
             );
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 attribute: c => new ActionModelAttribute(),
                 when: c =>
                     c.Type.Has<EntitySubclassAttribute>() && c.Method.Has<InitializerAttribute>() &&
@@ -61,10 +64,10 @@ public class EntitySubclassCodingStyleFeature : IFeature<CodingStyleConfigurator
                 order: 30
             );
 
-            builder.Conventions.Add(new UniqueIdParameterConvention(), order: RestApiLayer.MaxConventionOrder - 20);
-            builder.Conventions.Add(new EntitySubclassUnderEntitiesConvention(), order: RestApiLayer.MaxConventionOrder);
-            builder.Conventions.Add(new EntitySubclassInitializerIsPostResourceConvention(), order: RestApiLayer.MaxConventionOrder);
-            builder.Conventions.Add(new AddSubclassNameToRouteConvention(), order: RestApiLayer.MaxConventionOrder);
+            conventions.Add(new UniqueIdParameterConvention(), order: RestApiLayer.MaxConventionOrder - 20);
+            conventions.Add(new EntitySubclassUnderEntitiesConvention(), order: RestApiLayer.MaxConventionOrder);
+            conventions.Add(new EntitySubclassInitializerIsPostResourceConvention(), order: RestApiLayer.MaxConventionOrder);
+            conventions.Add(new AddSubclassNameToRouteConvention(), order: RestApiLayer.MaxConventionOrder);
         });
 
         configurator.Buildtime.ConfigureGeneratedAssemblyCollection(generatedAssemblies =>

--- a/core/src/Baked/CodingStyle/EntitySubclass/EntitySubclassCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/EntitySubclass/EntitySubclassCodingStyleFeature.cs
@@ -10,7 +10,7 @@ public class EntitySubclassCodingStyleFeature : IFeature<CodingStyleConfigurator
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add<EntitySubclassAttribute>();
         });

--- a/core/src/Baked/CodingStyle/Id/IdCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Id/IdCodingStyleFeature.cs
@@ -13,7 +13,7 @@ public class IdCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.RemoveTypeAttribute<ValueTypeAttribute>(
                 when: c => c.Type.Is<Business.Id>(),

--- a/core/src/Baked/CodingStyle/Id/IdCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Id/IdCodingStyleFeature.cs
@@ -13,13 +13,13 @@ public class IdCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.RemoveTypeAttribute<ValueTypeAttribute>(
+            conventions.RemoveTypeAttribute<ValueTypeAttribute>(
                 when: c => c.Type.Is<Business.Id>(),
                 order: 10
             );
-            builder.Conventions.SetPropertyAttribute(
+            conventions.SetPropertyAttribute(
                 when: c => c.Property.PropertyType.Is<Business.Id>(),
                 attribute: c => new IdAttribute(c.Property.Name.Camelize()),
                 order: int.MinValue + 10

--- a/core/src/Baked/CodingStyle/Initializable/InitializableCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Initializable/InitializableCodingStyleFeature.cs
@@ -13,9 +13,9 @@ public class InitializableCodingStyleFeature(IEnumerable<string> initalizerNames
 
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c =>
                     c.Type.IsClass && !c.Type.IsAbstract &&
                     c.Type.TryGetMembers(out var members) &&
@@ -23,14 +23,14 @@ public class InitializableCodingStyleFeature(IEnumerable<string> initalizerNames
                     _initializerNames.Any(i => members.Methods.Contains(i)),
                 attribute: () => new TransientAttribute()
             );
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 when: c => _initializerNames.Contains(c.Method.Name),
                 attribute: () => new InitializerAttribute()
             );
 
-            builder.Conventions.Add(new AddInitializerParametersToQueryConvention());
-            builder.Conventions.Add(new TargetUsingInitializerConvention(), order: RestApiLayer.MaxConventionOrder - 10);
-            builder.Conventions.Add(new RemoveInitializerNameFromRouteConvention(), order: RestApiLayer.MaxConventionOrder);
+            conventions.Add(new AddInitializerParametersToQueryConvention());
+            conventions.Add(new TargetUsingInitializerConvention(), order: RestApiLayer.MaxConventionOrder - 10);
+            conventions.Add(new RemoveInitializerNameFromRouteConvention(), order: RestApiLayer.MaxConventionOrder);
         });
     }
 }

--- a/core/src/Baked/CodingStyle/Initializable/InitializableCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Initializable/InitializableCodingStyleFeature.cs
@@ -13,7 +13,7 @@ public class InitializableCodingStyleFeature(IEnumerable<string> initalizerNames
 
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c =>

--- a/core/src/Baked/CodingStyle/Label/LabelCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Label/LabelCodingStyleFeature.cs
@@ -10,9 +10,9 @@ public class LabelCodingStyleFeature(IEnumerable<string> propertyNames)
 
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetPropertyAttribute(
+            conventions.SetPropertyAttribute(
                 when: c =>
                     (
                         c.Property.PropertyType.Is<string>() ||

--- a/core/src/Baked/CodingStyle/Label/LabelCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Label/LabelCodingStyleFeature.cs
@@ -10,7 +10,7 @@ public class LabelCodingStyleFeature(IEnumerable<string> propertyNames)
 
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetPropertyAttribute(
                 when: c =>

--- a/core/src/Baked/CodingStyle/Locatable/LocatableCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Locatable/LocatableCodingStyleFeature.cs
@@ -11,7 +11,7 @@ public class LocatableCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add<LocatableAttribute>();
         });

--- a/core/src/Baked/CodingStyle/Locatable/LocatableCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Locatable/LocatableCodingStyleFeature.cs
@@ -14,12 +14,15 @@ public class LocatableCodingStyleFeature : IFeature<CodingStyleConfigurator>
         configurator.Domain.ConfigureDomainModelBuilder(builder =>
         {
             builder.Index.Type.Add<LocatableAttribute>();
+        });
 
-            builder.Conventions.Add(new ReplaceTargetWithIdParameterConvention());
-            builder.Conventions.Add(new InitializeLocatablesConvention());
-            builder.Conventions.Add(new LookupLocatableParameterConvention(), order: RestApiLayer.MaxConventionOrder - 20);
-            builder.Conventions.Add(new LookupLocatableParametersConvention(), order: RestApiLayer.MaxConventionOrder - 20);
-            builder.Conventions.Add(new TargetFromLocatorConvention(), order: RestApiLayer.MaxConventionOrder - 10);
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            conventions.Add(new ReplaceTargetWithIdParameterConvention());
+            conventions.Add(new InitializeLocatablesConvention());
+            conventions.Add(new LookupLocatableParameterConvention(), order: RestApiLayer.MaxConventionOrder - 20);
+            conventions.Add(new LookupLocatableParametersConvention(), order: RestApiLayer.MaxConventionOrder - 20);
+            conventions.Add(new TargetFromLocatorConvention(), order: RestApiLayer.MaxConventionOrder - 10);
         });
 
         configurator.Domain.ConfigureExportConfigurations(exports =>

--- a/core/src/Baked/CodingStyle/Locatable/LocatableCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Locatable/LocatableCodingStyleFeature.cs
@@ -16,7 +16,7 @@ public class LocatableCodingStyleFeature : IFeature<CodingStyleConfigurator>
             builder.Index.Type.Add<LocatableAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.Add(new ReplaceTargetWithIdParameterConvention());
             conventions.Add(new InitializeLocatablesConvention());

--- a/core/src/Baked/CodingStyle/LocatableExtension/LocatableExtensionCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/LocatableExtension/LocatableExtensionCodingStyleFeature.cs
@@ -14,7 +14,7 @@ public class LocatableExtensionCodingStyleFeature : IFeature<CodingStyleConfigur
             builder.Index.Type.Add<LocatableExtensionAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c =>

--- a/core/src/Baked/CodingStyle/LocatableExtension/LocatableExtensionCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/LocatableExtension/LocatableExtensionCodingStyleFeature.cs
@@ -12,8 +12,11 @@ public class LocatableExtensionCodingStyleFeature : IFeature<CodingStyleConfigur
         configurator.Domain.ConfigureDomainModelBuilder(builder =>
         {
             builder.Index.Type.Add<LocatableExtensionAttribute>();
+        });
 
-            builder.Conventions.SetTypeAttribute(
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            conventions.SetTypeAttribute(
                 when: c =>
                     c.Type.IsClass &&
                     !c.Type.IsAbstract &&
@@ -31,7 +34,7 @@ public class LocatableExtensionCodingStyleFeature : IFeature<CodingStyleConfigur
                 },
                 order: 20
             );
-            builder.Conventions.SetPropertyAttribute(
+            conventions.SetPropertyAttribute(
                 when: c => c.Type.Has<LocatableExtensionAttribute>(),
                 attribute: c =>
                 {
@@ -41,7 +44,7 @@ public class LocatableExtensionCodingStyleFeature : IFeature<CodingStyleConfigur
                 },
                 order: 20
             );
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Has<LocatableExtensionAttribute>(),
                 apply: (c, set) =>
                 {
@@ -53,7 +56,7 @@ public class LocatableExtensionCodingStyleFeature : IFeature<CodingStyleConfigur
                 },
                 order: 20
             );
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Has<LocatableExtensionAttribute>(),
                 apply: (c, set) =>
                 {
@@ -68,8 +71,8 @@ public class LocatableExtensionCodingStyleFeature : IFeature<CodingStyleConfigur
                 order: 20
             );
 
-            builder.Conventions.Add(new ExtensionsUnderLocatablesConvention(), order: RestApiLayer.MaxConventionOrder);
-            builder.Conventions.Add(new ExtensionsAreServedUnderLocatableRoutesConvention(), order: RestApiLayer.MaxConventionOrder);
+            conventions.Add(new ExtensionsUnderLocatablesConvention(), order: RestApiLayer.MaxConventionOrder);
+            conventions.Add(new ExtensionsAreServedUnderLocatableRoutesConvention(), order: RestApiLayer.MaxConventionOrder);
         });
 
         configurator.Buildtime.ConfigureGeneratedAssemblyCollection(generatedAssemblies =>

--- a/core/src/Baked/CodingStyle/LocatableExtension/LocatableExtensionCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/LocatableExtension/LocatableExtensionCodingStyleFeature.cs
@@ -9,7 +9,7 @@ public class LocatableExtensionCodingStyleFeature : IFeature<CodingStyleConfigur
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add<LocatableExtensionAttribute>();
         });

--- a/core/src/Baked/CodingStyle/NamespaceAsRoute/NamespaceAsRouteCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/NamespaceAsRoute/NamespaceAsRouteCodingStyleFeature.cs
@@ -7,9 +7,9 @@ public class NamespaceAsRouteCodingStyleFeature : IFeature<CodingStyleConfigurat
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.Add(new UseNamespaceForBaseRouteConvention(), order: RestApiLayer.MaxConventionOrder - 10);
+            conventions.Add(new UseNamespaceForBaseRouteConvention(), order: RestApiLayer.MaxConventionOrder - 10);
         });
     }
 }

--- a/core/src/Baked/CodingStyle/NamespaceAsRoute/NamespaceAsRouteCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/NamespaceAsRoute/NamespaceAsRouteCodingStyleFeature.cs
@@ -7,7 +7,7 @@ public class NamespaceAsRouteCodingStyleFeature : IFeature<CodingStyleConfigurat
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.Add(new UseNamespaceForBaseRouteConvention(), order: RestApiLayer.MaxConventionOrder - 10);
         });

--- a/core/src/Baked/CodingStyle/ObjectAsJson/ObjectAsJsonCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/ObjectAsJson/ObjectAsJsonCodingStyleFeature.cs
@@ -10,7 +10,7 @@ public class ObjectAsJsonCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 attribute: () => new ApiInputAttribute(),

--- a/core/src/Baked/CodingStyle/ObjectAsJson/ObjectAsJsonCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/ObjectAsJson/ObjectAsJsonCodingStyleFeature.cs
@@ -10,14 +10,14 @@ public class ObjectAsJsonCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: () => new ApiInputAttribute(),
                 when: c => c.Type.Is<object>()
             );
 
-            builder.Conventions.Add(new SingleObjectParametersDontUseRequestClassConvention());
+            conventions.Add(new SingleObjectParametersDontUseRequestClassConvention());
         });
 
         configurator.DataAccess.ConfigureAutoPersistenceModel(model =>

--- a/core/src/Baked/CodingStyle/Query/QueryCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Query/QueryCodingStyleFeature.cs
@@ -10,7 +10,7 @@ public class QueryCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c =>

--- a/core/src/Baked/CodingStyle/Query/QueryCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Query/QueryCodingStyleFeature.cs
@@ -10,9 +10,9 @@ public class QueryCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c =>
                     c.Type.Has<LocatableAttribute>() &&
                     c.Domain.Types.TryGetValue(((IModel)c.Type).Id.Pluralize(), out var query) &&
@@ -29,8 +29,8 @@ public class QueryCodingStyleFeature : IFeature<CodingStyleConfigurator>
                 order: 30
             );
 
-            builder.Conventions.Add(new AutoHttpMethodConvention([(Regexes.StartsWithFirstBySingleByOrBy, HttpMethod.Get)]), order: -10);
-            builder.Conventions.Add(new RemoveFromRouteConvention(["FirstBy", "SingleBy", "By"],
+            conventions.Add(new AutoHttpMethodConvention([(Regexes.StartsWithFirstBySingleByOrBy, HttpMethod.Get)]), order: -10);
+            conventions.Add(new RemoveFromRouteConvention(["FirstBy", "SingleBy", "By"],
                 _whenContext: c => c.Type.TryGetMetadata(out var metadata) && metadata.Has<QueryAttribute>()
             ));
         });

--- a/core/src/Baked/CodingStyle/QueryMethod/QueryMethodCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/QueryMethod/QueryMethodCodingStyleFeature.cs
@@ -13,7 +13,7 @@ public class QueryMethodCodingStyleFeature(
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Method.Add<QueryMethodAttribute>();
             builder.Index.Parameter.Add<PagingAttribute>();

--- a/core/src/Baked/CodingStyle/QueryMethod/QueryMethodCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/QueryMethod/QueryMethodCodingStyleFeature.cs
@@ -18,17 +18,20 @@ public class QueryMethodCodingStyleFeature(
             builder.Index.Method.Add<QueryMethodAttribute>();
             builder.Index.Parameter.Add<PagingAttribute>();
             builder.Index.Parameter.Add<SortingAttribute>();
+        });
 
-            builder.Conventions.SetMethodAttribute(
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            conventions.SetMethodAttribute(
                 when: c => c.Type.Has<QueryAttribute>() && _queryMethodNames.Contains(c.Method.Name),
                 attribute: () => new QueryMethodAttribute(),
                 order: 40
             );
-            builder.Conventions.AddMethodAttributeConfiguration<QueryMethodAttribute>(
+            conventions.AddMethodAttributeConfiguration<QueryMethodAttribute>(
                 when: c => c.Method.DefaultOverload.Parameters.All(p => p.IsOptional),
                 attribute: qm => qm.AllParametersAreOptional = true
             );
-            builder.Conventions.AddMethodAttributeConfiguration<QueryMethodAttribute>(
+            conventions.AddMethodAttributeConfiguration<QueryMethodAttribute>(
                 when: c => c.Method.DefaultOverload.Parameters.Any(p => _primaryParameterNames.Contains(p.Name)),
                 attribute: (qm, c) =>
                 {
@@ -42,19 +45,19 @@ public class QueryMethodCodingStyleFeature(
                 }
             );
 
-            builder.Conventions.SetParameterAttribute(
+            conventions.SetParameterAttribute(
                 when: c => c.Method.Has<QueryMethodAttribute>() && _takeParameterNames.Contains(c.Parameter.Name),
                 attribute: () => new PagingAttribute(PagingAttribute.Role.Take),
                 order: 40
             );
 
-            builder.Conventions.SetParameterAttribute(
+            conventions.SetParameterAttribute(
                 when: c => c.Method.Has<QueryMethodAttribute>() && _skipParameterNames.Contains(c.Parameter.Name),
                 attribute: () => new PagingAttribute(PagingAttribute.Role.Skip),
                 order: 40
             );
 
-            builder.Conventions.SetParameterAttribute(
+            conventions.SetParameterAttribute(
                 when: c => c.Method.Has<QueryMethodAttribute>() && _sortingParameterNames.Contains(c.Parameter.Name),
                 attribute: () => new SortingAttribute(),
                 order: 40

--- a/core/src/Baked/CodingStyle/QueryMethod/QueryMethodCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/QueryMethod/QueryMethodCodingStyleFeature.cs
@@ -20,7 +20,7 @@ public class QueryMethodCodingStyleFeature(
             builder.Index.Parameter.Add<SortingAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetMethodAttribute(
                 when: c => c.Type.Has<QueryAttribute>() && _queryMethodNames.Contains(c.Method.Name),

--- a/core/src/Baked/CodingStyle/RecordsAreDtos/RecordsAreDtosCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/RecordsAreDtos/RecordsAreDtosCodingStyleFeature.cs
@@ -7,9 +7,9 @@ public class RecordsAreDtosCodingStyleFeature : IFeature<CodingStyleConfigurator
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: () => new ApiInputAttribute(),
                 when: c =>
                     c.Type.TryGetMembers(out var members) &&

--- a/core/src/Baked/CodingStyle/RecordsAreDtos/RecordsAreDtosCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/RecordsAreDtos/RecordsAreDtosCodingStyleFeature.cs
@@ -7,7 +7,7 @@ public class RecordsAreDtosCodingStyleFeature : IFeature<CodingStyleConfigurator
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 attribute: () => new ApiInputAttribute(),

--- a/core/src/Baked/CodingStyle/RemainingServicesAreSingleton/RemainingServicesAreSingletonCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/RemainingServicesAreSingleton/RemainingServicesAreSingletonCodingStyleFeature.cs
@@ -10,7 +10,7 @@ public class RemainingServicesAreSingletonCodingStyleFeature()
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                attribute: () => new SingletonAttribute(),

--- a/core/src/Baked/CodingStyle/RemainingServicesAreSingleton/RemainingServicesAreSingletonCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/RemainingServicesAreSingleton/RemainingServicesAreSingletonCodingStyleFeature.cs
@@ -10,9 +10,9 @@ public class RemainingServicesAreSingletonCodingStyleFeature()
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                attribute: () => new SingletonAttribute(),
                when: c =>
                    c.Type.IsClass && !c.Type.IsAbstract &&

--- a/core/src/Baked/CodingStyle/RichEntity/RichEntityCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/RichEntity/RichEntityCodingStyleFeature.cs
@@ -12,7 +12,7 @@ public class RichEntityCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c =>

--- a/core/src/Baked/CodingStyle/RichEntity/RichEntityCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/RichEntity/RichEntityCodingStyleFeature.cs
@@ -12,9 +12,9 @@ public class RichEntityCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c =>
                     c.Type.TryGetMembers(out var members) &&
                     TryGetEntityContextParameter(members, out var entityContextParameter) &&
@@ -22,7 +22,7 @@ public class RichEntityCodingStyleFeature : IFeature<CodingStyleConfigurator>
                     entityContextGenerics.GenericTypeArguments.First().Model == c.Type,
                 attribute: () => new EntityAttribute()
             );
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Has<EntityAttribute>(),
                 apply: (c, set) =>
                 {
@@ -30,7 +30,7 @@ public class RichEntityCodingStyleFeature : IFeature<CodingStyleConfigurator>
                     set(c.Type, new LocatableAttribute());
                 }
             );
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 when: c =>
                     c.Type.Has<EntityAttribute>() && c.Method.Has<InitializerAttribute>() &&
                     c.Method.Overloads.Any(o => o.IsPublic && !o.IsStatic && !o.IsSpecialName && o.AllParametersAreApiInput()),
@@ -38,7 +38,7 @@ public class RichEntityCodingStyleFeature : IFeature<CodingStyleConfigurator>
                 order: 30
             );
 
-            builder.Conventions.Add(new EntityInitializerIsPostResourceConvention());
+            conventions.Add(new EntityInitializerIsPostResourceConvention());
         });
 
         configurator.DataAccess.ConfigureNHibernateInterceptor(interceptor =>

--- a/core/src/Baked/CodingStyle/RichTransient/RichTransientCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/RichTransient/RichTransientCodingStyleFeature.cs
@@ -15,8 +15,11 @@ public class RichTransientCodingStyleFeature : IFeature<CodingStyleConfigurator>
         configurator.Domain.ConfigureDomainModelBuilder(builder =>
         {
             builder.Index.Type.Add<RichTransientAttribute>();
+        });
 
-            builder.Conventions.SetTypeAttribute(
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            conventions.SetTypeAttribute(
                 when: c =>
                     c.Type.IsClass && !c.Type.IsAbstract &&
                     c.Type.TryGetMembers(out var members) &&
@@ -39,7 +42,7 @@ public class RichTransientCodingStyleFeature : IFeature<CodingStyleConfigurator>
                 },
                 order: 10
             );
-            builder.Conventions.AddTypeAttributeConfiguration<LocatableAttribute>(
+            conventions.AddTypeAttributeConfiguration<LocatableAttribute>(
                 when: c => c.Type.Has<RichTransientAttribute>(),
                 attribute: (locatable, c) =>
                 {
@@ -55,7 +58,7 @@ public class RichTransientCodingStyleFeature : IFeature<CodingStyleConfigurator>
                 },
                 order: 10
             );
-            builder.Conventions.SetMethodAttribute(
+            conventions.SetMethodAttribute(
                 when: c =>
                     c.Type.Has<RichTransientAttribute>() &&
                     c.Type.TryGetMembers(out var members) &&
@@ -66,8 +69,8 @@ public class RichTransientCodingStyleFeature : IFeature<CodingStyleConfigurator>
                 order: 20
             );
 
-            builder.Conventions.Add(new RichTransientUnderPluralGroupConvention());
-            builder.Conventions.Add(new RichTransientInitializerIsGetResourceConvention(), order: 10);
+            conventions.Add(new RichTransientUnderPluralGroupConvention());
+            conventions.Add(new RichTransientInitializerIsGetResourceConvention(), order: 10);
         });
 
         configurator.Buildtime.ConfigureGeneratedAssemblyCollection(generatedAssemblies =>

--- a/core/src/Baked/CodingStyle/RichTransient/RichTransientCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/RichTransient/RichTransientCodingStyleFeature.cs
@@ -17,7 +17,7 @@ public class RichTransientCodingStyleFeature : IFeature<CodingStyleConfigurator>
             builder.Index.Type.Add<RichTransientAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c =>

--- a/core/src/Baked/CodingStyle/RichTransient/RichTransientCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/RichTransient/RichTransientCodingStyleFeature.cs
@@ -12,7 +12,7 @@ public class RichTransientCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add<RichTransientAttribute>();
         });

--- a/core/src/Baked/CodingStyle/ScopedBySuffix/ScopedBySuffixCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/ScopedBySuffix/ScopedBySuffixCodingStyleFeature.cs
@@ -9,9 +9,9 @@ public class ScopedBySuffixCodingStyleFeature(IEnumerable<string> _suffixes)
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: () => new ScopedAttribute(),
                 when: c =>
                     c.Type.IsClass && !c.Type.IsAbstract &&

--- a/core/src/Baked/CodingStyle/ScopedBySuffix/ScopedBySuffixCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/ScopedBySuffix/ScopedBySuffixCodingStyleFeature.cs
@@ -9,7 +9,7 @@ public class ScopedBySuffixCodingStyleFeature(IEnumerable<string> _suffixes)
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 attribute: () => new ScopedAttribute(),

--- a/core/src/Baked/CodingStyle/Unique/UniqueCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Unique/UniqueCodingStyleFeature.cs
@@ -8,7 +8,7 @@ public class UniqueCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetPropertyAttribute(
                 when: c =>

--- a/core/src/Baked/CodingStyle/Unique/UniqueCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/Unique/UniqueCodingStyleFeature.cs
@@ -8,9 +8,9 @@ public class UniqueCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetPropertyAttribute(
+            conventions.SetPropertyAttribute(
                 when: c =>
                     c.Type.Has<EntityAttribute>() &&
                     c.Type.TryGet<LocatableAttribute>(out var locatable) &&

--- a/core/src/Baked/CodingStyle/UriReturnIsRedirect/UriReturnIsRedirectCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/UriReturnIsRedirect/UriReturnIsRedirectCodingStyleFeature.cs
@@ -6,7 +6,7 @@ public class UriReturnIsRedirectCodingStyleFeature : IFeature<CodingStyleConfigu
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.Add(new UriReturnIsRedirectConvention());
             conventions.Add(new UriReturnWithoutParameterIsGetConvention());

--- a/core/src/Baked/CodingStyle/UriReturnIsRedirect/UriReturnIsRedirectCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/UriReturnIsRedirect/UriReturnIsRedirectCodingStyleFeature.cs
@@ -6,11 +6,11 @@ public class UriReturnIsRedirectCodingStyleFeature : IFeature<CodingStyleConfigu
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.Add(new UriReturnIsRedirectConvention());
-            builder.Conventions.Add(new UriReturnWithoutParameterIsGetConvention());
-            builder.Conventions.Add(new UriReturnWithParameterIsFormPostConvention(), order: -10);
+            conventions.Add(new UriReturnIsRedirectConvention());
+            conventions.Add(new UriReturnWithoutParameterIsGetConvention());
+            conventions.Add(new UriReturnWithParameterIsFormPostConvention(), order: -10);
         });
 
         configurator.RestApi.ConfigureApiModel(api =>

--- a/core/src/Baked/CodingStyle/UseBuiltInTypes/UseBuiltInTypesCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/UseBuiltInTypes/UseBuiltInTypesCodingStyleFeature.cs
@@ -13,9 +13,9 @@ public class UseBuiltInTypesCodingStyleFeature(IEnumerable<string> _textProperty
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: () => new ApiInputAttribute(),
                 when: c =>
                   c.Type.IsEnum ||
@@ -24,7 +24,7 @@ public class UseBuiltInTypesCodingStyleFeature(IEnumerable<string> _textProperty
                   c.Type.IsAssignableTo(typeof(string)),
               order: RestApiLayer.MinConventionOrder
             );
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: () => new ApiInputAttribute(),
                 when: c =>
                     c.Type.IsAssignableTo(typeof(IEnumerable<>)) &&
@@ -33,7 +33,7 @@ public class UseBuiltInTypesCodingStyleFeature(IEnumerable<string> _textProperty
                     genericArgMetadata.Has<ApiInputAttribute>(),
                 order: 20
             );
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 attribute: () => new ApiInputAttribute(),
                 when: c =>
                     c.Type.IsArray && c.Type.TryGetGenerics(out var generics) &&
@@ -42,9 +42,9 @@ public class UseBuiltInTypesCodingStyleFeature(IEnumerable<string> _textProperty
                 order: 20
             );
 
-            builder.Conventions.Add(new BoolDefaultValueConvention());
-            builder.Conventions.Add(new SetDefaultValueForEnumConvention());
-            builder.Conventions.Add(new StringDefaultValueConvention());
+            conventions.Add(new BoolDefaultValueConvention());
+            conventions.Add(new SetDefaultValueForEnumConvention());
+            conventions.Add(new StringDefaultValueConvention());
         });
 
         configurator.DataAccess.ConfigureAutoPersistenceModel(model =>

--- a/core/src/Baked/CodingStyle/UseBuiltInTypes/UseBuiltInTypesCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/UseBuiltInTypes/UseBuiltInTypesCodingStyleFeature.cs
@@ -13,7 +13,7 @@ public class UseBuiltInTypesCodingStyleFeature(IEnumerable<string> _textProperty
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 attribute: () => new ApiInputAttribute(),

--- a/core/src/Baked/CodingStyle/UseNullableTypes/UseNullableTypesCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/UseNullableTypes/UseNullableTypesCodingStyleFeature.cs
@@ -13,7 +13,7 @@ public class UseNullableTypesCodingStyleFeature : IFeature<CodingStyleConfigurat
 
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c =>

--- a/core/src/Baked/CodingStyle/UseNullableTypes/UseNullableTypesCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/UseNullableTypes/UseNullableTypesCodingStyleFeature.cs
@@ -13,9 +13,9 @@ public class UseNullableTypesCodingStyleFeature : IFeature<CodingStyleConfigurat
 
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c =>
                     c.Type.IsAssignableTo(typeof(Nullable<>)) &&
                     c.Type.GenericTypeArguments.FirstOrDefault()?.Model.TryGetMetadata(out var genericArgumentMetadata) == true &&
@@ -24,7 +24,7 @@ public class UseNullableTypesCodingStyleFeature : IFeature<CodingStyleConfigurat
                 order: RestApiLayer.MinConventionOrder
             );
 
-            builder.Conventions.SetParameterAttribute(
+            conventions.SetParameterAttribute(
                 when: c =>
                 {
                     var nullable = c.Parameter.ParameterType.IsAssignableTo(typeof(Nullable<>));
@@ -39,13 +39,13 @@ public class UseNullableTypesCodingStyleFeature : IFeature<CodingStyleConfigurat
                 order: RestApiLayer.MinConventionOrder
             );
 
-            builder.Conventions.SetParameterAttribute(
+            conventions.SetParameterAttribute(
                 when: c => !c.Parameter.IsOptional && !c.Parameter.IsNullable,
                 attribute: () => new RequiredAttribute()
             );
 
-            builder.Conventions.Add(new RequiredParametersAreRequiredInApiModelConvention());
-            builder.Conventions.Add(new SetDefaultValueForNullableEnumConvention());
+            conventions.Add(new RequiredParametersAreRequiredInApiModelConvention());
+            conventions.Add(new SetDefaultValueForNullableEnumConvention());
         });
 
         configurator.RestApi.ConfigureApiModel(api =>

--- a/core/src/Baked/CodingStyle/ValueType/ValueTypeCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/ValueType/ValueTypeCodingStyleFeature.cs
@@ -16,7 +16,7 @@ public class ValueTypeCodingStyleFeature : IFeature<CodingStyleConfigurator>
             builder.Index.Type.Add<ValueTypeAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c =>

--- a/core/src/Baked/CodingStyle/ValueType/ValueTypeCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/ValueType/ValueTypeCodingStyleFeature.cs
@@ -11,7 +11,7 @@ public class ValueTypeCodingStyleFeature : IFeature<CodingStyleConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add<ValueTypeAttribute>();
         });

--- a/core/src/Baked/CodingStyle/ValueType/ValueTypeCodingStyleFeature.cs
+++ b/core/src/Baked/CodingStyle/ValueType/ValueTypeCodingStyleFeature.cs
@@ -14,8 +14,11 @@ public class ValueTypeCodingStyleFeature : IFeature<CodingStyleConfigurator>
         configurator.Domain.ConfigureDomainModelBuilder(builder =>
         {
             builder.Index.Type.Add<ValueTypeAttribute>();
+        });
 
-            builder.Conventions.SetTypeAttribute(
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            conventions.SetTypeAttribute(
                 when: c =>
                     c.Type.IsValueType &&
                     !c.Type.IsEnum &&

--- a/core/src/Baked/Database/MySql/MySqlDatabaseFeature.cs
+++ b/core/src/Baked/Database/MySql/MySqlDatabaseFeature.cs
@@ -31,7 +31,7 @@ public class MySqlDatabaseFeature(Setting<string> _connectionString, Setting<boo
                     .Dialect<CustomMySQL57Dialect>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.Add(new AddFlatTransactionToActionConvention());
         });

--- a/core/src/Baked/Database/MySql/MySqlDatabaseFeature.cs
+++ b/core/src/Baked/Database/MySql/MySqlDatabaseFeature.cs
@@ -31,9 +31,9 @@ public class MySqlDatabaseFeature(Setting<string> _connectionString, Setting<boo
                     .Dialect<CustomMySQL57Dialect>();
         });
 
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.Add(new AddFlatTransactionToActionConvention());
+            conventions.Add(new AddFlatTransactionToActionConvention());
         });
     }
 }

--- a/core/src/Baked/Database/Oracle/OracleDatabaseFeature.cs
+++ b/core/src/Baked/Database/Oracle/OracleDatabaseFeature.cs
@@ -36,7 +36,7 @@ public class OracleDatabaseFeature(Setting<string> _connectionString, Setting<bo
             fluent.ExposeConfiguration(c => c.SetProperty(NHibernate.Cfg.Environment.OracleSuppressDecimalInvalidCastException, "true"));
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.Add(new AddFlatTransactionToActionConvention());
         });

--- a/core/src/Baked/Database/Oracle/OracleDatabaseFeature.cs
+++ b/core/src/Baked/Database/Oracle/OracleDatabaseFeature.cs
@@ -36,9 +36,9 @@ public class OracleDatabaseFeature(Setting<string> _connectionString, Setting<bo
             fluent.ExposeConfiguration(c => c.SetProperty(NHibernate.Cfg.Environment.OracleSuppressDecimalInvalidCastException, "true"));
         });
 
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.Add(new AddFlatTransactionToActionConvention());
+            conventions.Add(new AddFlatTransactionToActionConvention());
         });
     }
 }

--- a/core/src/Baked/Database/PostgreSql/PostgreSqlDatabaseFeature.cs
+++ b/core/src/Baked/Database/PostgreSql/PostgreSqlDatabaseFeature.cs
@@ -32,9 +32,9 @@ public class PostgreSqlDatabaseFeature(Setting<string> _connectionString, Settin
             ;
         });
 
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.Add(new AddFlatTransactionToActionConvention());
+            conventions.Add(new AddFlatTransactionToActionConvention());
         });
     }
 }

--- a/core/src/Baked/Database/PostgreSql/PostgreSqlDatabaseFeature.cs
+++ b/core/src/Baked/Database/PostgreSql/PostgreSqlDatabaseFeature.cs
@@ -32,7 +32,7 @@ public class PostgreSqlDatabaseFeature(Setting<string> _connectionString, Settin
             ;
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.Add(new AddFlatTransactionToActionConvention());
         });

--- a/core/src/Baked/Database/Sqlite/SqliteDatabaseFeature.cs
+++ b/core/src/Baked/Database/Sqlite/SqliteDatabaseFeature.cs
@@ -38,9 +38,9 @@ public class SqliteDatabaseFeature(Setting<string> _fileName, Setting<bool> _aut
             });
         });
 
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.Add(new AddFlatTransactionToActionConvention());
+            conventions.Add(new AddFlatTransactionToActionConvention());
         });
     }
 }

--- a/core/src/Baked/Database/Sqlite/SqliteDatabaseFeature.cs
+++ b/core/src/Baked/Database/Sqlite/SqliteDatabaseFeature.cs
@@ -38,7 +38,7 @@ public class SqliteDatabaseFeature(Setting<string> _fileName, Setting<bool> _aut
             });
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.Add(new AddFlatTransactionToActionConvention());
         });

--- a/core/src/Baked/Domain/Configuration/DomainModelBuilder.cs
+++ b/core/src/Baked/Domain/Configuration/DomainModelBuilder.cs
@@ -2,7 +2,7 @@
 
 namespace Baked.Domain.Configuration;
 
-public class DomainModelBuilder(DomainModelBuilderOptions _options)
+public class DomainModelBuilder(DomainModelBuilderOptions _options, IDomainModelConventionCollection _conventions)
 {
     readonly TypeModelBuildQueue _buildQueue = new();
     readonly HashSet<Type> _domainTypes = [];
@@ -34,7 +34,7 @@ public class DomainModelBuilder(DomainModelBuilderOptions _options)
         }
         while (!_buildQueue.IsEmpty);
 
-        return new(_options, new(new(_references.Select(t => t.Model))));
+        return new(_options, _conventions, new(new(_references.Select(t => t.Model))));
 
     }
 

--- a/core/src/Baked/Domain/Configuration/DomainModelBuilderOptions.cs
+++ b/core/src/Baked/Domain/Configuration/DomainModelBuilderOptions.cs
@@ -8,7 +8,6 @@ public class DomainModelBuilderOptions
 {
     public ICollection<TypeBuildLevelFilter> BuildLevels { get; set; } = [];
     public BindingFlagOptions BindingFlags { get; } = new();
-    public IDomainModelConventionCollection Conventions { get; set; } = new DomainModelConventionCollection();
     public DomainIndexOptions Index { get; set; } = new();
     public Func<IEnumerable<MethodOverloadModel>, MethodOverloadModel> DefaultOverloadSelector { get; set; } = overloads => overloads.First();
     public Action<DiagnosticsResult>? OnComplete { get; set; }

--- a/core/src/Baked/Domain/Configuration/DomainModelPostBuilder.cs
+++ b/core/src/Baked/Domain/Configuration/DomainModelPostBuilder.cs
@@ -2,13 +2,14 @@ using Baked.Domain.Model;
 
 namespace Baked.Domain.Configuration;
 
-public class DomainModelPostBuilder(DomainModelBuilderOptions options, DomainModel model)
+public class DomainModelPostBuilder(DomainModelBuilderOptions options, IDomainModelConventionCollection conventions, DomainModel model)
 {
     readonly DomainModelBuilderOptions _options = options;
+    readonly IDomainModelConventionCollection _conventions = conventions;
 
     public DomainModel Model { get; } = model;
 
-    public void EndBuild(IDomainModelConventionCollection conventions)
+    public void EndBuild()
     {
         using (Diagnostics.Start(nameof(DomainModelPostBuilder), onDispose: _options.OnComplete))
         {
@@ -16,7 +17,7 @@ public class DomainModelPostBuilder(DomainModelBuilderOptions options, DomainMod
             var conventionsRequiringIndex = new List<IDomainModelConvention>();
             var restOfTheConventions = new List<IDomainModelConvention>();
 
-            foreach (var convention in conventions.OrderBy(c => c.Order).Select(c => c.Convention))
+            foreach (var convention in _conventions.OrderBy(c => c.Order).Select(c => c.Convention))
             {
                 if (convention is IAddRemoveAttributeConvention addRemove && addRemove.AttributeRequiresIndex)
                 {

--- a/core/src/Baked/Domain/Configuration/DomainModelPostBuilder.cs
+++ b/core/src/Baked/Domain/Configuration/DomainModelPostBuilder.cs
@@ -8,7 +8,7 @@ public class DomainModelPostBuilder(DomainModelBuilderOptions options, DomainMod
 
     public DomainModel Model { get; } = model;
 
-    public void EndBuild()
+    public void EndBuild(IDomainModelConventionCollection conventions)
     {
         using (Diagnostics.Start(nameof(DomainModelPostBuilder), onDispose: _options.OnComplete))
         {
@@ -16,7 +16,7 @@ public class DomainModelPostBuilder(DomainModelBuilderOptions options, DomainMod
             var conventionsRequiringIndex = new List<IDomainModelConvention>();
             var restOfTheConventions = new List<IDomainModelConvention>();
 
-            foreach (var convention in _options.Conventions.OrderBy(c => c.Order).Select(c => c.Convention))
+            foreach (var convention in conventions.OrderBy(c => c.Order).Select(c => c.Convention))
             {
                 if (convention is IAddRemoveAttributeConvention addRemove && addRemove.AttributeRequiresIndex)
                 {

--- a/core/src/Baked/Domain/DomainExtensions.cs
+++ b/core/src/Baked/Domain/DomainExtensions.cs
@@ -26,7 +26,7 @@ public static class DomainExtensions
         public void ConfigureDomainTypeCollection(Action<IDomainTypeCollection> configuration) =>
             _configurator.Configure(configuration);
 
-        public void ConfigureDomainModelBuilder(Action<DomainModelBuilderOptions> configuration) =>
+        public void ConfigureBuilder(Action<DomainModelBuilderOptions> configuration) =>
             _configurator.Configure(configuration);
 
         public void ConfigureConventions(Action<IDomainModelConventionCollection> configuration) =>

--- a/core/src/Baked/Domain/DomainExtensions.cs
+++ b/core/src/Baked/Domain/DomainExtensions.cs
@@ -29,6 +29,9 @@ public static class DomainExtensions
         public void ConfigureDomainModelBuilder(Action<DomainModelBuilderOptions> configuration) =>
             _configurator.Configure(configuration);
 
+        public void ConfigureDomainConventions(Action<IDomainModelConventionCollection> configuration) =>
+            _configurator.Configure(configuration);
+
         public void ConfigureDomainServiceCollection(Action<DomainServiceCollection> configuration) =>
             ConfigureDomainServiceCollection((services, _) => configuration(services));
 

--- a/core/src/Baked/Domain/DomainExtensions.cs
+++ b/core/src/Baked/Domain/DomainExtensions.cs
@@ -29,7 +29,7 @@ public static class DomainExtensions
         public void ConfigureDomainModelBuilder(Action<DomainModelBuilderOptions> configuration) =>
             _configurator.Configure(configuration);
 
-        public void ConfigureDomainConventions(Action<IDomainModelConventionCollection> configuration) =>
+        public void ConfigureConventions(Action<IDomainModelConventionCollection> configuration) =>
             _configurator.Configure(configuration);
 
         public void ConfigureDomainServiceCollection(Action<DomainServiceCollection> configuration) =>

--- a/core/src/Baked/Domain/DomainLayer.cs
+++ b/core/src/Baked/Domain/DomainLayer.cs
@@ -100,9 +100,9 @@ public class DomainLayer : LayerBase<AddDomainTypes, Generate, AddServices>
     {
         protected override void Initialize(IDomainTypeCollection domainTypes)
         {
-            var builder = new DomainModelBuilder(_builderOptions).StartBuild(domainTypes);
+            var builder = new DomainModelBuilder(_builderOptions, _conventions).StartBuild(domainTypes);
             Context.Add(builder.Model);
-            builder.EndBuild(_conventions);
+            builder.EndBuild();
         }
     }
 }

--- a/core/src/Baked/Domain/DomainLayer.cs
+++ b/core/src/Baked/Domain/DomainLayer.cs
@@ -16,6 +16,7 @@ public class DomainLayer : LayerBase<AddDomainTypes, Generate, AddServices>
     readonly Inspect _inspect = new();
     readonly IDomainTypeCollection _domainTypes = new DomainTypeCollection();
     readonly DomainModelBuilderOptions _builderOptions = new();
+    readonly IDomainModelConventionCollection _conventions = new DomainModelConventionCollection();
     readonly DomainServiceCollection _domainServiceCollection = new();
     readonly AttributeProperties _attributeProperties = new();
     readonly ExportConfigurations _attributeExportConfigurations = new();
@@ -25,6 +26,7 @@ public class DomainLayer : LayerBase<AddDomainTypes, Generate, AddServices>
             .Add(_inspect)
             .Add(_domainTypes)
             .Add(_builderOptions)
+            .Add(_conventions)
             .Build();
 
     protected override PhaseContext GetContext(Generate phase)
@@ -81,7 +83,7 @@ public class DomainLayer : LayerBase<AddDomainTypes, Generate, AddServices>
     protected override IEnumerable<IPhase> GetGeneratePhases()
     {
         yield return new AddDomainTypes(_domainTypes);
-        yield return new BuildDomainModel(_builderOptions);
+        yield return new BuildDomainModel(_builderOptions, _conventions);
     }
 
     public class AddDomainTypes(IDomainTypeCollection _domainTypes)
@@ -93,14 +95,14 @@ public class DomainLayer : LayerBase<AddDomainTypes, Generate, AddServices>
         }
     }
 
-    public class BuildDomainModel(DomainModelBuilderOptions _builderOptions)
+    public class BuildDomainModel(DomainModelBuilderOptions _builderOptions, IDomainModelConventionCollection _conventions)
         : PhaseBase<IDomainTypeCollection>(PhaseOrder.Latest)
     {
         protected override void Initialize(IDomainTypeCollection domainTypes)
         {
             var builder = new DomainModelBuilder(_builderOptions).StartBuild(domainTypes);
             Context.Add(builder.Model);
-            builder.EndBuild();
+            builder.EndBuild(_conventions);
         }
     }
 }

--- a/core/src/Baked/Lifetime/Scoped/ScopedLifetimeFeature.cs
+++ b/core/src/Baked/Lifetime/Scoped/ScopedLifetimeFeature.cs
@@ -6,7 +6,7 @@ public class ScopedLifetimeFeature : IFeature<LifetimeConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add<ScopedAttribute>();
         });

--- a/core/src/Baked/Lifetime/Singleton/SingletonLifetimeFeature.cs
+++ b/core/src/Baked/Lifetime/Singleton/SingletonLifetimeFeature.cs
@@ -6,7 +6,7 @@ public class SingletonLifetimeFeature : IFeature<LifetimeConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add<SingletonAttribute>();
         });

--- a/core/src/Baked/Lifetime/Transient/TransientLifetimeFeature.cs
+++ b/core/src/Baked/Lifetime/Transient/TransientLifetimeFeature.cs
@@ -6,7 +6,7 @@ public class TransientLifetimeFeature : IFeature<LifetimeConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add<TransientAttribute>();
         });

--- a/core/src/Baked/Orm/AutoMap/AutoMapOrmFeature.cs
+++ b/core/src/Baked/Orm/AutoMap/AutoMapOrmFeature.cs
@@ -38,7 +38,7 @@ public class AutoMapOrmFeature : IFeature<OrmConfigurator>
             builder.Index.Property.Add(typeof(UniqueAttribute));
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetPropertyAttribute(
                 when: c =>

--- a/core/src/Baked/Orm/AutoMap/AutoMapOrmFeature.cs
+++ b/core/src/Baked/Orm/AutoMap/AutoMapOrmFeature.cs
@@ -32,7 +32,7 @@ public class AutoMapOrmFeature : IFeature<OrmConfigurator>
             """);
         });
 
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add(typeof(EntityAttribute));
             builder.Index.Property.Add(typeof(UniqueAttribute));

--- a/core/src/Baked/Orm/AutoMap/AutoMapOrmFeature.cs
+++ b/core/src/Baked/Orm/AutoMap/AutoMapOrmFeature.cs
@@ -36,14 +36,17 @@ public class AutoMapOrmFeature : IFeature<OrmConfigurator>
         {
             builder.Index.Type.Add(typeof(EntityAttribute));
             builder.Index.Property.Add(typeof(UniqueAttribute));
+        });
 
-            builder.Conventions.SetPropertyAttribute(
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            conventions.SetPropertyAttribute(
                 when: c =>
                     c.Type.Has<EntityAttribute>() &&
                     c.Property.IsAutoProperty,
                 attribute: () => new ColumnAttribute()
             );
-            builder.Conventions.SetPropertyAttribute(
+            conventions.SetPropertyAttribute(
                 when: c =>
                     c.Type.Has<EntityAttribute>() &&
                     c.Property.Has<ColumnAttribute>() &&

--- a/core/src/Baked/RateLimiter/Concurrency/ConcurrencyRateLimiterFeature.cs
+++ b/core/src/Baked/RateLimiter/Concurrency/ConcurrencyRateLimiterFeature.cs
@@ -14,7 +14,7 @@ public class ConcurrencyRateLimiterFeature(
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(action =>
                 action.AdditionalAttributes.Add("""EnableRateLimiting("Concurrency")""")

--- a/core/src/Baked/RateLimiter/Concurrency/ConcurrencyRateLimiterFeature.cs
+++ b/core/src/Baked/RateLimiter/Concurrency/ConcurrencyRateLimiterFeature.cs
@@ -14,9 +14,9 @@ public class ConcurrencyRateLimiterFeature(
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(action =>
+            conventions.AddMethodAttributeConfiguration<ActionModelAttribute>(action =>
                 action.AdditionalAttributes.Add("""EnableRateLimiting("Concurrency")""")
             );
         });

--- a/core/src/Baked/Theme/Default/DefaultThemeFeature.cs
+++ b/core/src/Baked/Theme/Default/DefaultThemeFeature.cs
@@ -24,17 +24,24 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
     {
         configurator.Domain.ConfigureDomainModelBuilder(builder =>
         {
-            // Type defaults
             builder.Index.Type.Add<RouteAttribute>();
-            builder.Conventions.AddTypeComponent(
+            builder.Index.Property.Add<DataAttribute>();
+            builder.Index.Method.Add<ActionAttribute>();
+            builder.Index.Method.Add<RouteAttribute>();
+        });
+
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            // Type defaults
+            conventions.AddTypeComponent(
                 where: cc => cc.Path.Is(nameof(Page), "*"),
                 component: (c, cc) => TypeTabbedPage(c.Type, cc)
             );
-            builder.Conventions.AddTypeComponent(
+            conventions.AddTypeComponent(
                 where: cc => cc.Path.Is(nameof(Page), "*"),
                 component: (c, cc) => TypeSimplePage(c.Type, cc)
             );
-            builder.Conventions.AddTypeAttributeConfiguration<RouteAttribute>(
+            conventions.AddTypeAttributeConfiguration<RouteAttribute>(
                 when: (c, r) =>
                     r.Path.Contains("[id]") &&
                     c.Type.TryGetMembers(out var members) &&
@@ -48,23 +55,22 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
             );
 
             // Enum Data
-            builder.Conventions.AddTypeSchema(
+            conventions.AddTypeSchema(
                 when: c => c.Type.SkipNullable().IsEnum,
                 schema: (c, cc) => EnumInline(c.Type, cc)
             );
 
             // Property defaults
-            builder.Index.Property.Add<DataAttribute>();
-            builder.Conventions.SetPropertyAttribute(
+            conventions.SetPropertyAttribute(
                 when: c => c.Property.IsPublic,
                 attribute: c => new DataAttribute(c.Property.Name.Camelize()) { Label = c.Property.Name.Titleize() },
                 order: -10
             );
-            builder.Conventions.AddPropertyAttributeConfiguration<DataAttribute>(
+            conventions.AddPropertyAttributeConfiguration<DataAttribute>(
                 when: c => c.Property.Has<IdAttribute>(),
                 attribute: data => data.Visible = false
             );
-            builder.Conventions.AddPropertyComponent(
+            conventions.AddPropertyComponent(
                 when: c =>
                     c.Property.PropertyType.Is<string>() ||
                     c.Property.PropertyType.SkipNullable().Is<Guid>() ||
@@ -77,37 +83,35 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
                 order: UiLayer.MinConventionOrder + 10
             );
 
-            // Method defaults
-            builder.Index.Method.Add<ActionAttribute>();
-            builder.Index.Method.Add<RouteAttribute>();
-            builder.Conventions.SetMethodAttribute(
+            // Method Defaults
+            conventions.SetMethodAttribute(
                 when: c => c.Method.Has<ActionModelAttribute>(),
                 attribute: () => new ActionAttribute(),
                 order: RestApiLayer.MaxConventionOrder + 10
             );
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 where: cc => cc.Path.Is(nameof(Page), "*", "*"),
                 component: (c, cc) => MethodFormPage(c.Method, cc)
             );
-            builder.Conventions.AddMethodSchema(
+            conventions.AddMethodSchema(
                 schema: (c, cc) => MethodContent(c.Method, cc)
             );
-            builder.Conventions.AddMethodSchema(
+            conventions.AddMethodSchema(
                 schema: c => MethodRemote(c.Method)
             );
-            builder.Conventions.AddMethodSchemaConfiguration<RemoteData>(
+            conventions.AddMethodSchemaConfiguration<RemoteData>(
                 when: c => c.Type.Has<LocatableAttribute>(),
                 schema: rd => rd.Params = Computed.UseRoute("params")
             );
-            builder.Conventions.AddMethodSchema(
+            conventions.AddMethodSchema(
                 when: c => c.Method.Has<ActionAttribute>(),
                 schema: (c, cc) => DomainActions.MethodRemote(c.Method)
             );
-            builder.Conventions.AddMethodSchemaConfiguration<RemoteAction>(
+            conventions.AddMethodSchemaConfiguration<RemoteAction>(
                 when: c => c.Method.DefaultOverload.Parameters.Any(),
                 schema: ra => ra.Body = Context.Model()
             );
-            builder.Conventions.AddMethodSchemaConfiguration<RemoteAction>(
+            conventions.AddMethodSchemaConfiguration<RemoteAction>(
                 when: c => c.Type.Has<LocatableAttribute>(),
                 where: cc => cc.Path.StartsWith(nameof(Page), "*", "*Page"),
                 schema: (ra, c, cc) =>
@@ -118,7 +122,7 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
                 }
             );
 
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c =>
                     c.Method.TryGet<ActionModelAttribute>(out var action) &&
                     action.Method != HttpMethod.Get,
@@ -126,7 +130,7 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
                 component: (c, cc) => MethodSimpleForm(c.Method, cc)
             );
 
-            builder.Conventions.AddMethodComponentConfiguration<SimpleForm>(
+            conventions.AddMethodComponentConfiguration<SimpleForm>(
                 component: (sf, c, cc) =>
                 {
                     cc = cc.Drill(nameof(SimpleForm), nameof(SimpleForm.Inputs));
@@ -139,7 +143,7 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
                     }
                 }
             );
-            builder.Conventions.AddMethodComponentConfiguration<FormPage>(
+            conventions.AddMethodComponentConfiguration<FormPage>(
                 component: (fp, c, cc) =>
                 {
                     var (_, l) = cc;
@@ -164,20 +168,20 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
             );
 
             // Parameter defaults
-            builder.Conventions.AddParameterAttributeConfiguration<GroupAttribute>(
+            conventions.AddParameterAttributeConfiguration<GroupAttribute>(
                 attribute: (group, c) => group.InputGroupKey = c.Parameter.Name
             );
 
-            builder.Conventions.AddParameterSchema(
+            conventions.AddParameterSchema(
                 when: c => c.Parameter.Has<ParameterModelAttribute>(),
                 schema: (c, cc) => ParameterFormPageInputGroup(c.Parameter, cc)
             );
 
-            builder.Conventions.AddParameterSchema(
+            conventions.AddParameterSchema(
                 when: c => c.Parameter.Has<ParameterModelAttribute>(),
                 schema: (c, cc) => ParameterInput(c.Parameter, cc)
             );
-            builder.Conventions.AddParameterSchemaConfiguration<Input>(
+            conventions.AddParameterSchemaConfiguration<Input>(
                 when: c =>
                     c.Parameter.ParameterType.SkipNullable().Is<int>() ||
                     c.Parameter.ParameterType.SkipNullable().Is<decimal>() ||
@@ -187,7 +191,7 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
                     c.Parameter.ParameterType.SkipNullable().Is<short>(),
                 schema: input => input.Numeric = true
             );
-            builder.Conventions.AddParameterSchemaConfiguration<Input>(
+            conventions.AddParameterSchemaConfiguration<Input>(
                 when: c => c.Parameter.Has<ParameterModelAttribute>(),
                 schema: (p, c) =>
                 {
@@ -196,14 +200,14 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
                 }
             );
 
-            builder.Conventions.AddParameterComponent(
+            conventions.AddParameterComponent(
                 when: c =>
                     c.Parameter.ParameterType.Is<string>() ||
                     c.Parameter.ParameterType.SkipNullable().TryGetMetadata(out var metadata) && metadata.Has<ValueTypeAttribute>(),
                 component: (c, cc) => ParameterInputText(c.Parameter, cc),
                 order: UiLayer.MinConventionOrder + 10
             );
-            builder.Conventions.AddParameterComponent(
+            conventions.AddParameterComponent(
                 when: c =>
                     c.Parameter.ParameterType.SkipNullable().Is<int>() ||
                     c.Parameter.ParameterType.SkipNullable().Is<long>(),
@@ -212,11 +216,11 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
             );
 
             // `PageTitle` defaults
-            builder.Conventions.AddTypeComponent(
+            conventions.AddTypeComponent(
                 where: cc => cc.Path.Is(nameof(Page), "*", "*Page", "Title"),
                 component: (c, cc) => TypePageTitle(c.Type, cc)
             );
-            builder.Conventions.AddTypeComponentConfiguration<PageTitle>(
+            conventions.AddTypeComponentConfiguration<PageTitle>(
                 component: (pt, c, cc) =>
                 {
                     cc = cc.Drill(nameof(PageTitle), nameof(PageTitle.Icon));
@@ -225,11 +229,11 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
                 }
             );
 
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 where: cc => cc.Path.Is(nameof(Page), "*", "*", "*Page", "Title"),
                 component: (c, cc) => MethodPageTitle(c.Method, cc)
             );
-            builder.Conventions.AddMethodComponentConfiguration<PageTitle>(
+            conventions.AddMethodComponentConfiguration<PageTitle>(
                 component: (pt, c, cc) =>
                 {
                     cc = cc.Drill(nameof(PageTitle), nameof(PageTitle.Icon));
@@ -238,7 +242,7 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
                 }
             );
 
-            builder.Conventions.AddTypeComponentConfiguration<PageTitle>(
+            conventions.AddTypeComponentConfiguration<PageTitle>(
                 component: (pt, c, cc) =>
                 {
                     foreach (var method in c.Type.GetMembers().Methods.Having<ActionAttribute>())
@@ -256,15 +260,15 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
             );
 
             // `Select` defaults
-            builder.Conventions.AddParameterComponentConfiguration<Select>(
+            conventions.AddParameterComponentConfiguration<Select>(
                 component: (s, c) => s.Schema.ShowClear = c.Parameter.IsNullable ? true : null
             );
 
             // `SelectButton` defaults
-            builder.Conventions.AddParameterComponentConfiguration<SelectButton>(
+            conventions.AddParameterComponentConfiguration<SelectButton>(
                 component: (s, c) => s.Schema.AllowEmpty = c.Parameter.IsNullable ? true : null
             );
-            builder.Conventions.AddParameterSchemaConfiguration<Input>(
+            conventions.AddParameterSchemaConfiguration<Input>(
                 schema: i =>
                 {
                     if (i.Component.Schema is not SelectButton sb) { return; }

--- a/core/src/Baked/Theme/Default/DefaultThemeFeature.cs
+++ b/core/src/Baked/Theme/Default/DefaultThemeFeature.cs
@@ -22,7 +22,7 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
 {
     public virtual void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Type.Add<RouteAttribute>();
             builder.Index.Property.Add<DataAttribute>();

--- a/core/src/Baked/Theme/Default/DefaultThemeFeature.cs
+++ b/core/src/Baked/Theme/Default/DefaultThemeFeature.cs
@@ -30,7 +30,7 @@ public class DefaultThemeFeature(IEnumerable<Route> _routes,
             builder.Index.Method.Add<RouteAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             // Type defaults
             conventions.AddTypeComponent(

--- a/core/src/Baked/Ux/ActionsAreContents/ActionsAreContentsUxFeature.cs
+++ b/core/src/Baked/Ux/ActionsAreContents/ActionsAreContentsUxFeature.cs
@@ -12,7 +12,7 @@ public class ActionsAreContentsUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddTypeComponentConfiguration<SimplePage>(
                 when: c =>

--- a/core/src/Baked/Ux/ActionsAreContents/ActionsAreContentsUxFeature.cs
+++ b/core/src/Baked/Ux/ActionsAreContents/ActionsAreContentsUxFeature.cs
@@ -12,9 +12,9 @@ public class ActionsAreContentsUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddTypeComponentConfiguration<SimplePage>(
+            conventions.AddTypeComponentConfiguration<SimplePage>(
                 when: c =>
                     c.Type.TryGetMembers(out var members) &&
                     members.Methods.Having<ActionModelAttribute>().Any(m => m.GetAction().Method == HttpMethod.Get),
@@ -35,7 +35,7 @@ public class ActionsAreContentsUxFeature : IFeature<UxConfigurator>
                     }
                 }
             );
-            builder.Conventions.AddTypeComponentConfiguration<TabbedPage>(
+            conventions.AddTypeComponentConfiguration<TabbedPage>(
                 when: c =>
                     c.Type.TryGetMembers(out var members) &&
                     members.Methods.Having<ActionModelAttribute>().Any(m => m.GetAction().Method == HttpMethod.Get),
@@ -67,7 +67,7 @@ public class ActionsAreContentsUxFeature : IFeature<UxConfigurator>
                 },
                 order: -10
             );
-            builder.Conventions.AddTypeComponentConfiguration<TabbedPage>(
+            conventions.AddTypeComponentConfiguration<TabbedPage>(
                component: (tp, c, cc) =>
                {
                    if (tp.Schema.Tabs.Count <= 1) { return; }

--- a/core/src/Baked/Ux/ActionsAsButtons/ActionsAsButtonsUxFeature.cs
+++ b/core/src/Baked/Ux/ActionsAsButtons/ActionsAsButtonsUxFeature.cs
@@ -14,17 +14,17 @@ public class ActionsAsButtonsUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
             // `Button`
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c => c.Method.Has<ActionAttribute>() && !c.Method.DefaultOverload.Parameters.Any(),
                 where: cc => cc.Path.EndsWith("Actions", "*"),
                 component: (c, cc) => MethodButton(c.Method, cc)
             );
 
             // `SimpleForm` with dialog options
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c =>
                     c.Method.Has<ActionAttribute>() &&
                     (
@@ -34,11 +34,11 @@ public class ActionsAsButtonsUxFeature : IFeature<UxConfigurator>
                 where: cc => cc.Path.EndsWith("Actions", "*"),
                 component: (c, cc) => MethodSimpleForm(c.Method, cc)
             );
-            builder.Conventions.AddMethodSchema(
+            conventions.AddMethodSchema(
                 where: cc => cc.Path.EndsWith("Actions", "*", nameof(SimpleForm), nameof(SimpleForm.DialogOptions)),
                 schema: (c, cc) => MethodSimpleFormDialog(c.Method, cc)
             );
-            builder.Conventions.AddMethodSchemaConfiguration<SimpleForm.Dialog>(
+            conventions.AddMethodSchemaConfiguration<SimpleForm.Dialog>(
                 when: c => !c.Method.DefaultOverload.Parameters.Any(),
                 schema: (sfd, _, cc) =>
                 {
@@ -49,7 +49,7 @@ public class ActionsAsButtonsUxFeature : IFeature<UxConfigurator>
             );
 
             // Routed button and routing back
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c => c.Method.Has<ActionAttribute>() && c.Method.Has<RouteAttribute>(),
                 where: cc => cc.Path.EndsWith("Actions", "*"),
                 component: (c, cc) =>
@@ -61,7 +61,7 @@ public class ActionsAsButtonsUxFeature : IFeature<UxConfigurator>
                     );
                 }
             );
-            builder.Conventions.AddMethodSchemaConfiguration<RemoteAction>(
+            conventions.AddMethodSchemaConfiguration<RemoteAction>(
                 when: c => c.Method.TryGet<ActionAttribute>(out var action) && action.RoutePathBack is not null,
                 where: cc => cc.Path.StartsWith(nameof(Page), "*", "*", nameof(FormPage)),
                 schema: (ra, c) =>
@@ -77,27 +77,27 @@ public class ActionsAsButtonsUxFeature : IFeature<UxConfigurator>
             );
 
             // Open button (for dialog)
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 where: cc => cc.Path.EndsWith(nameof(SimpleForm.DialogOptions), nameof(SimpleForm.DialogOptions.Open)),
                 component: (c, cc) => LocalizedButton(c.Method.Name.Titleize(), cc)
             );
 
             // Submit button (for dialog and page)
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c => c.Method.Has<ActionAttribute>(),
                 where: cc => cc.Path.EndsWith("Submit"),
                 component: (c, cc) => LocalizedButton(c.Method.Name.Titleize(), cc)
             );
-            builder.Conventions.AddMethodComponentConfiguration<Button>(
+            conventions.AddMethodComponentConfiguration<Button>(
                 where: cc => cc.Path.EndsWith("Submit"),
                 component: b => b.Schema.Severity = "primary"
             );
-            builder.Conventions.AddMethodComponentConfiguration<Button>(
+            conventions.AddMethodComponentConfiguration<Button>(
                 when: c => c.Method.GetAction().Method == HttpMethod.Delete,
                 where: cc => cc.Path.EndsWith("Submit"),
                 component: b => b.Schema.Severity = "danger"
             );
-            builder.Conventions.AddMethodComponentConfiguration<Button>(
+            conventions.AddMethodComponentConfiguration<Button>(
                 where: cc => cc.Path.EndsWith(nameof(FormPage), nameof(FormPage.Submit)),
                 component: (b, _, cc) =>
                 {
@@ -108,12 +108,12 @@ public class ActionsAsButtonsUxFeature : IFeature<UxConfigurator>
             );
 
             // Cancel and back buttons
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 where: cc => cc.Path.EndsWith(nameof(SimpleForm.DialogOptions), nameof(SimpleForm.DialogOptions.Cancel)),
                 component: (_, cc) => LocalizedButton("Cancel", cc)
             );
 
-            builder.Conventions.AddMethodComponentConfiguration<PageTitle>(
+            conventions.AddMethodComponentConfiguration<PageTitle>(
                 where: cc => cc.Path.StartsWith(nameof(Page), "*", "*", nameof(FormPage)),
                 component: (fp, c, cc) =>
                 {
@@ -123,22 +123,22 @@ public class ActionsAsButtonsUxFeature : IFeature<UxConfigurator>
                     fp.Schema.Actions.Add(back);
                 }
             );
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 where: cc => cc.Path.EndsWith(nameof(FormPage), nameof(FormPage.Title), nameof(PageTitle), nameof(PageTitle.Actions), "Back"),
                 component: (_, cc) => LocalizedButton("Back", cc)
             );
-            builder.Conventions.AddMethodComponentConfiguration<Button>(
+            conventions.AddMethodComponentConfiguration<Button>(
                 where: cc => cc.Path.EndsWith("Back"),
                 component: b => b.Action = Local.UseRedirectBack()
             );
 
-            builder.Conventions.AddMethodComponentConfiguration<Button>(
+            conventions.AddMethodComponentConfiguration<Button>(
                 where: cc => cc.Path.EndsWith("Cancel") || cc.Path.EndsWith("Back"),
                 component: b => b.Schema.Variant = "text"
             );
 
             // Icons
-            builder.Conventions.AddMethodComponentConfiguration<Button>(
+            conventions.AddMethodComponentConfiguration<Button>(
                 when: c => c.Method.Has<ActionAttribute>(),
                 where: cc =>
                     !cc.Path.Contains(nameof(FormPage)) &&

--- a/core/src/Baked/Ux/ActionsAsButtons/ActionsAsButtonsUxFeature.cs
+++ b/core/src/Baked/Ux/ActionsAsButtons/ActionsAsButtonsUxFeature.cs
@@ -14,7 +14,7 @@ public class ActionsAsButtonsUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             // `Button`
             conventions.AddMethodComponent(

--- a/core/src/Baked/Ux/ActionsAsDataPanels/ActionsAsDataPanelsUxFeature.cs
+++ b/core/src/Baked/Ux/ActionsAsDataPanels/ActionsAsDataPanelsUxFeature.cs
@@ -11,7 +11,7 @@ public class ActionsAsDataPanelsUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddMethodComponent(
                 where: cc => cc.Path.EndsWith("Contents", "*", "*", nameof(Content.Component)),

--- a/core/src/Baked/Ux/ActionsAsDataPanels/ActionsAsDataPanelsUxFeature.cs
+++ b/core/src/Baked/Ux/ActionsAsDataPanels/ActionsAsDataPanelsUxFeature.cs
@@ -11,17 +11,17 @@ public class ActionsAsDataPanelsUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 where: cc => cc.Path.EndsWith("Contents", "*", "*", nameof(Content.Component)),
                 component: (c, cc) => MethodDataPanel(c.Method, cc)
             );
-            builder.Conventions.AddMethodSchema(
+            conventions.AddMethodSchema(
                 where: cc => cc.Path.EndsWith(nameof(DataPanel), nameof(DataPanel.Title)),
                 schema: (c, cc) => MethodNameInline(c.Method, cc)
             );
-            builder.Conventions.AddMethodComponentConfiguration<DataPanel>(
+            conventions.AddMethodComponentConfiguration<DataPanel>(
                 when: c => c.Method.GetAction().Method == HttpMethod.Get,
                 component: (dp, c, cc) =>
                 {
@@ -33,7 +33,7 @@ public class ActionsAsDataPanelsUxFeature : IFeature<UxConfigurator>
                     }
                 }
             );
-            builder.Conventions.AddParameterSchemaConfiguration<Input>(
+            conventions.AddParameterSchemaConfiguration<Input>(
                 where: cc => cc.Path.EndsWith(nameof(DataPanel), nameof(DataPanel.Inputs)),
                 schema: (i, c, cc) =>
                 {

--- a/core/src/Baked/Ux/DataTableDefaults/DataTableDefaultsUxFeature.cs
+++ b/core/src/Baked/Ux/DataTableDefaults/DataTableDefaultsUxFeature.cs
@@ -13,9 +13,9 @@ public class DataTableDefaultsUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddMethodComponentConfiguration<DataTable>(
+            conventions.AddMethodComponentConfiguration<DataTable>(
                 component: dt =>
                 {
                     dt.Schema.Rows = 5;
@@ -24,15 +24,15 @@ public class DataTableDefaultsUxFeature : IFeature<UxConfigurator>
             );
 
             // Columns
-            builder.Conventions.AddPropertySchema(
+            conventions.AddPropertySchema(
                 when: c => c.Property.Has<DataAttribute>(),
                 schema: (c, cc) => PropertyDataTableColumn(c.Property, cc)
             );
-            builder.Conventions.AddPropertySchemaConfiguration<DataTable.Column>(
+            conventions.AddPropertySchemaConfiguration<DataTable.Column>(
                 when: c => c.Property.PropertyType.TryGetMetadata(out var metadata) && metadata.Has<LocatableAttribute>(),
                 schema: (dtc, c, cc) => dtc.Hidden = cc.Path.StartsWith(nameof(Page), c.Property.PropertyType.Name) ? true : null
             );
-            builder.Conventions.AddPropertySchemaConfiguration<DataTable.Column>(
+            conventions.AddPropertySchemaConfiguration<DataTable.Column>(
                 schema: (dtc, c, cc) =>
                 {
                     var (_, l) = cc;
@@ -42,7 +42,7 @@ public class DataTableDefaultsUxFeature : IFeature<UxConfigurator>
                     dtc.Exportable = true;
                 }
             );
-            builder.Conventions.AddPropertySchemaConfiguration<DataTable.Column>(
+            conventions.AddPropertySchemaConfiguration<DataTable.Column>(
                 when: c => c.Property.PropertyType.TryGetMembers(out var members) && members.Has<LocatableAttribute>(),
                 schema: (dtc, c, cc) =>
                 {
@@ -57,7 +57,7 @@ public class DataTableDefaultsUxFeature : IFeature<UxConfigurator>
                     dtc.Component.Data ??= Context.Parent(options: o => o.Prop = $"{rootProp}.{data.Prop}.{labelData.Prop}");
                 }
             );
-            builder.Conventions.AddPropertySchemaConfiguration<DataTable.Column>(
+            conventions.AddPropertySchemaConfiguration<DataTable.Column>(
                 schema: (dtc, c, cc) =>
                 {
                     var data = c.Property.Get<DataAttribute>();
@@ -69,20 +69,20 @@ public class DataTableDefaultsUxFeature : IFeature<UxConfigurator>
             );
 
             // Export
-            builder.Conventions.AddMethodSchema(
+            conventions.AddMethodSchema(
                 when: c => c.Method.Has<ComponentGeneratorAttribute<DataTable>>(),
                 schema: (c, cc) => MethodDataTableExport(c.Method, cc),
                 order: 10
             );
 
             // Actions
-            builder.Conventions.AddMethodSchemaConfiguration<RemoteAction>(
+            conventions.AddMethodSchemaConfiguration<RemoteAction>(
                 when: c => c.Method.Has<ActionAttribute>(),
                 where: cc => cc.Path.Contains(nameof(DataTable), nameof(DataTable.Actions)),
                 schema: ra => ra.Params = Context.Parent(options: o => o.Prop = "row")
             );
 
-            builder.Conventions.AddMethodComponentConfiguration<DataTable>(
+            conventions.AddMethodComponentConfiguration<DataTable>(
                 component: dt =>
                 {
                     if (dt.Schema.Actions is null) { return; }
@@ -99,7 +99,7 @@ public class DataTableDefaultsUxFeature : IFeature<UxConfigurator>
                 }
             );
 
-            builder.Conventions.AddMethodSchemaConfiguration<DataTable.Column>(
+            conventions.AddMethodSchemaConfiguration<DataTable.Column>(
                 where: cc => cc.Path.EndsWith(nameof(DataTable), nameof(DataTable.Actions)),
                 schema: (col, c, cc) =>
                 {
@@ -110,14 +110,14 @@ public class DataTableDefaultsUxFeature : IFeature<UxConfigurator>
             );
 
             // `Button` defaults
-            builder.Conventions.AddMethodComponentConfiguration<Button>(
+            conventions.AddMethodComponentConfiguration<Button>(
                 where: cc =>
                     cc.Path.EndsWith(nameof(DataTable), nameof(DataTable.Actions), "*") ||
                     cc.Path.EndsWith(nameof(DataTable), nameof(DataTable.Actions), "**", nameof(SimpleForm.DialogOptions.Open)),
                 component: ButtonDefaults,
                 order: 10
             );
-            builder.Conventions.AddPropertyComponentConfiguration<Button>(
+            conventions.AddPropertyComponentConfiguration<Button>(
                 where: cc => cc.Path.EndsWith(nameof(DataTable), nameof(DataTable.Columns), "**", nameof(SimpleForm.DialogOptions.Open)),
                 component: ButtonDefaults,
                 order: 10

--- a/core/src/Baked/Ux/DataTableDefaults/DataTableDefaultsUxFeature.cs
+++ b/core/src/Baked/Ux/DataTableDefaults/DataTableDefaultsUxFeature.cs
@@ -13,7 +13,7 @@ public class DataTableDefaultsUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddMethodComponentConfiguration<DataTable>(
                 component: dt =>

--- a/core/src/Baked/Ux/DescriptionProperty/DescriptionPropertyUxFeature.cs
+++ b/core/src/Baked/Ux/DescriptionProperty/DescriptionPropertyUxFeature.cs
@@ -16,42 +16,45 @@ public class DescriptionPropertyUxFeature : IFeature<UxConfigurator>
         {
             builder.Index.Property.Add<DescriptionAttribute>();
             builder.Index.Parameter.Add<DescriptionAttribute>();
+        });
 
-            builder.Conventions.SetPropertyAttribute(
+        configurator.Domain.ConfigureDomainConventions(conventions =>
+        {
+            conventions.SetPropertyAttribute(
                 when: c => c.Property.Name.EndsWith("Description"),
                 attribute: () => new DescriptionAttribute()
             );
 
-            builder.Conventions.SetParameterAttribute(
+            conventions.SetParameterAttribute(
                 when: c => c.Parameter.Name.Pascalize().EndsWith("Description"),
                 attribute: () => new DescriptionAttribute()
             );
 
-            builder.Conventions.AddPropertySchemaConfiguration<Field>(
+            conventions.AddPropertySchemaConfiguration<Field>(
                 when: c => c.Property.Has<DescriptionAttribute>(),
                 schema: f => f.Wide = true
             );
 
-            builder.Conventions.AddParameterSchemaConfiguration<FormPage.InputGroup>(
+            conventions.AddParameterSchemaConfiguration<FormPage.InputGroup>(
                 when: c => c.Parameter.Has<DescriptionAttribute>(),
                 schema: f => f.Wide = true
             );
 
-            builder.Conventions.AddPropertyComponent(
+            conventions.AddPropertyComponent(
                 when: c => c.Property.Has<DescriptionAttribute>(),
                 where: cc => cc.Path.EndsWith(nameof(DataTable), nameof(DataTable.Columns), "*", nameof(DataTable.Column.Component)),
                 component: (c, cc) => PropertyDialog(c.Property, cc)
             );
-            builder.Conventions.AddPropertyComponent(
+            conventions.AddPropertyComponent(
                 when: c => c.Property.Has<DescriptionAttribute>(),
                 where: cc => cc.Path.EndsWith(nameof(Dialog.Open)),
                 component: (c, cc) => LocalizedButton(c.Property.Name.Titleize(), cc)
             );
-            builder.Conventions.AddPropertyComponentConfiguration<Button>(
+            conventions.AddPropertyComponentConfiguration<Button>(
                 where: cc => cc.Path.EndsWith(nameof(Dialog.Open)),
                 component: b => b.Schema.Icon = "pi pi-eye"
             );
-            builder.Conventions.AddPropertyComponentConfiguration<Dialog>(
+            conventions.AddPropertyComponentConfiguration<Dialog>(
                 component: d => d.Schema.Content.Data ??= Context.Parent()
             );
         });

--- a/core/src/Baked/Ux/DescriptionProperty/DescriptionPropertyUxFeature.cs
+++ b/core/src/Baked/Ux/DescriptionProperty/DescriptionPropertyUxFeature.cs
@@ -12,7 +12,7 @@ public class DescriptionPropertyUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureBuilder(builder =>
         {
             builder.Index.Property.Add<DescriptionAttribute>();
             builder.Index.Parameter.Add<DescriptionAttribute>();

--- a/core/src/Baked/Ux/DescriptionProperty/DescriptionPropertyUxFeature.cs
+++ b/core/src/Baked/Ux/DescriptionProperty/DescriptionPropertyUxFeature.cs
@@ -18,7 +18,7 @@ public class DescriptionPropertyUxFeature : IFeature<UxConfigurator>
             builder.Index.Parameter.Add<DescriptionAttribute>();
         });
 
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetPropertyAttribute(
                 when: c => c.Property.Name.EndsWith("Description"),

--- a/core/src/Baked/Ux/EnumParameterIsSelect/EnumParameterIsSelectUxFeature.cs
+++ b/core/src/Baked/Ux/EnumParameterIsSelect/EnumParameterIsSelectUxFeature.cs
@@ -12,7 +12,7 @@ public class EnumParameterIsSelectUxFeature(int _maxMemberCountForSelectButton)
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             // Use `SelectButton` when enum member count is <= _maxMemberCountForSelectButton
             conventions.AddParameterComponent(

--- a/core/src/Baked/Ux/EnumParameterIsSelect/EnumParameterIsSelectUxFeature.cs
+++ b/core/src/Baked/Ux/EnumParameterIsSelect/EnumParameterIsSelectUxFeature.cs
@@ -12,16 +12,16 @@ public class EnumParameterIsSelectUxFeature(int _maxMemberCountForSelectButton)
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
             // Use `SelectButton` when enum member count is <= _maxMemberCountForSelectButton
-            builder.Conventions.AddParameterComponent(
+            conventions.AddParameterComponent(
                 when: c =>
                     c.Parameter.ParameterType.SkipNullable().IsEnum &&
                     c.Parameter.ParameterType.SkipNullable().GetEnumNames().Count() <= _maxMemberCountForSelectButton,
                 component: (c, cc) => ParameterSelectButton(c.Parameter, cc)
             );
-            builder.Conventions.AddParameterComponentConfiguration<SelectButton>(
+            conventions.AddParameterComponentConfiguration<SelectButton>(
                 when: c => c.Parameter.ParameterType.SkipNullable().IsEnum,
                 component: (s, c) =>
                 {
@@ -34,13 +34,13 @@ public class EnumParameterIsSelectUxFeature(int _maxMemberCountForSelectButton)
             );
 
             // Use `Select` when enum member count is > _maxMemberCountForSelectButton
-            builder.Conventions.AddParameterComponent(
+            conventions.AddParameterComponent(
                 when: c =>
                     c.Parameter.ParameterType.SkipNullable().IsEnum &&
                     c.Parameter.ParameterType.SkipNullable().GetEnumNames().Count() > _maxMemberCountForSelectButton,
                 component: (c, cc) => ParameterSelect(c.Parameter, cc)
             );
-            builder.Conventions.AddParameterComponentConfiguration<Select>(
+            conventions.AddParameterComponentConfiguration<Select>(
                 when: c => c.Parameter.ParameterType.SkipNullable().IsEnum,
                 component: (s, c) =>
                 {
@@ -54,7 +54,7 @@ public class EnumParameterIsSelectUxFeature(int _maxMemberCountForSelectButton)
 
             // Default value of a required enum parameter is set to the first enum
             // member when it is in query or route
-            builder.Conventions.AddParameterSchemaConfiguration<Input>(
+            conventions.AddParameterSchemaConfiguration<Input>(
                 when: c =>
                     c.Parameter.ParameterType.SkipNullable().IsEnum &&
                     c.Parameter.Has<RequiredAttribute>() &&

--- a/core/src/Baked/Ux/FormInputsAreIftaLabel/FormInputsAreIftaLabelUxFeature.cs
+++ b/core/src/Baked/Ux/FormInputsAreIftaLabel/FormInputsAreIftaLabelUxFeature.cs
@@ -8,7 +8,7 @@ public class FormInputsAreIftaLabelUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddParameterSchemaConfiguration<Input>(
                 where: cc =>

--- a/core/src/Baked/Ux/FormInputsAreIftaLabel/FormInputsAreIftaLabelUxFeature.cs
+++ b/core/src/Baked/Ux/FormInputsAreIftaLabel/FormInputsAreIftaLabelUxFeature.cs
@@ -8,9 +8,9 @@ public class FormInputsAreIftaLabelUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddParameterSchemaConfiguration<Input>(
+            conventions.AddParameterSchemaConfiguration<Input>(
                 where: cc =>
                     cc.Path.EndsWith(nameof(SimpleForm), nameof(SimpleForm.Inputs)) ||
                     cc.Path.EndsWith(nameof(FormPage), "**", nameof(FormPage.InputGroup.Inputs)),

--- a/core/src/Baked/Ux/InitializerParametersAreInPageTitle/InitializerParametersAreInPageTitleUxFeature.cs
+++ b/core/src/Baked/Ux/InitializerParametersAreInPageTitle/InitializerParametersAreInPageTitleUxFeature.cs
@@ -10,9 +10,9 @@ public class InitializerParametersAreInPageTitleUxFeature : IFeature<UxConfigura
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddTypeComponentConfiguration<TabbedPage>(
+            conventions.AddTypeComponentConfiguration<TabbedPage>(
                 when: c =>
                     c.Type.Has<TransientAttribute>() && c.Type.HasMembers() &&
                     !c.Type.Has<LocatableAttribute>(),
@@ -34,12 +34,12 @@ public class InitializerParametersAreInPageTitleUxFeature : IFeature<UxConfigura
                 }
             );
 
-            builder.Conventions.AddParameterSchemaConfiguration<Input>(
+            conventions.AddParameterSchemaConfiguration<Input>(
                 where: cc => cc.Path.EndsWith(nameof(TabbedPage), nameof(TabbedPage.Inputs)),
                 schema: i => i.QueryBound = true
             );
 
-            builder.Conventions.AddParameterSchemaConfiguration<Input>(
+            conventions.AddParameterSchemaConfiguration<Input>(
                 where: cc => cc.Path.EndsWith(nameof(TabbedPage), nameof(TabbedPage.Inputs)),
                 schema: (i, c, cc) =>
                 {

--- a/core/src/Baked/Ux/InitializerParametersAreInPageTitle/InitializerParametersAreInPageTitleUxFeature.cs
+++ b/core/src/Baked/Ux/InitializerParametersAreInPageTitle/InitializerParametersAreInPageTitleUxFeature.cs
@@ -10,7 +10,7 @@ public class InitializerParametersAreInPageTitleUxFeature : IFeature<UxConfigura
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddTypeComponentConfiguration<TabbedPage>(
                 when: c =>

--- a/core/src/Baked/Ux/LabelsAreFrozen/LabelsAreFrozenUxFeature.cs
+++ b/core/src/Baked/Ux/LabelsAreFrozen/LabelsAreFrozenUxFeature.cs
@@ -10,13 +10,13 @@ public class LabelsAreFrozenUxFeature()
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddPropertyAttributeConfiguration<DataAttribute>(
+            conventions.AddPropertyAttributeConfiguration<DataAttribute>(
                 when: c => c.Property.Has<LabelAttribute>(),
                 attribute: data => data.Order = -10
             );
-            builder.Conventions.AddPropertySchemaConfiguration<DataTable.Column>(
+            conventions.AddPropertySchemaConfiguration<DataTable.Column>(
                 when: c => c.Property.Has<LabelAttribute>(),
                 schema: dtc =>
                 {
@@ -24,7 +24,7 @@ public class LabelsAreFrozenUxFeature()
                     dtc.MinWidth = true;
                 }
             );
-            builder.Conventions.AddMethodComponentConfiguration<DataTable>(
+            conventions.AddMethodComponentConfiguration<DataTable>(
                 component: (dt, c) =>
                 {
                     if (dt.Schema.DataKey is not null) { return; }

--- a/core/src/Baked/Ux/LabelsAreFrozen/LabelsAreFrozenUxFeature.cs
+++ b/core/src/Baked/Ux/LabelsAreFrozen/LabelsAreFrozenUxFeature.cs
@@ -10,7 +10,7 @@ public class LabelsAreFrozenUxFeature()
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddPropertyAttributeConfiguration<DataAttribute>(
                 when: c => c.Property.Has<LabelAttribute>(),

--- a/core/src/Baked/Ux/ListIsDataTable/ListIsDataTableUxFeature.cs
+++ b/core/src/Baked/Ux/ListIsDataTable/ListIsDataTableUxFeature.cs
@@ -11,7 +11,7 @@ public class ListIsDataTableUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddMethodComponent(
                 when: c => c.Method.DefaultOverload.ReturnsList(),

--- a/core/src/Baked/Ux/ListIsDataTable/ListIsDataTableUxFeature.cs
+++ b/core/src/Baked/Ux/ListIsDataTable/ListIsDataTableUxFeature.cs
@@ -11,14 +11,14 @@ public class ListIsDataTableUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c => c.Method.DefaultOverload.ReturnsList(),
                 where: cc => cc.Path.EndsWith("*Panel", "Content") || cc.Path.EndsWith("*Container", "Content"),
                 component: (c, cc) => MethodDataTable(c.Method, cc)
             );
-            builder.Conventions.AddMethodComponentConfiguration<DataTable>(
+            conventions.AddMethodComponentConfiguration<DataTable>(
                 when: c =>
                     c.Method.DefaultOverload.ReturnsList() &&
                     c.Method.DefaultOverload.ReturnType.SkipTask().TryGetElementType(out var elementType) &&
@@ -43,7 +43,7 @@ public class ListIsDataTableUxFeature : IFeature<UxConfigurator>
                 },
                 order: -10
             );
-            builder.Conventions.AddMethodSchema(
+            conventions.AddMethodSchema(
                 when: c =>
                     c.Method.DefaultOverload.ReturnsList() &&
                     c.Method.DefaultOverload.ReturnType.SkipTask().TryGetElementType(out var elementType) &&
@@ -52,7 +52,7 @@ public class ListIsDataTableUxFeature : IFeature<UxConfigurator>
                 where: cc => cc.Path.EndsWith(nameof(DataTable), nameof(DataTable.Actions)),
                 schema: () => ActionsDataTableColumn()
             );
-            builder.Conventions.AddMethodSchemaConfiguration<DataTable.Column>(
+            conventions.AddMethodSchemaConfiguration<DataTable.Column>(
                 when: c =>
                     c.Method.DefaultOverload.ReturnsList() &&
                     c.Method.DefaultOverload.ReturnType.TryGetElementType(out var itemType) &&

--- a/core/src/Baked/Ux/NumericValuesAreFormatted/NumericValuesAreFormattedUxFeature.cs
+++ b/core/src/Baked/Ux/NumericValuesAreFormatted/NumericValuesAreFormattedUxFeature.cs
@@ -9,7 +9,7 @@ public class NumericValuesAreFormattedUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddPropertySchemaConfiguration<DataTable.Column>(
                 when: c =>

--- a/core/src/Baked/Ux/NumericValuesAreFormatted/NumericValuesAreFormattedUxFeature.cs
+++ b/core/src/Baked/Ux/NumericValuesAreFormatted/NumericValuesAreFormattedUxFeature.cs
@@ -9,9 +9,9 @@ public class NumericValuesAreFormattedUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddPropertySchemaConfiguration<DataTable.Column>(
+            conventions.AddPropertySchemaConfiguration<DataTable.Column>(
                 when: c =>
                     c.Property.PropertyType.SkipNullable().Is<int>() ||
                     c.Property.PropertyType.SkipNullable().Is<long>() ||
@@ -19,17 +19,17 @@ public class NumericValuesAreFormattedUxFeature : IFeature<UxConfigurator>
                     c.Property.PropertyType.SkipNullable().Is<decimal>(),
                 schema: dtc => dtc.AlignRight = true
             );
-            builder.Conventions.AddPropertyComponent(
+            conventions.AddPropertyComponent(
                 when: c =>
                     c.Property.PropertyType.SkipNullable().Is<int>() ||
                     c.Property.PropertyType.SkipNullable().Is<long>(),
                 component: (c) => B.Number()
             );
-            builder.Conventions.AddPropertyComponent(
+            conventions.AddPropertyComponent(
                 when: c => c.Property.PropertyType.SkipNullable().Is<decimal>(),
                 component: () => B.Money()
             );
-            builder.Conventions.AddPropertyComponent(
+            conventions.AddPropertyComponent(
                 when: c => c.Property.PropertyType.SkipNullable().Is<double>(),
                 component: () => B.Rate()
             );

--- a/core/src/Baked/Ux/ObjectWithListIsDataTable/ObjectWithListIsDataTableUxFeature.cs
+++ b/core/src/Baked/Ux/ObjectWithListIsDataTable/ObjectWithListIsDataTableUxFeature.cs
@@ -12,9 +12,9 @@ public class ObjectWithListIsDataTableUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c =>
                     c.Type.TryGetMembers(out var members) &&
                     members.Properties.Any(p =>
@@ -34,14 +34,14 @@ public class ObjectWithListIsDataTableUxFeature : IFeature<UxConfigurator>
                 )
             );
 
-            builder.Conventions.AddPropertyAttributeConfiguration<DataAttribute>(
+            conventions.AddPropertyAttributeConfiguration<DataAttribute>(
                 when: c =>
                     c.Type.TryGet<ObjectWithListAttribute>(out var objectWithList) &&
                     c.Property.Name == objectWithList.ListPropertyName,
                 attribute: data => data.Visible = false
             );
 
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c =>
                     c.Method.DefaultOverload.ReturnType.SkipTask().TryGetMetadata(out var returnMetadata) &&
                     returnMetadata.Has<ObjectWithListAttribute>(),
@@ -56,7 +56,7 @@ public class ObjectWithListIsDataTableUxFeature : IFeature<UxConfigurator>
                         .Camelize();
                 })
             );
-            builder.Conventions.AddMethodComponentConfiguration<DataTable>(
+            conventions.AddMethodComponentConfiguration<DataTable>(
                 when: c =>
                     c.Method.DefaultOverload.ReturnType.SkipTask().TryGetMetadata(out var returnMetadata) &&
                     returnMetadata.Has<ObjectWithListAttribute>(),
@@ -70,7 +70,7 @@ public class ObjectWithListIsDataTableUxFeature : IFeature<UxConfigurator>
                         .Camelize();
                 }
             );
-            builder.Conventions.AddMethodComponentConfiguration<DataTable>(
+            conventions.AddMethodComponentConfiguration<DataTable>(
                 when: c =>
                     c.Method.DefaultOverload.ReturnType.SkipTask().TryGetMembers(out var returnMembers) &&
                     returnMembers.TryGet<ObjectWithListAttribute>(out var objectWithList) &&
@@ -101,7 +101,7 @@ public class ObjectWithListIsDataTableUxFeature : IFeature<UxConfigurator>
                 },
                 order: -10
             );
-            builder.Conventions.AddMethodSchema(
+            conventions.AddMethodSchema(
                 when: c =>
                     c.Method.DefaultOverload.ReturnType.SkipTask().TryGetMembers(out var returnMembers) &&
                     returnMembers.TryGet<ObjectWithListAttribute>(out var objectWithList) &&
@@ -113,7 +113,7 @@ public class ObjectWithListIsDataTableUxFeature : IFeature<UxConfigurator>
                 where: cc => cc.Path.EndsWith(nameof(DataTable), nameof(DataTable.Actions)),
                 schema: () => ActionsDataTableColumn()
             );
-            builder.Conventions.AddMethodSchemaConfiguration<DataTable.Column>(
+            conventions.AddMethodSchemaConfiguration<DataTable.Column>(
                 when: c =>
                     c.Method.DefaultOverload.ReturnType.SkipTask().TryGetMembers(out var returnMembers) &&
                     returnMembers.TryGet<ObjectWithListAttribute>(out var objectWithList) &&
@@ -142,13 +142,13 @@ public class ObjectWithListIsDataTableUxFeature : IFeature<UxConfigurator>
                 }
             );
 
-            builder.Conventions.AddMethodSchema(
+            conventions.AddMethodSchema(
                 when: c =>
                     c.Method.DefaultOverload.ReturnType.SkipTask().TryGetMetadata(out var returnMetadata) &&
                     returnMetadata.Has<ObjectWithListAttribute>(),
                 schema: (c, cc) => MethodDataTableFooter(c.Method, cc)
             );
-            builder.Conventions.AddMethodSchemaConfiguration<DataTable.Footer>(
+            conventions.AddMethodSchemaConfiguration<DataTable.Footer>(
                 when: c =>
                     c.Method.DefaultOverload.ReturnType.SkipTask().TryGetMembers(out var returnMembers) &&
                     returnMembers.Has<ObjectWithListAttribute>(),
@@ -171,7 +171,7 @@ public class ObjectWithListIsDataTableUxFeature : IFeature<UxConfigurator>
                 }
             );
 
-            builder.Conventions.AddPropertySchemaConfiguration<DataTable.Column>(
+            conventions.AddPropertySchemaConfiguration<DataTable.Column>(
                 where: cc => cc.Path.Contains(nameof(DataTable), nameof(DataTable.FooterTemplate)),
                 schema: dtc =>
                 {

--- a/core/src/Baked/Ux/ObjectWithListIsDataTable/ObjectWithListIsDataTableUxFeature.cs
+++ b/core/src/Baked/Ux/ObjectWithListIsDataTable/ObjectWithListIsDataTableUxFeature.cs
@@ -12,7 +12,7 @@ public class ObjectWithListIsDataTableUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c =>

--- a/core/src/Baked/Ux/PanelParametersAreStateful/PanelParametersAreStatefulUxFeature.cs
+++ b/core/src/Baked/Ux/PanelParametersAreStateful/PanelParametersAreStatefulUxFeature.cs
@@ -7,7 +7,7 @@ public class PanelParametersAreStatefulUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddParameterComponentConfiguration<Select>(
                 component: sb => sb.Schema.Stateful = true,

--- a/core/src/Baked/Ux/PanelParametersAreStateful/PanelParametersAreStatefulUxFeature.cs
+++ b/core/src/Baked/Ux/PanelParametersAreStateful/PanelParametersAreStatefulUxFeature.cs
@@ -7,13 +7,13 @@ public class PanelParametersAreStatefulUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddParameterComponentConfiguration<Select>(
+            conventions.AddParameterComponentConfiguration<Select>(
                 component: sb => sb.Schema.Stateful = true,
                 where: cc => cc.Path.EndsWith(nameof(DataPanel), nameof(DataPanel.Inputs), "*", nameof(Input.Component))
             );
-            builder.Conventions.AddParameterComponentConfiguration<SelectButton>(
+            conventions.AddParameterComponentConfiguration<SelectButton>(
                 component: sb => sb.Schema.Stateful = true,
                 where: cc => cc.Path.EndsWith(nameof(DataPanel), nameof(DataPanel.Inputs), "*", nameof(Input.Component))
             );

--- a/core/src/Baked/Ux/PropertiesAsFieldset/PropertiesAsFieldsetUxFeature.cs
+++ b/core/src/Baked/Ux/PropertiesAsFieldset/PropertiesAsFieldsetUxFeature.cs
@@ -12,9 +12,9 @@ public class PropertiesAsFieldsetUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddTypeComponentConfiguration<SimplePage>(
+            conventions.AddTypeComponentConfiguration<SimplePage>(
                 when: c =>
                     c.Type.TryGetMembers(out var members) &&
                     members.Properties.GetDataProperties().Any(),
@@ -29,21 +29,21 @@ public class PropertiesAsFieldsetUxFeature : IFeature<UxConfigurator>
                 },
                 order: -10
             );
-            builder.Conventions.AddTypeSchema(
+            conventions.AddTypeSchema(
                 when: c =>
                     c.Type.TryGetMembers(out var members) &&
                     members.Properties.GetDataProperties().Any(),
                 where: cc => cc.Path.EndsWith("Fields"),
                 schema: (c, cc) => TypeContent(c.Type, cc, "fields")
             );
-            builder.Conventions.AddTypeComponent(
+            conventions.AddTypeComponent(
                 when: c =>
                     c.Type.TryGetMembers(out var members) &&
                     members.Properties.GetDataProperties().Any(),
                 where: cc => cc.Path.EndsWith("Fields", nameof(Content.Component)),
                 component: (c, cc) => TypeFieldset(c.Type.GetMembers(), cc)
             );
-            builder.Conventions.AddTypeComponentConfiguration<Fieldset>(
+            conventions.AddTypeComponentConfiguration<Fieldset>(
                 when: c =>
                     c.Type.TryGetMembers(out var members) &&
                     members.Properties.GetDataProperties().Any(),
@@ -60,10 +60,10 @@ public class PropertiesAsFieldsetUxFeature : IFeature<UxConfigurator>
                     }
                 }
             );
-            builder.Conventions.AddPropertySchema(
+            conventions.AddPropertySchema(
                 schema: (c, cc) => PropertyField(c.Property, cc)
             );
-            builder.Conventions.AddPropertySchemaConfiguration<Field>(
+            conventions.AddPropertySchemaConfiguration<Field>(
                 when: c =>
                     c.Property.Has<DataAttribute>() &&
                     c.Property.PropertyType.TryGetMembers(out var members) && members.Has<LocatableAttribute>(),
@@ -79,7 +79,7 @@ public class PropertiesAsFieldsetUxFeature : IFeature<UxConfigurator>
                     dtc.Component.Data ??= Context.Parent(options: o => o.Prop = $"data.{data.Prop}.{labelData.Prop}");
                 }
             );
-            builder.Conventions.AddPropertySchemaConfiguration<Field>(
+            conventions.AddPropertySchemaConfiguration<Field>(
                 when: c => c.Property.Has<DataAttribute>(),
                 schema: (f, c) =>
                 {

--- a/core/src/Baked/Ux/PropertiesAsFieldset/PropertiesAsFieldsetUxFeature.cs
+++ b/core/src/Baked/Ux/PropertiesAsFieldset/PropertiesAsFieldsetUxFeature.cs
@@ -12,7 +12,7 @@ public class PropertiesAsFieldsetUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddTypeComponentConfiguration<SimplePage>(
                 when: c =>

--- a/core/src/Baked/Ux/QueryActionAsDataContainer/QueryActionAsDataContainerUxFeature.cs
+++ b/core/src/Baked/Ux/QueryActionAsDataContainer/QueryActionAsDataContainerUxFeature.cs
@@ -19,7 +19,7 @@ public class QueryActionAsDataContainerUxFeature(int[] _pageSizeOptions)
 
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             // Order is set to -10 to allow DataPanel override
             conventions.AddMethodComponent(

--- a/core/src/Baked/Ux/QueryActionAsDataContainer/QueryActionAsDataContainerUxFeature.cs
+++ b/core/src/Baked/Ux/QueryActionAsDataContainer/QueryActionAsDataContainerUxFeature.cs
@@ -19,23 +19,23 @@ public class QueryActionAsDataContainerUxFeature(int[] _pageSizeOptions)
 
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
             // Order is set to -10 to allow DataPanel override
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c => c.Method.Has<QueryMethodAttribute>(),
                 where: cc => cc.Path.EndsWith("Contents", "*", "*", nameof(Content.Component)),
                 component: (c, cc) => MethodDataContainer(c.Method, cc),
                 order: -10
             );
-            builder.Conventions.AddMethodComponent(
+            conventions.AddMethodComponent(
                 when: c => c.Method.Has<QueryMethodAttribute>(),
                 where: cc => cc.Path.EndsWith(nameof(DataPanel), nameof(DataPanel.Content)),
                 component: (c, cc) => MethodDataContainer(c.Method, cc)
             );
 
             // Add sort and paging parameters to RemoteData query
-            builder.Conventions.AddMethodSchemaConfiguration<RemoteData>(
+            conventions.AddMethodSchemaConfiguration<RemoteData>(
                 when: c => c.Method.Has<QueryMethodAttribute>(),
                 where: cc => cc.Path.EndsWith(nameof(DataContainer), nameof(DataContainer.Content), "*", nameof(IComponentDescriptor.Data)),
                 schema: rd => rd.Query += Context.Parent(options: cd => cd.Prop = "container-parameters"),
@@ -43,7 +43,7 @@ public class QueryActionAsDataContainerUxFeature(int[] _pageSizeOptions)
             );
 
             // Add all inputs to DataContainer
-            builder.Conventions.AddMethodComponentConfiguration<DataContainer>(
+            conventions.AddMethodComponentConfiguration<DataContainer>(
                 component: (dc, c, cc) =>
                 {
                     foreach (var parameter in c.Method.DefaultOverload.Parameters)
@@ -55,7 +55,7 @@ public class QueryActionAsDataContainerUxFeature(int[] _pageSizeOptions)
             );
 
             // Set paging inputs to be required and numeric
-            builder.Conventions.AddParameterSchemaConfiguration<Input>(
+            conventions.AddParameterSchemaConfiguration<Input>(
                 when: c => c.Parameter.Has<PagingAttribute>(),
                 schema: input =>
                 {
@@ -68,7 +68,7 @@ public class QueryActionAsDataContainerUxFeature(int[] _pageSizeOptions)
             // Split inputs between `DataPanel` and `DataContainer` when
             // container is under a panel, keeping only sorting and paging in
             // container while keeping the rest in panel
-            builder.Conventions.AddMethodComponentConfiguration<DataPanel>(
+            conventions.AddMethodComponentConfiguration<DataPanel>(
                 when: c => c.Method.Has<QueryMethodAttribute>(),
                 component: (dp, c) =>
                 {
@@ -98,7 +98,7 @@ public class QueryActionAsDataContainerUxFeature(int[] _pageSizeOptions)
 
             // Disable virtual scroll, configure paginator and publish
             // data length when skip parameter exists
-            builder.Conventions.AddMethodComponentConfiguration<DataTable>(
+            conventions.AddMethodComponentConfiguration<DataTable>(
                 where: cc => cc.Path.Contains(nameof(DataContainer)),
                 component: (dt, c) =>
                 {
@@ -114,11 +114,11 @@ public class QueryActionAsDataContainerUxFeature(int[] _pageSizeOptions)
             );
 
             // Skip
-            builder.Conventions.AddParameterComponent(
+            conventions.AddParameterComponent(
                 when: c => c.Parameter.TryGet<PagingAttribute>(out var paging) && paging.IsSkip,
                 component: () => B.Paginator()
             );
-            builder.Conventions.AddParameterComponentConfiguration<Paginator>(
+            conventions.AddParameterComponentConfiguration<Paginator>(
                 component: p =>
                 {
                     p.Data = Context.Page(o =>
@@ -131,12 +131,12 @@ public class QueryActionAsDataContainerUxFeature(int[] _pageSizeOptions)
                 }
             );
             // When there is no take parameter, set take to 10
-            builder.Conventions.AddParameterComponentConfiguration<Paginator>(
+            conventions.AddParameterComponentConfiguration<Paginator>(
                 when: c => !c.Method.DefaultOverload.Parameters.Having<PagingAttribute>().Any(p => p.Get<PagingAttribute>().IsTake),
                 component: p => p.Data += Inline(new { take = 10 })
             );
             // When there is take parameter, use take parameter's value from page context
-            builder.Conventions.AddParameterComponentConfiguration<Paginator>(
+            conventions.AddParameterComponentConfiguration<Paginator>(
                 when: c => c.Method.DefaultOverload.Parameters.Having<PagingAttribute>().Any(p => p.Get<PagingAttribute>().IsTake),
                 component: (p, c) =>
                 {
@@ -150,7 +150,7 @@ public class QueryActionAsDataContainerUxFeature(int[] _pageSizeOptions)
             );
 
             // Take
-            builder.Conventions.AddParameterComponent(
+            conventions.AddParameterComponent(
                 when: c => c.Parameter.TryGet<PagingAttribute>(out var paging) && paging.IsTake,
                 component: (c, cc) =>
                 {
@@ -160,11 +160,11 @@ public class QueryActionAsDataContainerUxFeature(int[] _pageSizeOptions)
                     return B.Select(Inline(_pageSizeOptions, options: i => i.RequireLocalization = false));
                 }
             );
-            builder.Conventions.AddParameterComponentConfiguration<Select>(
+            conventions.AddParameterComponentConfiguration<Select>(
                 when: c => c.Parameter.TryGet<PagingAttribute>(out var paging) && paging.IsTake,
                 component: s => s.Override(B.PageSize())
             );
-            builder.Conventions.AddParameterComponentConfiguration<Select>(
+            conventions.AddParameterComponentConfiguration<Select>(
                 when: c => c.Parameter.TryGet<PagingAttribute>(out var paging) && paging.IsTake,
                 component: s =>
                 {

--- a/core/src/Baked/Ux/RoutedTypesAsNavLinks/RoutedTypesAsNavLinksUxFeature.cs
+++ b/core/src/Baked/Ux/RoutedTypesAsNavLinks/RoutedTypesAsNavLinksUxFeature.cs
@@ -12,7 +12,7 @@ public class RoutedTypesAsNavLinksUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainConventions(conventions =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             conventions.AddPropertyComponent(
                 when: c => c.Type.Has<RouteAttribute>() && c.Property.Has<LabelAttribute>(),

--- a/core/src/Baked/Ux/RoutedTypesAsNavLinks/RoutedTypesAsNavLinksUxFeature.cs
+++ b/core/src/Baked/Ux/RoutedTypesAsNavLinks/RoutedTypesAsNavLinksUxFeature.cs
@@ -12,14 +12,14 @@ public class RoutedTypesAsNavLinksUxFeature : IFeature<UxConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureDomainConventions(conventions =>
         {
-            builder.Conventions.AddPropertyComponent(
+            conventions.AddPropertyComponent(
                 when: c => c.Type.Has<RouteAttribute>() && c.Property.Has<LabelAttribute>(),
                 where: cc => cc.Path.EndsWith(nameof(DataTable), nameof(DataTable.Columns), "*", nameof(DataTable.Column.Component)),
                 component: (c, cc) => TypeNavLink(c.Type, cc)
             );
-            builder.Conventions.AddPropertyComponentConfiguration<NavLink>(
+            conventions.AddPropertyComponentConfiguration<NavLink>(
                 when: c => c.Type.Has<RouteAttribute>(),
                 where: cc => cc.Path.EndsWith(nameof(DataTable), nameof(DataTable.Columns), "*", nameof(DataTable.Column.Component)),
                 component: (link, c) =>

--- a/core/test/Baked.Test.Specs/Domain/ReportingErrorsInConventions.cs
+++ b/core/test/Baked.Test.Specs/Domain/ReportingErrorsInConventions.cs
@@ -13,13 +13,14 @@ public class ReportingErrorsInConventions : TestSpec
     public void Domain_model_builder_continues_execution_even_if_an_exception_occurs_during_post_build()
     {
         var hit = false;
-        var builder = GiveMe.ADomainModelBuilder(options: builder =>
+        var builder = GiveMe.ADomainModelBuilder();
+        var conventions = GiveMe.ADomainModelConventionCollection(options: conventions =>
         {
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Is<string>(),
                 attribute: () => throw GiveMe.ADiagnosticCode().Exception(GiveMe.AString())
             );
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Is<string>(),
                 attribute: () =>
                 {
@@ -32,7 +33,7 @@ public class ReportingErrorsInConventions : TestSpec
 
         builder
             .StartBuild([typeof(string)])
-            .EndBuild();
+            .EndBuild(conventions);
 
         hit.ShouldBeTrue();
     }
@@ -43,16 +44,20 @@ public class ReportingErrorsInConventions : TestSpec
         var exceptions = new List<Exception>();
         var builder = GiveMe.ADomainModelBuilder(options: builder =>
         {
-            builder.Conventions.SetTypeAttribute(
+            builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
+        });
+
+        var conventions = GiveMe.ADomainModelConventionCollection(options: conventions =>
+        {
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Is<string>(),
                 attribute: () => throw GiveMe.ADiagnosticCode().Exception("test")
             );
-            builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
         });
 
         builder
             .StartBuild([typeof(string)])
-            .EndBuild();
+            .EndBuild(conventions);
 
         exceptions.Count.ShouldBe(1);
         exceptions.ShouldContain(e => e.Message == "test");
@@ -64,20 +69,23 @@ public class ReportingErrorsInConventions : TestSpec
         var exceptions = new List<Exception>();
         var builder = GiveMe.ADomainModelBuilder(options: builder =>
         {
-            builder.Conventions.SetTypeAttribute(
+            builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
+        });
+        var conventions = GiveMe.ADomainModelConventionCollection(options: conventions =>
+        {
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Is<string>(),
                 attribute: () => throw GiveMe.ADiagnosticCode().Exception("string error")
             );
-            builder.Conventions.SetTypeAttribute(
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Is<int>(),
                 attribute: () => throw GiveMe.ADiagnosticCode().Exception("int error")
             );
-            builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
         });
 
         builder
             .StartBuild([typeof(string), typeof(int)])
-            .EndBuild();
+            .EndBuild(conventions);
 
         exceptions.Count.ShouldBe(2);
         exceptions.ShouldContain(e => e.Message == "string error");
@@ -90,16 +98,19 @@ public class ReportingErrorsInConventions : TestSpec
         var exceptions = new List<Exception>();
         var builder = GiveMe.ADomainModelBuilder(options: builder =>
         {
-            builder.Conventions.SetTypeAttribute(
+            builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
+        });
+        var conventions = GiveMe.ADomainModelConventionCollection(options: conventions =>
+        {
+            conventions.SetTypeAttribute(
                 when: c => c.Type.Is<string>() || c.Type.Is<int>(),
                 attribute: c => throw GiveMe.ADiagnosticCode().Exception($"{c.Type.Name} error")
             );
-            builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
         });
 
         builder
             .StartBuild([typeof(string), typeof(int)])
-            .EndBuild();
+            .EndBuild(conventions);
 
         exceptions.Count.ShouldBe(2);
         exceptions.ShouldContain(e => e.Message == "String error");
@@ -155,13 +166,16 @@ public class ReportingErrorsInConventions : TestSpec
             builder.BuildLevels.Add(BuildLevels.Basics);
             builder.BindingFlags.Property = BindingFlags.Instance | BindingFlags.Public;
             builder.BindingFlags.Method = BindingFlags.Instance | BindingFlags.Public;
-            builder.Conventions.Add(new StubConvention(GiveMe));
             builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
+        });
+        var conventions = GiveMe.ADomainModelConventionCollection(options: conventions =>
+        {
+            conventions.Add(new StubConvention(GiveMe));
         });
 
         builder
             .StartBuild([typeof(char), typeof(int), typeof(double), typeof(long), typeof(string)])
-            .EndBuild();
+            .EndBuild(conventions);
 
         exceptions.ShouldContain(e => e.Message == "basics");
         exceptions.ShouldContain(e => e.Message == "generics");

--- a/core/test/Baked.Test.Specs/Domain/ReportingErrorsInConventions.cs
+++ b/core/test/Baked.Test.Specs/Domain/ReportingErrorsInConventions.cs
@@ -13,22 +13,24 @@ public class ReportingErrorsInConventions : TestSpec
     public void Domain_model_builder_continues_execution_even_if_an_exception_occurs_during_post_build()
     {
         var hit = false;
-        var builder = GiveMe.ADomainModelBuilder(conventions: conventions =>
-        {
-            conventions.SetTypeAttribute(
-                when: c => c.Type.Is<string>(),
-                attribute: () => throw GiveMe.ADiagnosticCode().Exception(GiveMe.AString())
-            );
-            conventions.SetTypeAttribute(
-                when: c => c.Type.Is<string>(),
-                attribute: () =>
-                {
-                    hit = true;
+        var builder = GiveMe.ADomainModelBuilder(
+            conventions: c =>
+            {
+                c.SetTypeAttribute(
+                    when: c => c.Type.Is<string>(),
+                    attribute: () => throw GiveMe.ADiagnosticCode().Exception(GiveMe.AString())
+                );
+                c.SetTypeAttribute(
+                    when: c => c.Type.Is<string>(),
+                    attribute: () =>
+                    {
+                        hit = true;
 
-                    return new CustomAttribute();
-                }
-            );
-        });
+                        return new CustomAttribute();
+                    }
+                );
+            }
+        );
 
         builder
             .StartBuild([typeof(string)])
@@ -42,17 +44,12 @@ public class ReportingErrorsInConventions : TestSpec
     {
         var exceptions = new List<Exception>();
         var builder = GiveMe.ADomainModelBuilder(
-            options: builder =>
-            {
-                builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
-            },
-            conventions: conventions =>
-            {
-                conventions.SetTypeAttribute(
+            conventions: c =>
+                c.SetTypeAttribute(
                     when: c => c.Type.Is<string>(),
                     attribute: () => throw GiveMe.ADiagnosticCode().Exception("test")
-                );
-            }
+                ),
+            options: o => o.OnComplete = e => exceptions.AddRange(e.Exceptions)
         );
 
         builder
@@ -68,21 +65,18 @@ public class ReportingErrorsInConventions : TestSpec
     {
         var exceptions = new List<Exception>();
         var builder = GiveMe.ADomainModelBuilder(
-            options: builder =>
+            conventions: c =>
             {
-                builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
-            },
-            conventions: conventions =>
-            {
-                conventions.SetTypeAttribute(
+                c.SetTypeAttribute(
                     when: c => c.Type.Is<string>(),
                     attribute: () => throw GiveMe.ADiagnosticCode().Exception("string error")
                 );
-                conventions.SetTypeAttribute(
+                c.SetTypeAttribute(
                     when: c => c.Type.Is<int>(),
                     attribute: () => throw GiveMe.ADiagnosticCode().Exception("int error")
                 );
-            }
+            },
+            options: o => o.OnComplete = e => exceptions.AddRange(e.Exceptions)
         );
 
         builder
@@ -99,16 +93,14 @@ public class ReportingErrorsInConventions : TestSpec
     {
         var exceptions = new List<Exception>();
         var builder = GiveMe.ADomainModelBuilder(
-            options: builder =>
+            conventions: c =>
             {
-                builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
-            }, conventions: conventions =>
-            {
-                conventions.SetTypeAttribute(
+                c.SetTypeAttribute(
                     when: c => c.Type.Is<string>() || c.Type.Is<int>(),
                     attribute: c => throw GiveMe.ADiagnosticCode().Exception($"{c.Type.Name} error")
                 );
-            }
+            },
+            options: o => o.OnComplete = e => exceptions.AddRange(e.Exceptions)
         );
 
         builder
@@ -160,21 +152,18 @@ public class ReportingErrorsInConventions : TestSpec
     {
         var exceptions = new List<Exception>();
         var builder = GiveMe.ADomainModelBuilder(
-            options: builder =>
+            conventions: c => c.Add(new StubConvention(GiveMe)),
+            options: o =>
             {
-                builder.BuildLevels.Clear();
-                builder.BuildLevels.Add(t => t == typeof(string), BuildLevels.Members);
-                builder.BuildLevels.Add(t => t == typeof(long), BuildLevels.Metadata);
-                builder.BuildLevels.Add(t => t == typeof(double), BuildLevels.Inheritance);
-                builder.BuildLevels.Add(t => t == typeof(int), BuildLevels.Generics);
-                builder.BuildLevels.Add(BuildLevels.Basics);
-                builder.BindingFlags.Property = BindingFlags.Instance | BindingFlags.Public;
-                builder.BindingFlags.Method = BindingFlags.Instance | BindingFlags.Public;
-                builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
-            },
-            conventions: conventions =>
-            {
-                conventions.Add(new StubConvention(GiveMe));
+                o.BuildLevels.Clear();
+                o.BuildLevels.Add(t => t == typeof(string), BuildLevels.Members);
+                o.BuildLevels.Add(t => t == typeof(long), BuildLevels.Metadata);
+                o.BuildLevels.Add(t => t == typeof(double), BuildLevels.Inheritance);
+                o.BuildLevels.Add(t => t == typeof(int), BuildLevels.Generics);
+                o.BuildLevels.Add(BuildLevels.Basics);
+                o.BindingFlags.Property = BindingFlags.Instance | BindingFlags.Public;
+                o.BindingFlags.Method = BindingFlags.Instance | BindingFlags.Public;
+                o.OnComplete = e => exceptions.AddRange(e.Exceptions);
             }
         );
 

--- a/core/test/Baked.Test.Specs/Domain/ReportingErrorsInConventions.cs
+++ b/core/test/Baked.Test.Specs/Domain/ReportingErrorsInConventions.cs
@@ -13,8 +13,7 @@ public class ReportingErrorsInConventions : TestSpec
     public void Domain_model_builder_continues_execution_even_if_an_exception_occurs_during_post_build()
     {
         var hit = false;
-        var builder = GiveMe.ADomainModelBuilder();
-        var conventions = GiveMe.ADomainModelConventionCollection(options: conventions =>
+        var builder = GiveMe.ADomainModelBuilder(conventions: conventions =>
         {
             conventions.SetTypeAttribute(
                 when: c => c.Type.Is<string>(),
@@ -33,7 +32,7 @@ public class ReportingErrorsInConventions : TestSpec
 
         builder
             .StartBuild([typeof(string)])
-            .EndBuild(conventions);
+            .EndBuild();
 
         hit.ShouldBeTrue();
     }
@@ -42,22 +41,23 @@ public class ReportingErrorsInConventions : TestSpec
     public void After_post_build__domain_model_builder_delegates_reported_error_to_configured_error_handler()
     {
         var exceptions = new List<Exception>();
-        var builder = GiveMe.ADomainModelBuilder(options: builder =>
-        {
-            builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
-        });
-
-        var conventions = GiveMe.ADomainModelConventionCollection(options: conventions =>
-        {
-            conventions.SetTypeAttribute(
-                when: c => c.Type.Is<string>(),
-                attribute: () => throw GiveMe.ADiagnosticCode().Exception("test")
-            );
-        });
+        var builder = GiveMe.ADomainModelBuilder(
+            options: builder =>
+            {
+                builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
+            },
+            conventions: conventions =>
+            {
+                conventions.SetTypeAttribute(
+                    when: c => c.Type.Is<string>(),
+                    attribute: () => throw GiveMe.ADiagnosticCode().Exception("test")
+                );
+            }
+        );
 
         builder
             .StartBuild([typeof(string)])
-            .EndBuild(conventions);
+            .EndBuild();
 
         exceptions.Count.ShouldBe(1);
         exceptions.ShouldContain(e => e.Message == "test");
@@ -67,25 +67,27 @@ public class ReportingErrorsInConventions : TestSpec
     public void It_allows_multiple_errors_in_one_execution()
     {
         var exceptions = new List<Exception>();
-        var builder = GiveMe.ADomainModelBuilder(options: builder =>
-        {
-            builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
-        });
-        var conventions = GiveMe.ADomainModelConventionCollection(options: conventions =>
-        {
-            conventions.SetTypeAttribute(
-                when: c => c.Type.Is<string>(),
-                attribute: () => throw GiveMe.ADiagnosticCode().Exception("string error")
-            );
-            conventions.SetTypeAttribute(
-                when: c => c.Type.Is<int>(),
-                attribute: () => throw GiveMe.ADiagnosticCode().Exception("int error")
-            );
-        });
+        var builder = GiveMe.ADomainModelBuilder(
+            options: builder =>
+            {
+                builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
+            },
+            conventions: conventions =>
+            {
+                conventions.SetTypeAttribute(
+                    when: c => c.Type.Is<string>(),
+                    attribute: () => throw GiveMe.ADiagnosticCode().Exception("string error")
+                );
+                conventions.SetTypeAttribute(
+                    when: c => c.Type.Is<int>(),
+                    attribute: () => throw GiveMe.ADiagnosticCode().Exception("int error")
+                );
+            }
+        );
 
         builder
             .StartBuild([typeof(string), typeof(int)])
-            .EndBuild(conventions);
+            .EndBuild();
 
         exceptions.Count.ShouldBe(2);
         exceptions.ShouldContain(e => e.Message == "string error");
@@ -96,21 +98,22 @@ public class ReportingErrorsInConventions : TestSpec
     public void It_continues_execution_for_the_same_convention_per_domain_member()
     {
         var exceptions = new List<Exception>();
-        var builder = GiveMe.ADomainModelBuilder(options: builder =>
-        {
-            builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
-        });
-        var conventions = GiveMe.ADomainModelConventionCollection(options: conventions =>
-        {
-            conventions.SetTypeAttribute(
-                when: c => c.Type.Is<string>() || c.Type.Is<int>(),
-                attribute: c => throw GiveMe.ADiagnosticCode().Exception($"{c.Type.Name} error")
-            );
-        });
+        var builder = GiveMe.ADomainModelBuilder(
+            options: builder =>
+            {
+                builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
+            }, conventions: conventions =>
+            {
+                conventions.SetTypeAttribute(
+                    when: c => c.Type.Is<string>() || c.Type.Is<int>(),
+                    attribute: c => throw GiveMe.ADiagnosticCode().Exception($"{c.Type.Name} error")
+                );
+            }
+        );
 
         builder
             .StartBuild([typeof(string), typeof(int)])
-            .EndBuild(conventions);
+            .EndBuild();
 
         exceptions.Count.ShouldBe(2);
         exceptions.ShouldContain(e => e.Message == "String error");
@@ -156,26 +159,28 @@ public class ReportingErrorsInConventions : TestSpec
     public void Exception_handling_is_applied_for_all_convention_types()
     {
         var exceptions = new List<Exception>();
-        var builder = GiveMe.ADomainModelBuilder(options: builder =>
-        {
-            builder.BuildLevels.Clear();
-            builder.BuildLevels.Add(t => t == typeof(string), BuildLevels.Members);
-            builder.BuildLevels.Add(t => t == typeof(long), BuildLevels.Metadata);
-            builder.BuildLevels.Add(t => t == typeof(double), BuildLevels.Inheritance);
-            builder.BuildLevels.Add(t => t == typeof(int), BuildLevels.Generics);
-            builder.BuildLevels.Add(BuildLevels.Basics);
-            builder.BindingFlags.Property = BindingFlags.Instance | BindingFlags.Public;
-            builder.BindingFlags.Method = BindingFlags.Instance | BindingFlags.Public;
-            builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
-        });
-        var conventions = GiveMe.ADomainModelConventionCollection(options: conventions =>
-        {
-            conventions.Add(new StubConvention(GiveMe));
-        });
+        var builder = GiveMe.ADomainModelBuilder(
+            options: builder =>
+            {
+                builder.BuildLevels.Clear();
+                builder.BuildLevels.Add(t => t == typeof(string), BuildLevels.Members);
+                builder.BuildLevels.Add(t => t == typeof(long), BuildLevels.Metadata);
+                builder.BuildLevels.Add(t => t == typeof(double), BuildLevels.Inheritance);
+                builder.BuildLevels.Add(t => t == typeof(int), BuildLevels.Generics);
+                builder.BuildLevels.Add(BuildLevels.Basics);
+                builder.BindingFlags.Property = BindingFlags.Instance | BindingFlags.Public;
+                builder.BindingFlags.Method = BindingFlags.Instance | BindingFlags.Public;
+                builder.OnComplete = e => exceptions.AddRange(e.Exceptions);
+            },
+            conventions: conventions =>
+            {
+                conventions.Add(new StubConvention(GiveMe));
+            }
+        );
 
         builder
             .StartBuild([typeof(char), typeof(int), typeof(double), typeof(long), typeof(string)])
-            .EndBuild(conventions);
+            .EndBuild();
 
         exceptions.ShouldContain(e => e.Message == "basics");
         exceptions.ShouldContain(e => e.Message == "generics");

--- a/core/test/Baked.Test.Specs/Extensions/DomainModelExtensions.cs
+++ b/core/test/Baked.Test.Specs/Extensions/DomainModelExtensions.cs
@@ -48,7 +48,8 @@ public static class DomainModelExtensions
         }
 
         public DomainModelBuilder ADomainModelBuilder(
-            Action<DomainModelBuilderOptions>? options = default
+            Action<DomainModelBuilderOptions>? options = default,
+            Action<IDomainModelConventionCollection>? conventions = default
         )
         {
             var optionsInstance = new DomainModelBuilderOptions();
@@ -60,21 +61,13 @@ public static class DomainModelExtensions
                 options(optionsInstance);
             }
 
-            return new DomainModelBuilder(optionsInstance);
-        }
-
-        public IDomainModelConventionCollection ADomainModelConventionCollection(
-            Action<IDomainModelConventionCollection>? options = default
-        )
-        {
-            var optionsInstance = new DomainModelConventionCollection();
-
-            if (options is not null)
+            var conventionsInstance = new DomainModelConventionCollection();
+            if (conventions is not null)
             {
-                options(optionsInstance);
+                conventions(conventionsInstance);
             }
 
-            return optionsInstance;
+            return new DomainModelBuilder(optionsInstance, conventionsInstance);
         }
     }
 

--- a/core/test/Baked.Test.Specs/Extensions/DomainModelExtensions.cs
+++ b/core/test/Baked.Test.Specs/Extensions/DomainModelExtensions.cs
@@ -62,6 +62,20 @@ public static class DomainModelExtensions
 
             return new DomainModelBuilder(optionsInstance);
         }
+
+        public IDomainModelConventionCollection ADomainModelConventionCollection(
+            Action<IDomainModelConventionCollection>? options = default
+        )
+        {
+            var optionsInstance = new DomainModelConventionCollection();
+
+            if (options is not null)
+            {
+                options(optionsInstance);
+            }
+
+            return optionsInstance;
+        }
     }
 
     extension(DomainModelBuilder builder)

--- a/docs/features/coding-style.md
+++ b/docs/features/coding-style.md
@@ -80,7 +80,7 @@ public class Entity(IEntityContext<Parent> _context)
 > `IdAttribute` as below,
 >
 > ```csharp
-> builder.Conventions.AddPropertyAttributeConfiguration<IdAttribute>(
+> conventions.AddPropertyAttributeConfiguration<IdAttribute>(
 >     when: c => c.Type.Is<MyEntity>(),
 >     attribute: id => id.Assigned() // or id.AutoIncrement()
 > );

--- a/docs/features/theme.md
+++ b/docs/features/theme.md
@@ -49,7 +49,7 @@ public class CustomThemeFeature(IEnumerable<Func<Router, Route>> routes)
         {
             // Your custom conventions and page overrides
         });
-        
+
         configurator.Ui.ConfigureComponentExports(c =>
         {
             // Add your component exports using your own `Components` extensions

--- a/docs/features/theme.md
+++ b/docs/features/theme.md
@@ -45,11 +45,11 @@ public class CustomThemeFeature(IEnumerable<Func<Router, Route>> routes)
         // Applies default theme rules
         base.Configure(configurator);
 
-        configurator.Domain.ConfigureDomainModelBuilder(builder =>
+        configurator.Domain.ConfigureConventions(conventions =>
         {
             // Your custom conventions and page overrides
         });
-
+        
         configurator.Ui.ConfigureComponentExports(c =>
         {
             // Add your component exports using your own `Components` extensions

--- a/docs/layers/domain.md
+++ b/docs/layers/domain.md
@@ -100,7 +100,7 @@ This target exposes options for configuring built-in `DomainModelBuilder` and is
 provided in `AddDomainTypes` phase. To configure it in a feature;
 
 ```csharp
-configurator.Domain.ConfigureDomainModelBuilder(builder =>
+configurator.Domain.ConfigureBuilder(builder =>
 {
     ...
 });
@@ -206,7 +206,7 @@ or added attributes to improve performance. Indexes of a model in domain can
 be specified from its builder options.
 
 ```csharp
-configurator.Domain.ConfigureDomainModelBuilder(builder =>
+configurator.Domain.ConfigureBuilder(builder =>
 {
     builder.Index.Type.Add<MyTypeAttribute>();
     builder.Index.Property.Add<MyPropertyAttribute>();

--- a/docs/layers/domain.md
+++ b/docs/layers/domain.md
@@ -106,6 +106,18 @@ configurator.Domain.ConfigureDomainModelBuilder(builder =>
 });
 ```
 
+### `IDomainModelConventionCollection`
+
+This target exposes options for configuring domain conventions and levels and is
+provided in `AddDomainTypes` phase. To configure it in a feature;
+
+```csharp
+configurator.Domain.ConfigureDomainConventions(conventions =>
+{
+    ...
+});
+```
+
 ### `DomainServiceCollection`
 
 This target is provided in `Generate` phase and it is used to generate
@@ -224,7 +236,7 @@ foreach(var type in domain.Types.Having<MyTypeAttribute>())
 Attributes can be directly added to types or members as well as using built-in
 convetion system of baked. A convention can be used to add/remove or configure
 an attribute. Baked provides `IDomainModelConvention<TModel>` to create custom
-convention classes and extension methods for `DomainModelConvetionCollection` 
+convention classes and extension methods for `DomainModelConventionCollection` 
 to manage attributes.
 
 ```csharp
@@ -238,13 +250,13 @@ public class IdConvention : IDomainModelConvention<PropertyModelContext>
     }
 }
 
-configurator.Domain.ConfigureDomainModelBuilder(builder =>
+configurator.Domain.ConfigureDomainConventions(conventions =>
 {
     // Adding an implemented convention
-    builder.Conventions.Add(new IdConvention());
+    conventions.Add(new IdConvention());
 
     // Adding convention via extensions
-    builder.Conventions.SetPropertyAttribute(
+    conventions.SetPropertyAttribute(
         when: c => c.Property.Name == "Id"
         attribute: () => new IdAttribute()
     );
@@ -266,21 +278,21 @@ public class FeatureA : IFeature
 {
     // this convention wil apply before conventions
     // in feature B with default order
-    builder.Conventions.SetPropertyAttribute(...);
+    conventions.SetPropertyAttribute(...);
 }
 
 public class FeatureB : IFeature 
 {
     // This convention will apply first since a
     // global order is given
-    builder.Conventions.SetPropertyAttribute(
+    conventions.SetPropertyAttribute(
         ...,
         order: Order.Earliest
     );
 
     // This convention will apply after conventions
     // in feature A
-    builder.Conventions.SetPropertyAttribute(...);
+    conventions.SetPropertyAttribute(...);
 }
 ```
 
@@ -309,14 +321,14 @@ remaining conventions.
 
 ```csharp
 // This convention will apply before the indexes are built
-builder.Conventions.SetPropertyAttribute(
+conventions.SetPropertyAttribute(
     ...,
     order: Order.Latest;
     beforeBuildingIndexes: true
 );
 
 // This convention will apply after the indexes are built
-builder.Conventions.SetPropertyAttribute(
+conventions.SetPropertyAttribute(
     ...,
     order: Order.Earliest,
 );
@@ -328,18 +340,18 @@ accross multiple features and provide a predictable ordering between related
 convention groups.
 
 ```csharp
-configurator.Domain.ConfigureDomainModelBuilder(builder =>
+configurator.Domain.ConfigureDomainConventions(builder =>
 {
-    builder.Levels.Add("LevelA");
-    builder.Levels.Add("LevelB");
+    conventions.Levels.Add("LevelA");
+    conventions.Levels.Add("LevelB");
 
-    builder.Conventions.SetPropertyAttribute(
+    conventions.SetPropertyAttribute(
         ...,
         order: Order.Level("LevelB")
     );
 
     // This convention executes first
-    builder.Conventions.SetPropertyAttribute(
+    conventions.SetPropertyAttribute(
         ...,
         order: Order.Level("LevelA")
     );
@@ -351,12 +363,12 @@ will have 0 as its order relative to its level. It is also possible to specify
 min/max values or a specific position within the level.
 
 ```csharp
-builder.Conventions.SetPropertyAttribute(
+conventions.SetPropertyAttribute(
     ...,
     order: Order.Level("LevelA").Min
 );
 
-builder.Conventions.SetPropertyAttribute(
+conventions.SetPropertyAttribute(
     ...,
     order: Order.Level("LevelA") + 10
 );

--- a/docs/layers/domain.md
+++ b/docs/layers/domain.md
@@ -112,7 +112,7 @@ This target exposes options for configuring domain conventions and levels and is
 provided in `AddDomainTypes` phase. To configure it in a feature;
 
 ```csharp
-configurator.Domain.ConfigureDomainConventions(conventions =>
+configurator.Domain.ConfigureConventions(conventions =>
 {
     ...
 });
@@ -250,7 +250,7 @@ public class IdConvention : IDomainModelConvention<PropertyModelContext>
     }
 }
 
-configurator.Domain.ConfigureDomainConventions(conventions =>
+configurator.Domain.ConfigureConventions(conventions =>
 {
     // Adding an implemented convention
     conventions.Add(new IdConvention());
@@ -340,7 +340,7 @@ accross multiple features and provide a predictable ordering between related
 convention groups.
 
 ```csharp
-configurator.Domain.ConfigureDomainConventions(builder =>
+configurator.Domain.ConfigureConventions(builder =>
 {
     conventions.Levels.Add("LevelA");
     conventions.Levels.Add("LevelB");

--- a/docs/layers/ui.md
+++ b/docs/layers/ui.md
@@ -193,7 +193,7 @@ domain models that don't have the given `TComponentSchema` or `TSchema` at the
 expected component path.
 
 ```csharp
-configurator.Domain.ConfigureDomainModelBuilder(builder =>
+configurator.Domain.ConfigureConventions(conventions =>
 {
     // This convention will automatically apply only to the types that have a
     // `SimplePage` component

--- a/docs/layers/ui.md
+++ b/docs/layers/ui.md
@@ -121,7 +121,7 @@ domain model, for instance to a type, use the `AddTypeComponent` extension of
 `IDomainModelConventionCollection`;
 
 ```csharp
-configurator.Domain.ConfigureDomainConventions(conventions =>
+configurator.Domain.ConfigureConventions(conventions =>
 {
     conventions.AddTypeComponent(
         when: c => c.Type...,

--- a/docs/layers/ui.md
+++ b/docs/layers/ui.md
@@ -121,9 +121,9 @@ domain model, for instance to a type, use the `AddTypeComponent` extension of
 `IDomainModelConventionCollection`;
 
 ```csharp
-configurator.Domain.ConfigureDomainModelBuilder(builder =>
+configurator.Domain.ConfigureDomainConventions(conventions =>
 {
-    builder.Conventions.AddTypeComponent(
+    conventions.AddTypeComponent(
         when: c => c.Type...,
         where: cc => cc.Path.EndsWith("Page"),
         component: (c, cc) => ...
@@ -197,7 +197,7 @@ configurator.Domain.ConfigureDomainModelBuilder(builder =>
 {
     // This convention will automatically apply only to the types that have a
     // `SimplePage` component
-    builder.Conventions.AddTypeComponentConfiguration<SimplePage>(
+    conventions.AddTypeComponentConfiguration<SimplePage>(
         component: sp =>
         {
             sp.Title = ...;

--- a/unreleased.md
+++ b/unreleased.md
@@ -17,7 +17,7 @@
   });
 
   // current usage
-  configurator.Domain.ConfigureDomainConventions(conventions =>
+  configurator.Domain.ConfigureConventions(conventions =>
   {
     conventions.Add(...);
   });

--- a/unreleased.md
+++ b/unreleased.md
@@ -7,7 +7,21 @@
 
 ## Breaking Changes
 
-- `requireIndex` convention flag is renamed to `beforeIndex`
+- `requireIndex` convention flag is renamed to `beforeBuildingIndex`
+- `IDomainModelConventionCollection` is now provided as a configuration target
+```csharp
+// old usage
+configurator.Domain.ConfigureDomainModelBuilder(builder =>
+{
+  builder.Conventions.Add(...);
+});
+
+// current usage
+configurator.Domain.ConfigureDomainConventions(conventions =>
+{
+  conventions.Add(...);
+});
+```
 
 ## Bugfixes
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -8,6 +8,20 @@
 ## Breaking Changes
 
 - `requireIndex` convention flag is renamed to `beforeBuildingIndex`
+- `ConfigureDomainModelBuilder` is is renamed to `ConfigureBuilder`
+  ```csharp
+  // old usage
+  configurator.Domain.ConfigureDomainModelBuilder(builder =>
+  {
+    ...
+  });
+
+  // current usage
+  configurator.Domain.ConfigureBuilder(builder =>
+  {
+    ...
+  });
+  ```
 - `IDomainModelConventionCollection` is now provided as a configuration target
   ```csharp
   // old usage

--- a/unreleased.md
+++ b/unreleased.md
@@ -13,13 +13,13 @@
   // old usage
   configurator.Domain.ConfigureDomainModelBuilder(builder =>
   {
-    ...
+      ...
   });
 
   // current usage
   configurator.Domain.ConfigureBuilder(builder =>
   {
-    ...
+      ...
   });
   ```
 - `IDomainModelConventionCollection` is now provided as a configuration target
@@ -27,13 +27,13 @@
   // old usage
   configurator.Domain.ConfigureDomainModelBuilder(builder =>
   {
-    builder.Conventions.Add(...);
+      builder.Conventions.Add(...);
   });
 
   // current usage
   configurator.Domain.ConfigureConventions(conventions =>
   {
-    conventions.Add(...);
+      conventions.Add(...);
   });
   ```
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -9,19 +9,19 @@
 
 - `requireIndex` convention flag is renamed to `beforeBuildingIndex`
 - `IDomainModelConventionCollection` is now provided as a configuration target
-```csharp
-// old usage
-configurator.Domain.ConfigureDomainModelBuilder(builder =>
-{
-  builder.Conventions.Add(...);
-});
+  ```csharp
+  // old usage
+  configurator.Domain.ConfigureDomainModelBuilder(builder =>
+  {
+    builder.Conventions.Add(...);
+  });
 
-// current usage
-configurator.Domain.ConfigureDomainConventions(conventions =>
-{
-  conventions.Add(...);
-});
-```
+  // current usage
+  configurator.Domain.ConfigureDomainConventions(conventions =>
+  {
+    conventions.Add(...);
+  });
+  ```
 
 ## Bugfixes
 


### PR DESCRIPTION
Provide `IDomainModelConventionCollection` as a seperate target

## Tasks

- [x] Remove `IDomainModelConventionCollection` from options
- [x] Provide from `DomainLayer`
- [x] Update features for new usage
- [x] Update documentation