### PR TITLE
Inspect Convention Level

### DIFF
--- a/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
+++ b/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
@@ -88,7 +88,7 @@ public class Diagnostics : IDisposable
             var stackTrace = new StackTrace(ex, true);
             if (stackTrace.TryFindFeatureSource(out var source))
             {
-                ReportError(ex.Code, $"{ex.Message}{Environment.NewLine}[gray]{source}[/]");
+                ReportError(ex.Code, $"{ex.Message} [gray]{source}[/]");
             }
             else
             {

--- a/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
+++ b/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
@@ -142,7 +142,7 @@ public class Diagnostics : IDisposable
             string fileName = filePath.Split(@"\").Last().Replace(".cs", string.Empty);
             int lineNumber = int.Parse(match.Groups["line"].Value);
 
-            source = $"[gray][bold red]⠕[/][link={filePath}]{fileName}[/]:{lineNumber}[/]";
+            source = $"[gray][link={filePath}]{fileName}[/]:{lineNumber}[/]";
         }
 
         return source != null;

--- a/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
+++ b/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
@@ -1,7 +1,6 @@
 using Baked.Buildtime.Diagnostics;
 using Spectre.Console;
-using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
+using System.Diagnostics;
 
 // NOTE namespace is at root for a better experience in Coding Style & UX
 // development
@@ -86,9 +85,10 @@ public class Diagnostics : IDisposable
         catch (DiagnosticException ex)
         {
             _exceptions.Add(ex);
-            if (TryFindFeatureSource(ex.StackTrace, out var source))
+            var stackTrace = new StackTrace(ex, true);
+            if (stackTrace.TryFindFeatureSource(out var source))
             {
-                ReportError(ex.Code, $"{ex.Message}{Environment.NewLine}{source}");
+                ReportError(ex.Code, $"{ex.Message}{Environment.NewLine}[gray]{source}[/]");
             }
             else
             {
@@ -125,25 +125,6 @@ public class Diagnostics : IDisposable
         DiagnosticCode? code = default,
         string? group = default
     ) => _messages.Add(new(message, level, code, group));
-
-    bool TryFindFeatureSource(string? stackTrace, [NotNullWhen(true)] out string? source)
-    {
-        source = null;
-        if (stackTrace is null) { return false; }
-
-        var matches = Regex.Matches(stackTrace, @"in (?<file>.*?Feature\.cs):line (?<line>\d+)");
-        var match = matches.FirstOrDefault();
-        if (match is not null)
-        {
-            string filePath = match.Groups["file"].Value;
-            string fileName = Path.GetFileName(filePath).Replace(".cs", string.Empty);
-            int lineNumber = int.Parse(match.Groups["line"].Value);
-
-            source = $"[gray][link={filePath}]{fileName}[/]:{lineNumber}[/]";
-        }
-
-        return source != null;
-    }
 
     public void OnDispose(Action<DiagnosticsResult> handler) =>
         _dispose = handler;

--- a/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
+++ b/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
@@ -86,17 +86,13 @@ public class Diagnostics : IDisposable
         catch (DiagnosticException ex)
         {
             _exceptions.Add(ex);
-            ReportError(ex.Code, ex.Message);
-            if (ex.StackTrace is not null)
+            if (TryFindFeatureSource(ex.StackTrace, out var source))
             {
-                if (TryFindFeatureSource(ex.StackTrace, out var source))
-                {
-                    ReportInfo(source);
-                }
-                else
-                {
-                    ReportInfo(Markup.Escape(ex.StackTrace));
-                }
+                ReportError(ex.Code, $"{ex.Message}{Environment.NewLine}{source}");
+            }
+            else
+            {
+                ReportError(ex.Code, ex.Message);
             }
 
             return default;
@@ -130,9 +126,10 @@ public class Diagnostics : IDisposable
         string? group = default
     ) => _messages.Add(new(message, level, code, group));
 
-    bool TryFindFeatureSource(string stackTrace, [NotNullWhen(true)] out string? source)
+    bool TryFindFeatureSource(string? stackTrace, [NotNullWhen(true)] out string? source)
     {
         source = null;
+        if (stackTrace is null) { return false; }
 
         var matches = Regex.Matches(stackTrace, @"in (?<file>.*?Feature\.cs):line (?<line>\d+)");
         var match = matches.FirstOrDefault();

--- a/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
+++ b/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
@@ -1,5 +1,7 @@
 using Baked.Buildtime.Diagnostics;
 using Spectre.Console;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 
 // NOTE namespace is at root for a better experience in Coding Style & UX
 // development
@@ -85,6 +87,17 @@ public class Diagnostics : IDisposable
         {
             _exceptions.Add(ex);
             ReportError(ex.Code, ex.Message);
+            if (ex.StackTrace is not null)
+            {
+                if (TryFindFeatureSource(ex.StackTrace, out var source))
+                {
+                    ReportInfo(source);
+                }
+                else
+                {
+                    ReportInfo(Markup.Escape(ex.StackTrace));
+                }
+            }
 
             return default;
         }
@@ -116,6 +129,24 @@ public class Diagnostics : IDisposable
         DiagnosticCode? code = default,
         string? group = default
     ) => _messages.Add(new(message, level, code, group));
+
+    bool TryFindFeatureSource(string stackTrace, [NotNullWhen(true)] out string? source)
+    {
+        source = null;
+
+        var matches = Regex.Matches(stackTrace, @"in (?<file>.*?Feature\.cs):line (?<line>\d+)");
+        var match = matches.FirstOrDefault();
+        if (match is not null)
+        {
+            string filePath = match.Groups["file"].Value;
+            string fileName = filePath.Split(@"\").Last().Replace(".cs", string.Empty);
+            int lineNumber = int.Parse(match.Groups["line"].Value);
+
+            source = $"[gray][bold red]⠕[/][link={filePath}]{fileName}[/]:{lineNumber}[/]";
+        }
+
+        return source != null;
+    }
 
     public void OnDispose(Action<DiagnosticsResult> handler) =>
         _dispose = handler;

--- a/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
+++ b/core/src/Baked/Buildtime/Diagnostics/Diagnostics.cs
@@ -139,7 +139,7 @@ public class Diagnostics : IDisposable
         if (match is not null)
         {
             string filePath = match.Groups["file"].Value;
-            string fileName = filePath.Split(@"\").Last().Replace(".cs", string.Empty);
+            string fileName = Path.GetFileName(filePath).Replace(".cs", string.Empty);
             int lineNumber = int.Parse(match.Groups["line"].Value);
 
             source = $"[gray][link={filePath}]{fileName}[/]:{lineNumber}[/]";

--- a/core/src/Baked/Business/BusinessExtensions.cs
+++ b/core/src/Baked/Business/BusinessExtensions.cs
@@ -247,7 +247,12 @@ public static class BusinessExtensions
         public void SetTypeAttribute(Action<TypeModelMetadataContext, Action<ICustomAttributesModel, Attribute>> apply, Func<TypeModelMetadataContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new SetAttributeConvention<TypeModelMetadataContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        )
+        {
+            order = order.BusinessDefault.Add;
+
+            conventions.Add(new SetAttributeConvention<TypeModelMetadataContext>(apply, when, order, beforeBuildingIndexes: beforeBuildingIndexes), order);
+        }
 
         public void AddTypeAttribute(Func<Attribute> attribute, Func<TypeModelMetadataContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -262,7 +267,12 @@ public static class BusinessExtensions
         public void AddTypeAttribute(Action<TypeModelMetadataContext, Action<ICustomAttributesModel, Attribute>> apply, Func<TypeModelMetadataContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new AddAttributeConvention<TypeModelMetadataContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        )
+        {
+            order = order.BusinessDefault.Add;
+
+            conventions.Add(new AddAttributeConvention<TypeModelMetadataContext>(apply, when, order, beforeBuildingIndexes: beforeBuildingIndexes), order);
+        }
 
         public void RemoveTypeAttribute<TAttribute>(Func<TypeModelMetadataContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -283,7 +293,12 @@ public static class BusinessExtensions
         public void SetPropertyAttribute(Action<PropertyModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<PropertyModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new SetAttributeConvention<PropertyModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        )
+        {
+            order = order.BusinessDefault.Add;
+
+            conventions.Add(new SetAttributeConvention<PropertyModelContext>(apply, when, order, beforeBuildingIndexes: beforeBuildingIndexes), order);
+        }
 
         public void AddPropertyAttribute(Func<Attribute> attribute, Func<PropertyModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -298,7 +313,12 @@ public static class BusinessExtensions
         public void AddPropertyAttribute(Action<PropertyModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<PropertyModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new AddAttributeConvention<PropertyModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        )
+        {
+            order = order.BusinessDefault.Add;
+
+            conventions.Add(new AddAttributeConvention<PropertyModelContext>(apply, when, order, beforeBuildingIndexes: beforeBuildingIndexes), order);
+        }
 
         public void RemovePropertyAttribute<TAttribute>(Func<PropertyModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -319,7 +339,12 @@ public static class BusinessExtensions
         public void SetMethodAttribute(Action<MethodModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<MethodModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new SetAttributeConvention<MethodModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        )
+        {
+            order = order.BusinessDefault.Add;
+
+            conventions.Add(new SetAttributeConvention<MethodModelContext>(apply, when, order, beforeBuildingIndexes: beforeBuildingIndexes), order);
+        }
 
         public void AddMethodAttribute(Func<Attribute> attribute, Func<MethodModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -334,7 +359,12 @@ public static class BusinessExtensions
         public void AddMethodAttribute(Action<MethodModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<MethodModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new AddAttributeConvention<MethodModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        )
+        {
+            order = order.BusinessDefault.Add;
+
+            conventions.Add(new AddAttributeConvention<MethodModelContext>(apply, when, order, beforeBuildingIndexes: beforeBuildingIndexes), order);
+        }
 
         public void RemoveMethodAttribute<TAttribute>(Func<MethodModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -355,7 +385,12 @@ public static class BusinessExtensions
         public void SetParameterAttribute(Action<ParameterModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<ParameterModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new SetAttributeConvention<ParameterModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        )
+        {
+            order = order.BusinessDefault.Add;
+
+            conventions.Add(new SetAttributeConvention<ParameterModelContext>(apply, when, order, beforeBuildingIndexes: beforeBuildingIndexes), order);
+        }
 
         public void AddParameterAttribute(Func<Attribute> attribute, Func<ParameterModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -370,7 +405,12 @@ public static class BusinessExtensions
         public void AddParameterAttribute(Action<ParameterModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<ParameterModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new AddAttributeConvention<ParameterModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        )
+        {
+            order = order.BusinessDefault.Add;
+
+            conventions.Add(new AddAttributeConvention<ParameterModelContext>(apply, when, order, beforeBuildingIndexes: beforeBuildingIndexes), order);
+        }
 
         public void RemoveParameterAttribute<TAttribute>(Func<ParameterModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -399,8 +439,12 @@ public static class BusinessExtensions
         public void AddTypeAttributeConfiguration<TAttribute>(Action<TAttribute, TypeModelMetadataContext> attribute,
             Func<TypeModelMetadataContext, TAttribute, bool>? when = default,
             Order order = default
-        ) where TAttribute : Attribute =>
-            conventions.Add(new TypeAttributeConfigurationConvention<TAttribute>(attribute, order.BusinessDefault.Configure, when: when), order: order.BusinessDefault.Configure);
+        ) where TAttribute : Attribute
+        {
+            order = order.BusinessDefault.Configure;
+
+            conventions.Add(new TypeAttributeConfigurationConvention<TAttribute>(attribute, order, when: when), order: order);
+        }
 
         public void AddPropertyAttributeConfiguration<TAttribute>(Action<TAttribute> attribute,
             Func<PropertyModelContext, bool> when, // NOTE this is not optional to avoid ambiguous call when not given
@@ -423,8 +467,12 @@ public static class BusinessExtensions
         public void AddPropertyAttributeConfiguration<TAttribute>(Action<TAttribute, PropertyModelContext> attribute,
             Func<PropertyModelContext, TAttribute, bool>? when = default,
             Order order = default
-        ) where TAttribute : Attribute =>
-            conventions.Add(new PropertyAttributeConfigurationConvention<TAttribute>(attribute, order.BusinessDefault.Configure, when: when), order: order.BusinessDefault.Configure);
+        ) where TAttribute : Attribute
+        {
+            order = order.BusinessDefault.Configure;
+
+            conventions.Add(new PropertyAttributeConfigurationConvention<TAttribute>(attribute, order, when: when), order: order);
+        }
 
         public void AddMethodAttributeConfiguration<TAttribute>(Action<TAttribute> attribute,
             Func<MethodModelContext, bool> when, // NOTE this is not optional to avoid ambiguous call when not given
@@ -447,8 +495,12 @@ public static class BusinessExtensions
         public void AddMethodAttributeConfiguration<TAttribute>(Action<TAttribute, MethodModelContext> attribute,
             Func<MethodModelContext, TAttribute, bool>? when = default,
             Order order = default
-        ) where TAttribute : Attribute =>
-            conventions.Add(new MethodAttributeConfigurationConvention<TAttribute>(attribute, order.BusinessDefault.Configure, when: when), order: order.BusinessDefault.Configure);
+        ) where TAttribute : Attribute
+        {
+            order = order.BusinessDefault.Configure;
+
+            conventions.Add(new MethodAttributeConfigurationConvention<TAttribute>(attribute, order, when: when), order: order);
+        }
 
         public void AddParameterAttributeConfiguration<TAttribute>(Action<TAttribute> attribute,
             Func<ParameterModelContext, bool> when, // NOTE this is not optional to avoid ambiguous call when not given
@@ -471,8 +523,12 @@ public static class BusinessExtensions
         public void AddParameterAttributeConfiguration<TAttribute>(Action<TAttribute, ParameterModelContext> attribute,
             Func<ParameterModelContext, TAttribute, bool>? when = default,
             Order order = default
-        ) where TAttribute : Attribute =>
-            conventions.Add(new ParameterAttributeConfigurationConvention<TAttribute>(attribute, order.BusinessDefault.Configure, when: when), order: order.BusinessDefault.Configure);
+        ) where TAttribute : Attribute
+        {
+            order = order.BusinessDefault.Configure;
+
+            conventions.Add(new ParameterAttributeConfigurationConvention<TAttribute>(attribute, order, when: when), order: order);
+        }
     }
 
     extension(Stubber _)

--- a/core/src/Baked/Business/BusinessExtensions.cs
+++ b/core/src/Baked/Business/BusinessExtensions.cs
@@ -399,7 +399,7 @@ public static class BusinessExtensions
             Func<TypeModelMetadataContext, TAttribute, bool>? when = default,
             Order order = default
         ) where TAttribute : Attribute =>
-            conventions.Add(new TypeAttributeConfigurationConvention<TAttribute>(attribute, when: when), order: order.BusinessDefault.Configure);
+            conventions.Add(new TypeAttributeConfigurationConvention<TAttribute>(attribute, order.BusinessDefault.Configure, when: when), order: order.BusinessDefault.Configure);
 
         public void AddPropertyAttributeConfiguration<TAttribute>(Action<TAttribute> attribute,
             Func<PropertyModelContext, bool> when, // NOTE this is not optional to avoid ambiguous call when not given
@@ -423,7 +423,7 @@ public static class BusinessExtensions
             Func<PropertyModelContext, TAttribute, bool>? when = default,
             Order order = default
         ) where TAttribute : Attribute =>
-            conventions.Add(new PropertyAttributeConfigurationConvention<TAttribute>(attribute, when: when), order: order.BusinessDefault.Configure);
+            conventions.Add(new PropertyAttributeConfigurationConvention<TAttribute>(attribute, order.BusinessDefault.Configure, when: when), order: order.BusinessDefault.Configure);
 
         public void AddMethodAttributeConfiguration<TAttribute>(Action<TAttribute> attribute,
             Func<MethodModelContext, bool> when, // NOTE this is not optional to avoid ambiguous call when not given
@@ -447,7 +447,7 @@ public static class BusinessExtensions
             Func<MethodModelContext, TAttribute, bool>? when = default,
             Order order = default
         ) where TAttribute : Attribute =>
-            conventions.Add(new MethodAttributeConfigurationConvention<TAttribute>(attribute, when: when), order: order.BusinessDefault.Configure);
+            conventions.Add(new MethodAttributeConfigurationConvention<TAttribute>(attribute, order.BusinessDefault.Configure, when: when), order: order.BusinessDefault.Configure);
 
         public void AddParameterAttributeConfiguration<TAttribute>(Action<TAttribute> attribute,
             Func<ParameterModelContext, bool> when, // NOTE this is not optional to avoid ambiguous call when not given
@@ -471,7 +471,7 @@ public static class BusinessExtensions
             Func<ParameterModelContext, TAttribute, bool>? when = default,
             Order order = default
         ) where TAttribute : Attribute =>
-            conventions.Add(new ParameterAttributeConfigurationConvention<TAttribute>(attribute, when: when), order: order.BusinessDefault.Configure);
+            conventions.Add(new ParameterAttributeConfigurationConvention<TAttribute>(attribute, order.BusinessDefault.Configure, when: when), order: order.BusinessDefault.Configure);
     }
 
     extension(Stubber _)

--- a/core/src/Baked/Business/BusinessExtensions.cs
+++ b/core/src/Baked/Business/BusinessExtensions.cs
@@ -231,7 +231,6 @@ public static class BusinessExtensions
             parameter.Has<RequiredAttribute>().ShouldBeFalse($"{parameter.Name} should not have `[RequiredAttribute]`");
     }
 
-    // TODO convert extensions to block body
     extension(IDomainModelConventionCollection conventions)
     {
         public void SetTypeAttribute(Func<Attribute> attribute, Func<TypeModelMetadataContext, bool> when,

--- a/core/src/Baked/Business/BusinessExtensions.cs
+++ b/core/src/Baked/Business/BusinessExtensions.cs
@@ -231,6 +231,7 @@ public static class BusinessExtensions
             parameter.Has<RequiredAttribute>().ShouldBeFalse($"{parameter.Name} should not have `[RequiredAttribute]`");
     }
 
+    // TODO convert extensions to block body
     extension(IDomainModelConventionCollection conventions)
     {
         public void SetTypeAttribute(Func<Attribute> attribute, Func<TypeModelMetadataContext, bool> when,

--- a/core/src/Baked/Business/BusinessExtensions.cs
+++ b/core/src/Baked/Business/BusinessExtensions.cs
@@ -246,7 +246,7 @@ public static class BusinessExtensions
         public void SetTypeAttribute(Action<TypeModelMetadataContext, Action<ICustomAttributesModel, Attribute>> apply, Func<TypeModelMetadataContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new SetAttributeConvention<TypeModelMetadataContext>(apply, when, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        ) => conventions.Add(new SetAttributeConvention<TypeModelMetadataContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
 
         public void AddTypeAttribute(Func<Attribute> attribute, Func<TypeModelMetadataContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -261,7 +261,7 @@ public static class BusinessExtensions
         public void AddTypeAttribute(Action<TypeModelMetadataContext, Action<ICustomAttributesModel, Attribute>> apply, Func<TypeModelMetadataContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new AddAttributeConvention<TypeModelMetadataContext>(apply, when, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        ) => conventions.Add(new AddAttributeConvention<TypeModelMetadataContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
 
         public void RemoveTypeAttribute<TAttribute>(Func<TypeModelMetadataContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -282,7 +282,7 @@ public static class BusinessExtensions
         public void SetPropertyAttribute(Action<PropertyModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<PropertyModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new SetAttributeConvention<PropertyModelContext>(apply, when, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        ) => conventions.Add(new SetAttributeConvention<PropertyModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
 
         public void AddPropertyAttribute(Func<Attribute> attribute, Func<PropertyModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -297,7 +297,7 @@ public static class BusinessExtensions
         public void AddPropertyAttribute(Action<PropertyModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<PropertyModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new AddAttributeConvention<PropertyModelContext>(apply, when, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        ) => conventions.Add(new AddAttributeConvention<PropertyModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
 
         public void RemovePropertyAttribute<TAttribute>(Func<PropertyModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -318,7 +318,7 @@ public static class BusinessExtensions
         public void SetMethodAttribute(Action<MethodModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<MethodModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new SetAttributeConvention<MethodModelContext>(apply, when, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        ) => conventions.Add(new SetAttributeConvention<MethodModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
 
         public void AddMethodAttribute(Func<Attribute> attribute, Func<MethodModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -333,7 +333,7 @@ public static class BusinessExtensions
         public void AddMethodAttribute(Action<MethodModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<MethodModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new AddAttributeConvention<MethodModelContext>(apply, when, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        ) => conventions.Add(new AddAttributeConvention<MethodModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
 
         public void RemoveMethodAttribute<TAttribute>(Func<MethodModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -354,7 +354,7 @@ public static class BusinessExtensions
         public void SetParameterAttribute(Action<ParameterModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<ParameterModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new SetAttributeConvention<ParameterModelContext>(apply, when, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        ) => conventions.Add(new SetAttributeConvention<ParameterModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
 
         public void AddParameterAttribute(Func<Attribute> attribute, Func<ParameterModelContext, bool> when,
             bool beforeBuildingIndexes = true,
@@ -369,7 +369,7 @@ public static class BusinessExtensions
         public void AddParameterAttribute(Action<ParameterModelContext, Action<ICustomAttributesModel, Attribute>> apply, Func<ParameterModelContext, bool> when,
             bool beforeBuildingIndexes = true,
             Order order = default
-        ) => conventions.Add(new AddAttributeConvention<ParameterModelContext>(apply, when, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
+        ) => conventions.Add(new AddAttributeConvention<ParameterModelContext>(apply, when, order.BusinessDefault.Add, beforeBuildingIndexes: beforeBuildingIndexes), order.BusinessDefault.Add);
 
         public void RemoveParameterAttribute<TAttribute>(Func<ParameterModelContext, bool> when,
             bool beforeBuildingIndexes = true,

--- a/core/src/Baked/Caching/InMemory/CacheApplicationPlugin.cs
+++ b/core/src/Baked/Caching/InMemory/CacheApplicationPlugin.cs
@@ -2,7 +2,4 @@
 
 namespace Baked.Caching.InMemory;
 
-public record CacheApplicationPlugin : ModulePluginBase
-{
-    public int ExpirationInMinutes { get; set; } = 60;
-}
+public record CacheApplicationPlugin : ModulePluginBase;

--- a/core/src/Baked/Caching/InMemory/InMemoryCachingExtensions.cs
+++ b/core/src/Baked/Caching/InMemory/InMemoryCachingExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Baked.Caching;
 using Baked.Caching.InMemory;
-using Baked.Runtime;
 using Baked.Testing;
 using Microsoft.Extensions.Caching.Memory;
 using NUnit.Framework;
@@ -12,9 +11,8 @@ public static class InMemoryCachingExtensions
     extension(CachingConfigurator _)
     {
         public InMemoryCachingFeature InMemory(
-            Action<MemoryCacheOptions>? options = default,
-            Setting<TimeSpan>? clientExpiration = default
-        ) => new(options ?? (_ => { }), clientExpiration ?? TimeSpan.FromHours(1));
+            Action<MemoryCacheOptions>? options = default
+        ) => new(options ?? (_ => { }));
     }
 
     extension(Stubber giveMe)

--- a/core/src/Baked/Caching/InMemory/InMemoryCachingFeature.cs
+++ b/core/src/Baked/Caching/InMemory/InMemoryCachingFeature.cs
@@ -1,13 +1,12 @@
 ﻿using Baked.Architecture;
 using Baked.Domain.Configuration;
-using Baked.Runtime;
 using Baked.Ui;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Baked.Caching.InMemory;
 
-public class InMemoryCachingFeature(Action<MemoryCacheOptions> _options, Setting<TimeSpan> clientExpiration)
+public class InMemoryCachingFeature(Action<MemoryCacheOptions> _options)
     : IFeature<CachingConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
@@ -28,9 +27,7 @@ public class InMemoryCachingFeature(Action<MemoryCacheOptions> _options, Setting
 
         configurator.Ui.ConfigureAppDescriptor(app =>
         {
-            app.Plugins.Add(
-                new CacheApplicationPlugin { ExpirationInMinutes = (int)clientExpiration.GetValue().TotalMinutes }
-            );
+            app.Plugins.Add(new CacheApplicationPlugin());
         });
 
         configurator.Testing.ConfigureTestConfiguration(test =>

--- a/core/src/Baked/Caching/ScopedMemory/CacheUserPlugin.cs
+++ b/core/src/Baked/Caching/ScopedMemory/CacheUserPlugin.cs
@@ -2,7 +2,4 @@ using Baked.Ui.Configuration;
 
 namespace Baked.Caching.ScopedMemory;
 
-public record CacheUserPlugin : ModulePluginBase
-{
-    public int ExpirationInMinutes { get; set; } = 60;
-}
+public record CacheUserPlugin : ModulePluginBase;

--- a/core/src/Baked/Caching/ScopedMemory/ScopedMemoryCachingExtensions.cs
+++ b/core/src/Baked/Caching/ScopedMemory/ScopedMemoryCachingExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Baked.Caching;
 using Baked.Caching.ScopedMemory;
-using Baked.Runtime;
 using Baked.Testing;
 using Microsoft.Extensions.Caching.Memory;
 using NUnit.Framework;
@@ -11,9 +10,8 @@ public static class ScopedMemoryCachingExtensions
 {
     extension(CachingConfigurator _)
     {
-        public ScopedMemoryCachingFeature ScopedMemory(
-            Setting<TimeSpan>? clientExpiration = default
-        ) => new(clientExpiration ?? TimeSpan.FromHours(1));
+        public ScopedMemoryCachingFeature ScopedMemory() =>
+            new();
     }
 
     extension(Stubber giveMe)

--- a/core/src/Baked/Caching/ScopedMemory/ScopedMemoryCachingFeature.cs
+++ b/core/src/Baked/Caching/ScopedMemory/ScopedMemoryCachingFeature.cs
@@ -1,14 +1,12 @@
 ﻿using Baked.Architecture;
 using Baked.Domain.Configuration;
-using Baked.Runtime;
 using Baked.Ui;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Baked.Caching.ScopedMemory;
 
-public class ScopedMemoryCachingFeature(Setting<TimeSpan> clientExpiration)
-    : IFeature<CachingConfigurator>
+public class ScopedMemoryCachingFeature : IFeature<CachingConfigurator>
 {
     public void Configure(LayerConfigurator configurator)
     {
@@ -29,9 +27,7 @@ public class ScopedMemoryCachingFeature(Setting<TimeSpan> clientExpiration)
 
         configurator.Ui.ConfigureAppDescriptor(app =>
         {
-            app.Plugins.Add(
-                new CacheUserPlugin { ExpirationInMinutes = (int)clientExpiration.GetValue().TotalMinutes }
-            );
+            app.Plugins.Add(new CacheUserPlugin());
         });
 
         configurator.Testing.ConfigureTestConfiguration(test =>

--- a/core/src/Baked/Domain/Configuration/DomainModelBuilderOptions.cs
+++ b/core/src/Baked/Domain/Configuration/DomainModelBuilderOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Baked.Buildtime.Diagnostics;
+using Baked.Domain.Inspection;
 using Baked.Domain.Model;
 using System.Reflection;
 
@@ -13,6 +14,7 @@ public class DomainModelBuilderOptions
     public Action<DiagnosticsResult>? OnComplete { get; set; }
     public ConventionOrderMatrixOptions ConventionOrderMatrix { get; } = new();
     public string? DefaultConventionLevel { get; set; }
+    public Inspect Inspect { get; } = new();
 
     public class ConventionOrderMatrixOptions
     {

--- a/core/src/Baked/Domain/Configuration/Order.cs
+++ b/core/src/Baked/Domain/Configuration/Order.cs
@@ -120,9 +120,9 @@ public readonly struct Order
 
     public override string ToString()
     {
-        var baseCode = $"{_base}?"[0];
-        var levelCode = $"{_level}?"[0];
-        var extCode = $"{_extension}?"[0];
+        var baseCode = _base?[0] ?? '?';
+        var levelCode = _level?[0] ?? '?';
+        var extCode = _extension?[0] ?? '?';
         var offset = _offset >= 0 ? $"+{_offset:D4}" : $"{_offset:D4}";
 
         return $"{baseCode}{levelCode}{extCode}{offset}";

--- a/core/src/Baked/Domain/Configuration/Order.cs
+++ b/core/src/Baked/Domain/Configuration/Order.cs
@@ -118,6 +118,16 @@ public readonly struct Order
         return (levelIndex - defaultLevelIndex) * LEVEL_SPAN + _offset;
     }
 
+    public override string ToString()
+    {
+        var baseCode = $"{_base}?"[0];
+        var levelCode = $"{_level}?"[0];
+        var extCode = $"{_extension}?"[0];
+        var offset = _offset >= 0 ? $"+{_offset:D4}" : $"{_offset:D4}";
+
+        return $"{baseCode}{levelCode}{extCode}{offset}";
+    }
+
     public static implicit operator Order(int value) =>
         new(offset: value);
 

--- a/core/src/Baked/Domain/Conventions/AddAttributeConvention.cs
+++ b/core/src/Baked/Domain/Conventions/AddAttributeConvention.cs
@@ -13,7 +13,7 @@ public class AddAttributeConvention<TModelContext>(
     where TModelContext : DomainModelContext
 {
     readonly Trace _trace = Trace.Here();
-    readonly string _orderInfo = (beforeBuildingIndexes ? "+" : "-") + $"{_order}";
+    readonly string _orderInfo = $"{(beforeBuildingIndexes ? "+" : "-")}{_order}";
 
     bool IDomainModelConvention.BeforeBuildingIndexes => beforeBuildingIndexes;
 

--- a/core/src/Baked/Domain/Conventions/AddAttributeConvention.cs
+++ b/core/src/Baked/Domain/Conventions/AddAttributeConvention.cs
@@ -7,11 +7,13 @@ namespace Baked.Domain.Conventions;
 public class AddAttributeConvention<TModelContext>(
     Action<TModelContext, Action<ICustomAttributesModel, Attribute>> _apply,
     Func<TModelContext, bool> _when,
+    Order _order,
     bool beforeBuildingIndexes = true
 ) : IDomainModelConvention<TModelContext>
     where TModelContext : DomainModelContext
 {
     readonly Trace _trace = Trace.Here();
+    readonly string _orderInfo = (beforeBuildingIndexes ? "+" : "-") + $"{_order}";
 
     bool IDomainModelConvention.BeforeBuildingIndexes => beforeBuildingIndexes;
 
@@ -27,7 +29,7 @@ public class AddAttributeConvention<TModelContext>(
                 Add(model, attribute);
 
                 return attribute;
-            })
+            }, orderInfo: _orderInfo)
         );
     }
 

--- a/core/src/Baked/Domain/Conventions/AttributeConfigurationConventionBase.cs
+++ b/core/src/Baked/Domain/Conventions/AttributeConfigurationConventionBase.cs
@@ -4,8 +4,7 @@ using Baked.Domain.Model;
 
 namespace Baked.Domain.Conventions;
 
-public abstract class AttributeConfigurationConventionBase<TModelContext, TAttribute>(Action<TAttribute, TModelContext> apply,
-    Order order,
+public abstract class AttributeConfigurationConventionBase<TModelContext, TAttribute>(Action<TAttribute, TModelContext> apply, Order order,
     Func<TModelContext, TAttribute, bool>? when = default
 ) : IDomainModelConvention<TModelContext>
     where TAttribute : Attribute
@@ -13,6 +12,7 @@ public abstract class AttributeConfigurationConventionBase<TModelContext, TAttri
 {
     readonly Trace _trace = Trace.Here();
     readonly string _orderInfo = $"+{order}";
+
     protected abstract ICustomAttributesModel GetMetadata(TModelContext context);
 
     public void Apply(TModelContext context)

--- a/core/src/Baked/Domain/Conventions/AttributeConfigurationConventionBase.cs
+++ b/core/src/Baked/Domain/Conventions/AttributeConfigurationConventionBase.cs
@@ -5,13 +5,14 @@ using Baked.Domain.Model;
 namespace Baked.Domain.Conventions;
 
 public abstract class AttributeConfigurationConventionBase<TModelContext, TAttribute>(Action<TAttribute, TModelContext> apply,
+    Order order,
     Func<TModelContext, TAttribute, bool>? when = default
 ) : IDomainModelConvention<TModelContext>
     where TAttribute : Attribute
     where TModelContext : DomainModelContext
 {
     readonly Trace _trace = Trace.Here();
-
+    readonly string _orderInfo = $"+{order}";
     protected abstract ICustomAttributesModel GetMetadata(TModelContext context);
 
     public void Apply(TModelContext context)
@@ -35,7 +36,7 @@ public abstract class AttributeConfigurationConventionBase<TModelContext, TAttri
         {
             if (when is not null && !when(context, attribute)) { continue; }
 
-            _trace.CaptureAttribute(context, attribute, () => apply(attribute, context));
+            _trace.CaptureAttribute(context, attribute, () => apply(attribute, context), orderInfo: _orderInfo);
         }
     }
 }

--- a/core/src/Baked/Domain/Conventions/MethodAttributeConfigurationConvention.cs
+++ b/core/src/Baked/Domain/Conventions/MethodAttributeConfigurationConvention.cs
@@ -3,8 +3,7 @@ using Baked.Domain.Model;
 
 namespace Baked.Domain.Conventions;
 
-public class MethodAttributeConfigurationConvention<TAttribute>(Action<TAttribute, MethodModelContext> apply,
-    Order order,
+public class MethodAttributeConfigurationConvention<TAttribute>(Action<TAttribute, MethodModelContext> apply, Order order,
     Func<MethodModelContext, TAttribute, bool>? when = default
 ) : AttributeConfigurationConventionBase<MethodModelContext, TAttribute>(apply, order, when: when)
     where TAttribute : Attribute

--- a/core/src/Baked/Domain/Conventions/MethodAttributeConfigurationConvention.cs
+++ b/core/src/Baked/Domain/Conventions/MethodAttributeConfigurationConvention.cs
@@ -4,8 +4,9 @@ using Baked.Domain.Model;
 namespace Baked.Domain.Conventions;
 
 public class MethodAttributeConfigurationConvention<TAttribute>(Action<TAttribute, MethodModelContext> apply,
+    Order order,
     Func<MethodModelContext, TAttribute, bool>? when = default
-) : AttributeConfigurationConventionBase<MethodModelContext, TAttribute>(apply, when: when)
+) : AttributeConfigurationConventionBase<MethodModelContext, TAttribute>(apply, order, when: when)
     where TAttribute : Attribute
 {
     protected override ICustomAttributesModel GetMetadata(MethodModelContext context) =>

--- a/core/src/Baked/Domain/Conventions/ParameterAttributeConfigurationConvention.cs
+++ b/core/src/Baked/Domain/Conventions/ParameterAttributeConfigurationConvention.cs
@@ -4,8 +4,9 @@ using Baked.Domain.Model;
 namespace Baked.Domain.Conventions;
 
 public class ParameterAttributeConfigurationConvention<TAttribute>(Action<TAttribute, ParameterModelContext> apply,
+    Order order,
     Func<ParameterModelContext, TAttribute, bool>? when = default
-) : AttributeConfigurationConventionBase<ParameterModelContext, TAttribute>(apply, when: when)
+) : AttributeConfigurationConventionBase<ParameterModelContext, TAttribute>(apply, order, when: when)
     where TAttribute : Attribute
 {
     protected override ICustomAttributesModel GetMetadata(ParameterModelContext context) =>

--- a/core/src/Baked/Domain/Conventions/ParameterAttributeConfigurationConvention.cs
+++ b/core/src/Baked/Domain/Conventions/ParameterAttributeConfigurationConvention.cs
@@ -3,8 +3,7 @@ using Baked.Domain.Model;
 
 namespace Baked.Domain.Conventions;
 
-public class ParameterAttributeConfigurationConvention<TAttribute>(Action<TAttribute, ParameterModelContext> apply,
-    Order order,
+public class ParameterAttributeConfigurationConvention<TAttribute>(Action<TAttribute, ParameterModelContext> apply, Order order,
     Func<ParameterModelContext, TAttribute, bool>? when = default
 ) : AttributeConfigurationConventionBase<ParameterModelContext, TAttribute>(apply, order, when: when)
     where TAttribute : Attribute

--- a/core/src/Baked/Domain/Conventions/PropertyAttributeConfigurationConvention.cs
+++ b/core/src/Baked/Domain/Conventions/PropertyAttributeConfigurationConvention.cs
@@ -3,8 +3,7 @@ using Baked.Domain.Model;
 
 namespace Baked.Domain.Conventions;
 
-public class PropertyAttributeConfigurationConvention<TAttribute>(Action<TAttribute, PropertyModelContext> apply,
-    Order order,
+public class PropertyAttributeConfigurationConvention<TAttribute>(Action<TAttribute, PropertyModelContext> apply, Order order,
     Func<PropertyModelContext, TAttribute, bool>? when = default
 ) : AttributeConfigurationConventionBase<PropertyModelContext, TAttribute>(apply, order, when: when)
     where TAttribute : Attribute

--- a/core/src/Baked/Domain/Conventions/PropertyAttributeConfigurationConvention.cs
+++ b/core/src/Baked/Domain/Conventions/PropertyAttributeConfigurationConvention.cs
@@ -4,8 +4,9 @@ using Baked.Domain.Model;
 namespace Baked.Domain.Conventions;
 
 public class PropertyAttributeConfigurationConvention<TAttribute>(Action<TAttribute, PropertyModelContext> apply,
+    Order order,
     Func<PropertyModelContext, TAttribute, bool>? when = default
-) : AttributeConfigurationConventionBase<PropertyModelContext, TAttribute>(apply, when: when)
+) : AttributeConfigurationConventionBase<PropertyModelContext, TAttribute>(apply, order, when: when)
     where TAttribute : Attribute
 {
     protected override ICustomAttributesModel GetMetadata(PropertyModelContext context) =>

--- a/core/src/Baked/Domain/Conventions/SetAttributeConvention.cs
+++ b/core/src/Baked/Domain/Conventions/SetAttributeConvention.cs
@@ -13,7 +13,7 @@ public class SetAttributeConvention<TModelContext>(
     where TModelContext : DomainModelContext
 {
     readonly Trace _trace = Trace.Here();
-    readonly string _orderInfo = (beforeBuildingIndexes ? "+" : "-") + $"{_order}";
+    readonly string _orderInfo = (beforeBuildingIndexes ? "-" : "+") + $"{_order}";
 
     bool IDomainModelConvention.BeforeBuildingIndexes => beforeBuildingIndexes;
 

--- a/core/src/Baked/Domain/Conventions/SetAttributeConvention.cs
+++ b/core/src/Baked/Domain/Conventions/SetAttributeConvention.cs
@@ -7,11 +7,13 @@ namespace Baked.Domain.Conventions;
 public class SetAttributeConvention<TModelContext>(
     Action<TModelContext, Action<ICustomAttributesModel, Attribute>> _apply,
     Func<TModelContext, bool> _when,
+    Order _order,
     bool beforeBuildingIndexes = true
 ) : IDomainModelConvention<TModelContext>
     where TModelContext : DomainModelContext
 {
     readonly Trace _trace = Trace.Here();
+    readonly string _orderInfo = (beforeBuildingIndexes ? "+" : "-") + $"{_order}";
 
     bool IDomainModelConvention.BeforeBuildingIndexes => beforeBuildingIndexes;
 
@@ -27,7 +29,7 @@ public class SetAttributeConvention<TModelContext>(
                 Set(model, attribute);
 
                 return attribute;
-            })
+            }, orderInfo: _orderInfo)
         );
     }
 

--- a/core/src/Baked/Domain/Conventions/SetAttributeConvention.cs
+++ b/core/src/Baked/Domain/Conventions/SetAttributeConvention.cs
@@ -13,7 +13,7 @@ public class SetAttributeConvention<TModelContext>(
     where TModelContext : DomainModelContext
 {
     readonly Trace _trace = Trace.Here();
-    readonly string _orderInfo = (beforeBuildingIndexes ? "-" : "+") + $"{_order}";
+    readonly string _orderInfo = $"{(beforeBuildingIndexes ? "-" : "+")}{_order}";
 
     bool IDomainModelConvention.BeforeBuildingIndexes => beforeBuildingIndexes;
 

--- a/core/src/Baked/Domain/Conventions/TypeAttributeConfigurationConvention.cs
+++ b/core/src/Baked/Domain/Conventions/TypeAttributeConfigurationConvention.cs
@@ -3,8 +3,7 @@ using Baked.Domain.Model;
 
 namespace Baked.Domain.Conventions;
 
-public class TypeAttributeConfigurationConvention<TAttribute>(Action<TAttribute, TypeModelMetadataContext> apply,
-    Order order,
+public class TypeAttributeConfigurationConvention<TAttribute>(Action<TAttribute, TypeModelMetadataContext> apply, Order order,
     Func<TypeModelMetadataContext, TAttribute, bool>? when = default
 ) : AttributeConfigurationConventionBase<TypeModelMetadataContext, TAttribute>(apply, order, when: when)
     where TAttribute : Attribute

--- a/core/src/Baked/Domain/Conventions/TypeAttributeConfigurationConvention.cs
+++ b/core/src/Baked/Domain/Conventions/TypeAttributeConfigurationConvention.cs
@@ -4,8 +4,9 @@ using Baked.Domain.Model;
 namespace Baked.Domain.Conventions;
 
 public class TypeAttributeConfigurationConvention<TAttribute>(Action<TAttribute, TypeModelMetadataContext> apply,
+    Order order,
     Func<TypeModelMetadataContext, TAttribute, bool>? when = default
-) : AttributeConfigurationConventionBase<TypeModelMetadataContext, TAttribute>(apply, when: when)
+) : AttributeConfigurationConventionBase<TypeModelMetadataContext, TAttribute>(apply, order, when: when)
     where TAttribute : Attribute
 {
     protected override ICustomAttributesModel GetMetadata(TypeModelMetadataContext context) =>

--- a/core/src/Baked/Domain/DomainExtensions.cs
+++ b/core/src/Baked/Domain/DomainExtensions.cs
@@ -2,7 +2,6 @@
 using Baked.Domain;
 using Baked.Domain.Configuration;
 using Baked.Domain.Export;
-using Baked.Domain.Inspection;
 using Baked.Domain.Model;
 using Baked.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,9 +18,6 @@ public static class DomainExtensions
 {
     public class Configurator(LayerConfigurator _configurator)
     {
-        public void ConfigureInspect(Action<Inspect> configuration) =>
-            _configurator.Configure(configuration);
-
         public void ConfigureDomainTypeCollection(Action<IDomainTypeCollection> configuration) =>
             _configurator.Configure(configuration);
 

--- a/core/src/Baked/Domain/DomainExtensions.cs
+++ b/core/src/Baked/Domain/DomainExtensions.cs
@@ -7,6 +7,7 @@ using Baked.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -61,6 +62,45 @@ public static class DomainExtensions
         public static DiagnosticCode OrderOutOfBounds => new(303, "order-out-of-bounds");
         public static DiagnosticCode UndefinedLevel => new(304, "undefined-level");
         public static DiagnosticCode InvalidOrder => new(305, "invalid-order");
+    }
+
+    extension(StackTrace stackTrace)
+    {
+        public bool TryFindFeatureSource([NotNullWhen(true)] out string? source)
+        {
+            source = null;
+
+            var frames = stackTrace.GetFrames();
+            var featureFrame =
+                frames.FirstOrDefault(f => f.GetMethod()?.ReflectedType?.DeclaringType?.Name.EndsWith("Feature") == true) ??
+                frames.FirstOrDefault(f => f.GetMethod()?.DeclaringType?.Name.EndsWith("Feature") == true);
+            if (featureFrame is null) { return false; }
+
+            source =
+                featureFrame.GetMethod()?.ReflectedType?.DeclaringType?.Name ??
+                featureFrame.GetMethod()?.DeclaringType?.Name ??
+                string.Empty;
+
+            var fileName = featureFrame.GetFileName();
+            if (fileName is null)
+            {
+                source += " [bold red]⠕[/]";
+
+                return true;
+            }
+
+            var title = source;
+            var url = new Uri(fileName).AbsoluteUri;
+            source = $"[link={url}]{title}[/]";
+
+            var lineNumber = featureFrame.GetFileLineNumber();
+            if (lineNumber > 0)
+            {
+                source += $":{lineNumber}";
+            }
+
+            return true;
+        }
     }
 
     extension(ApplicationContext application)

--- a/core/src/Baked/Domain/DomainLayer.cs
+++ b/core/src/Baked/Domain/DomainLayer.cs
@@ -2,7 +2,6 @@
 using Baked.Buildtime;
 using Baked.Domain.Configuration;
 using Baked.Domain.Export;
-using Baked.Domain.Inspection;
 using Humanizer;
 
 using static Baked.Buildtime.BuildtimeLayer;
@@ -13,7 +12,6 @@ namespace Baked.Domain;
 
 public class DomainLayer : LayerBase<AddDomainTypes, Generate, AddServices>
 {
-    readonly Inspect _inspect = new();
     readonly IDomainTypeCollection _domainTypes = new DomainTypeCollection();
     readonly DomainModelBuilderOptions _builderOptions = new();
     readonly IDomainModelConventionCollection _conventions;
@@ -31,7 +29,6 @@ public class DomainLayer : LayerBase<AddDomainTypes, Generate, AddServices>
         IDisposable diagnostics = Diagnostics.Start(nameof(DomainLayer));
 
         return phase.CreateContextBuilder()
-            .Add(_inspect)
             .Add(_domainTypes)
             .Add(_builderOptions)
             .Add(_conventions)

--- a/core/src/Baked/Domain/DomainLayer.cs
+++ b/core/src/Baked/Domain/DomainLayer.cs
@@ -75,6 +75,8 @@ public class DomainLayer : LayerBase<AddDomainTypes, Generate, AddServices>
                         generatedFiles.Add($"{fileName.Kebaberize()}", content, extension: "kdl", outdir: Path.Join("Export", $"{key.Kebaberize()}"));
                     }
                 }
+
+                Inspection.Inspection.Clear();
             })
             .Build();
     }

--- a/core/src/Baked/Domain/DomainLayer.cs
+++ b/core/src/Baked/Domain/DomainLayer.cs
@@ -76,6 +76,8 @@ public class DomainLayer : LayerBase<AddDomainTypes, Generate, AddServices>
                     }
                 }
 
+                // NOTE
+                // This code is added to fix test run all error
                 Inspection.Inspection.Clear();
             })
             .Build();

--- a/core/src/Baked/Domain/Inspection/AttributeCaptureType.cs
+++ b/core/src/Baked/Domain/Inspection/AttributeCaptureType.cs
@@ -2,10 +2,11 @@ using Baked.Domain.Configuration;
 
 namespace Baked.Domain.Inspection;
 
-public class AttributeCaptureType(DomainModelContext _context)
+public class AttributeCaptureType(DomainModelContext _context, string? _orderInfo)
     : ICaptureType
 {
     public string Id => _context.Identifier;
+    public string? OrderInfo => _orderInfo;
 
     public string BuildTitle(Type type) =>
         $"[[{type.Name.Replace("Attribute", string.Empty)}]]";

--- a/core/src/Baked/Domain/Inspection/Capture.cs
+++ b/core/src/Baked/Domain/Inspection/Capture.cs
@@ -63,8 +63,8 @@ internal class Capture<T>
         if (!_initial && Equals(value, previousValue)) { return target; }
 
         var source = TryFindFeatureSource(out var featureSource)
-            ? $"[magenta]{featureSource}[/]"
-            : $"[magenta]<unknown>[/]{Environment.NewLine}[gray]{Markup.Escape($"{_stackTrace}")}[/]";
+            ? $"[magenta]{featureSource}[/] {OrderInfo()}"
+            : $"[magenta]<unknown>[/] {OrderInfo()}{Environment.NewLine}[gray]{Markup.Escape($"{_stackTrace}")}[/]";
         Diagnostics.Current.ReportInfo($"  [darkgoldenrod]{Property}:[/] {FormatValue(value)} [gray]«[/] {source}", group: _captureType.Id);
 
         return target;
@@ -119,4 +119,7 @@ internal class Capture<T>
 
         return true;
     }
+
+    string OrderInfo() =>
+        $"{(_captureType.OrderInfo == null ? string.Empty : $"[gray] Order: {_captureType.OrderInfo}[/]")}";
 }

--- a/core/src/Baked/Domain/Inspection/Capture.cs
+++ b/core/src/Baked/Domain/Inspection/Capture.cs
@@ -57,15 +57,15 @@ internal class Capture<T>
 
         if (_initial)
         {
-            Diagnostics.Current.ReportInfo($"[steelblue3]{_captureType.BuildTitle(type)}[/] [gray]{_captureType.Id}[/]", group: _captureType.Id);
+            Diagnostics.Current.ReportInfo($"[steelblue3]{_captureType.BuildTitle(type)}[/] [gray]»[/] [magenta]{_captureType.Id}[/]", group: _captureType.Id);
         }
 
         if (!_initial && Equals(value, previousValue)) { return target; }
 
         var source = _stackTrace.TryFindFeatureSource(out var featureSource)
-            ? $"[magenta]{featureSource}[/] {OrderInfo()}"
-            : $"[magenta]<unknown>[/] {OrderInfo()}{Environment.NewLine}[gray]{Markup.Escape($"{_stackTrace}")}[/]";
-        Diagnostics.Current.ReportInfo($"  [darkgoldenrod]{Property}:[/] {FormatValue(value)} [gray]«[/] {source}", group: _captureType.Id);
+            ? $"[gray]{featureSource}[/]"
+            : $"[gray]<unknown>[/]{Environment.NewLine}[gray]{Markup.Escape($"{_stackTrace}")}[/]";
+        Diagnostics.Current.ReportInfo($"  [gray]{OrderInfo()} »[/] [darkgoldenrod]{Property}:[/] {FormatValue(value)} [gray]«[/] {source}", group: _captureType.Id);
 
         return target;
     }
@@ -85,5 +85,5 @@ internal class Capture<T>
     }
 
     string OrderInfo() =>
-        $"{(_captureType.OrderInfo == null ? string.Empty : $"[gray] Order: {_captureType.OrderInfo}[/]")}";
+        $"{(_captureType.OrderInfo == null ? string.Empty : $"[gray]{_captureType.OrderInfo}[/]")}";
 }

--- a/core/src/Baked/Domain/Inspection/Capture.cs
+++ b/core/src/Baked/Domain/Inspection/Capture.cs
@@ -62,7 +62,7 @@ internal class Capture<T>
 
         if (!_initial && Equals(value, previousValue)) { return target; }
 
-        var source = TryFindFeatureSource(out var featureSource)
+        var source = _stackTrace.TryFindFeatureSource(out var featureSource)
             ? $"[magenta]{featureSource}[/] {OrderInfo()}"
             : $"[magenta]<unknown>[/] {OrderInfo()}{Environment.NewLine}[gray]{Markup.Escape($"{_stackTrace}")}[/]";
         Diagnostics.Current.ReportInfo($"  [darkgoldenrod]{Property}:[/] {FormatValue(value)} [gray]«[/] {source}", group: _captureType.Id);
@@ -80,42 +80,6 @@ internal class Capture<T>
 
         value = _inspection.Evaluate(targetObject);
         concreteTypeOfTarget = targetObject.GetType();
-
-        return true;
-    }
-
-    bool TryFindFeatureSource([NotNullWhen(true)] out string? source)
-    {
-        source = null;
-
-        var frames = _stackTrace.GetFrames();
-        var featureFrame =
-            frames.FirstOrDefault(f => f.GetMethod()?.ReflectedType?.DeclaringType?.Name.EndsWith("Feature") == true) ??
-            frames.FirstOrDefault(f => f.GetMethod()?.DeclaringType?.Name.EndsWith("Feature") == true);
-        if (featureFrame is null) { return false; }
-
-        source =
-            featureFrame.GetMethod()?.ReflectedType?.DeclaringType?.Name ??
-            featureFrame.GetMethod()?.DeclaringType?.Name ??
-            string.Empty;
-
-        var fileName = featureFrame.GetFileName();
-        if (fileName is null)
-        {
-            source += " [bold red]⠕[/]";
-
-            return true;
-        }
-
-        var title = source;
-        var url = new Uri(fileName).AbsoluteUri;
-        source = $"[link={url}]{title}[/]";
-
-        var lineNumber = featureFrame.GetFileLineNumber();
-        if (lineNumber > 0)
-        {
-            source += $":{lineNumber}";
-        }
 
         return true;
     }

--- a/core/src/Baked/Domain/Inspection/ICaptureType.cs
+++ b/core/src/Baked/Domain/Inspection/ICaptureType.cs
@@ -3,6 +3,7 @@ namespace Baked.Domain.Inspection;
 internal interface ICaptureType
 {
     string Id { get; }
+    string? OrderInfo { get; }
 
     string BuildTitle(Type type);
     object? ConvertTarget<T>(T? target);

--- a/core/src/Baked/Domain/Inspection/Trace.cs
+++ b/core/src/Baked/Domain/Inspection/Trace.cs
@@ -26,19 +26,21 @@ public class Trace(StackTrace? stackTrace)
 
     public StackTrace StackTrace => stackTrace ?? new();
 
-    public TTarget CaptureAttribute<TModelContext, TTarget>(TModelContext context, Func<TTarget> create)
-        where TModelContext : DomainModelContext
+    public TTarget CaptureAttribute<TModelContext, TTarget>(TModelContext context, Func<TTarget> create,
+        string? orderInfo = default
+    ) where TModelContext : DomainModelContext
     {
         if (!ShouldCapture(context, out var inspection))
         {
             return create();
         }
 
-        return new Capture<TTarget>(inspection, StackTrace, create, new AttributeCaptureType(context)).Execute();
+        return new Capture<TTarget>(inspection, StackTrace, create, new AttributeCaptureType(context, orderInfo)).Execute();
     }
 
-    public TTarget CaptureAttribute<TModelContext, TTarget>(TModelContext context, TTarget target, Action update)
-        where TModelContext : DomainModelContext
+    public TTarget CaptureAttribute<TModelContext, TTarget>(TModelContext context, TTarget target, Action update,
+        string? orderInfo = default
+    ) where TModelContext : DomainModelContext
     {
         if (!ShouldCapture(context, out var inspection))
         {
@@ -47,6 +49,6 @@ public class Trace(StackTrace? stackTrace)
             return target;
         }
 
-        return new Capture<TTarget>(inspection, StackTrace, update, new AttributeCaptureType(context), target).Execute();
+        return new Capture<TTarget>(inspection, StackTrace, update, new AttributeCaptureType(context, orderInfo), target).Execute();
     }
 }

--- a/core/src/Baked/Theme/DescriptorCaptureType.cs
+++ b/core/src/Baked/Theme/DescriptorCaptureType.cs
@@ -3,10 +3,11 @@ using Baked.Ui;
 
 namespace Baked.Theme;
 
-public class DescriptorCaptureType(ComponentContext _context)
+public class DescriptorCaptureType(ComponentContext _context, string? _orderInfo)
     : ICaptureType
 {
     public string Id => $"{_context.Path}";
+    public string? OrderInfo => _orderInfo;
 
     public string BuildTitle(Type type) =>
         $"<{type.GetName(includeDeclaringTypes: true)}>";

--- a/core/src/Baked/Theme/ThemeExtensions.cs
+++ b/core/src/Baked/Theme/ThemeExtensions.cs
@@ -474,16 +474,17 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
+            order = order.ThemeDefault;
 
             conventions.AddMethodAttributeConfiguration<GeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (s, cc) => schema(s, c, cc),
                     where: where,
-                    order: order.ThemeDefault
+                    order: order
                 ),
                 when: c => when(c),
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -689,6 +690,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= cc => true;
+            order = order.ThemeDefault;
 
             conventions.AddMethodAttribute(
                 apply: (c, add) =>
@@ -706,7 +708,7 @@ public static class ThemeExtensions
                 },
                 when: c => c.Type.Has<ControllerModelAttribute>() && c.Method.Has<ActionModelAttribute>() && when(c),
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order
             );
         }
 

--- a/core/src/Baked/Theme/ThemeExtensions.cs
+++ b/core/src/Baked/Theme/ThemeExtensions.cs
@@ -1357,17 +1357,21 @@ public static class ThemeExtensions
         }
 #pragma warning restore IDE0051
 
-        public T CaptureDescriptor<T>(DomainModelContext c, ComponentContext cc, Func<T> create)
+        public T CaptureDescriptor<T>(DomainModelContext c, ComponentContext cc, Func<T> create,
+            string? orderInfo = default
+        )
         {
             if (!ShouldCapture(c, cc, out var inspection))
             {
                 return create();
             }
 
-            return new Capture<T>(inspection, trace.StackTrace, create, new DescriptorCaptureType(cc)).Execute();
+            return new Capture<T>(inspection, trace.StackTrace, create, new DescriptorCaptureType(cc, orderInfo)).Execute();
         }
 
-        public T CaptureDescriptor<T>(DomainModelContext c, ComponentContext cc, T target, Action update)
+        public T CaptureDescriptor<T>(DomainModelContext c, ComponentContext cc, T target, Action update,
+            string? orderInfo = default
+        )
         {
             if (!ShouldCapture(c, cc, out var inspection))
             {
@@ -1376,7 +1380,7 @@ public static class ThemeExtensions
                 return target;
             }
 
-            return new Capture<T>(inspection, trace.StackTrace, update, new DescriptorCaptureType(cc), target).Execute();
+            return new Capture<T>(inspection, trace.StackTrace, update, new DescriptorCaptureType(cc, orderInfo), target).Execute();
         }
     }
 

--- a/core/src/Baked/Theme/ThemeExtensions.cs
+++ b/core/src/Baked/Theme/ThemeExtensions.cs
@@ -175,7 +175,7 @@ public static class ThemeExtensions
             conventions.AddTypeAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
                 {
-                    Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => schema(c, cc)),
+                    Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => schema(c, cc), orderInfo: $"+{order}"),
                     Filter = where,
                     Trace = c.Trace
                 },
@@ -229,7 +229,7 @@ public static class ThemeExtensions
             conventions.AddPropertyAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
                 {
-                    Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => schema(c, cc)),
+                    Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => schema(c, cc), orderInfo: $"+{order}"),
                     Filter = where,
                     Trace = c.Trace
                 },
@@ -283,7 +283,7 @@ public static class ThemeExtensions
             conventions.AddMethodAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
                 {
-                    Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => schema(c, cc)),
+                    Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => schema(c, cc), orderInfo: $"+{order}"),
                     Filter = where,
                     Trace = c.Trace
                 },
@@ -337,7 +337,7 @@ public static class ThemeExtensions
             conventions.AddParameterAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
                 {
-                    Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => schema(c, cc)),
+                    Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => schema(c, cc), orderInfo: $"+{order}"),
                     Filter = where,
                     Trace = c.Trace
                 },
@@ -390,7 +390,8 @@ public static class ThemeExtensions
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (s, cc) => schema(s, c, cc),
-                    where: where
+                    where: where,
+                    order: order.ThemeDefault
                 ),
                 when: c => when(c),
                 order: order.ThemeDefault
@@ -430,7 +431,8 @@ public static class ThemeExtensions
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (s, cc) => schema(s, c, cc),
-                    where: where
+                    where: where,
+                    order: order.ThemeDefault
                 ),
                 when: c => when(c),
                 order: order.ThemeDefault
@@ -470,7 +472,8 @@ public static class ThemeExtensions
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (s, cc) => schema(s, c, cc),
-                    where: where
+                    where: where,
+                    order: order.ThemeDefault
                 ),
                 when: c => when(c),
                 order: order.ThemeDefault
@@ -510,7 +513,8 @@ public static class ThemeExtensions
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (s, cc) => schema(s, c, cc),
-                    where: where
+                    where: where,
+                    order: order.ThemeDefault
                 ),
                 when: c => when(c),
                 order: order.ThemeDefault
@@ -555,7 +559,7 @@ public static class ThemeExtensions
                 {
                     add(c.Type, new ComponentGeneratorAttribute<TSchema>
                     {
-                        Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => component(c, cc)),
+                        Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => component(c, cc), orderInfo: $"+{order}"),
                         Filter = where,
                         Trace = c.Trace
                     });
@@ -618,7 +622,7 @@ public static class ThemeExtensions
                 {
                     add(c.Property, new ComponentGeneratorAttribute<TSchema>
                     {
-                        Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => component(c, cc)),
+                        Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => component(c, cc), orderInfo: $"+{order}"),
                         Filter = where,
                         Trace = c.Trace
                     });
@@ -681,7 +685,7 @@ public static class ThemeExtensions
                 {
                     add(c.Method, new ComponentGeneratorAttribute<TSchema>
                     {
-                        Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => component(c, cc)),
+                        Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => component(c, cc), orderInfo: $"+{order}"),
                         Filter = where,
                         Trace = c.Trace
                     });
@@ -744,7 +748,7 @@ public static class ThemeExtensions
                 {
                     add(c.Parameter, new ComponentGeneratorAttribute<TSchema>
                     {
-                        Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => component(c, cc)),
+                        Generator = cc => cc.Trace.CaptureDescriptor(c, cc, () => component(c, cc), orderInfo: $"+{order}"),
                         Filter = where,
                         Trace = c.Trace
                     });
@@ -804,7 +808,8 @@ public static class ThemeExtensions
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (d, cc) => component(d, c, cc),
-                    where: where
+                    where: where,
+                    order: order.ThemeDefault
                 ),
                 when: c => when(c),
                 order: order.ThemeDefault
@@ -846,7 +851,8 @@ public static class ThemeExtensions
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (d, cc) => component(d, c, cc),
-                    where: where
+                    where: where,
+                    order: order.ThemeDefault
                 ),
                 when: c => when(c),
                 order: order.ThemeDefault
@@ -888,7 +894,8 @@ public static class ThemeExtensions
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (d, cc) => component(d, c, cc),
-                    where: where
+                    where: where,
+                    order: order.ThemeDefault
                 ),
                 when: c => when(c),
                 order: order.ThemeDefault
@@ -930,7 +937,8 @@ public static class ThemeExtensions
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (d, cc) => component(d, c, cc),
-                    where: where
+                    where: where,
+                    order: order.ThemeDefault
                 ),
                 when: c => when(c),
                 order: order.ThemeDefault
@@ -1088,7 +1096,8 @@ public static class ThemeExtensions
         void WrapGenerator(
             DomainModelContext context,
             Func<ComponentContext, bool> where,
-            Action<TSchema, ComponentContext> apply
+            Action<TSchema, ComponentContext> apply,
+            Order order
         )
         {
             var prev = attribute.Generator;
@@ -1099,7 +1108,7 @@ public static class ThemeExtensions
                 var result = prev(cc);
                 if (!where(cc)) { return result; }
 
-                return trace.CaptureDescriptor(context, cc, result, () => apply(result, cc));
+                return trace.CaptureDescriptor(context, cc, result, () => apply(result, cc), orderInfo: $"+{order}");
             };
         }
 #pragma warning restore IDE0051

--- a/core/src/Baked/Theme/ThemeExtensions.cs
+++ b/core/src/Baked/Theme/ThemeExtensions.cs
@@ -10,6 +10,7 @@ using Baked.Theme;
 using Baked.Theme.Default;
 using Baked.Ui;
 using Baked.Ui.Configuration;
+using Microsoft.OpenApi;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
@@ -171,6 +172,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
+            order = order.ThemeDefault;
 
             conventions.AddTypeAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
@@ -181,7 +183,7 @@ public static class ThemeExtensions
                 },
                 when: when,
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -225,6 +227,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
+            order = order.ThemeDefault;
 
             conventions.AddPropertyAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
@@ -235,7 +238,7 @@ public static class ThemeExtensions
                 },
                 when: when,
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -279,6 +282,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
+            order = order.ThemeDefault;
 
             conventions.AddMethodAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
@@ -289,7 +293,7 @@ public static class ThemeExtensions
                 },
                 when: c => c.Type.Has<ControllerModelAttribute>() && c.Method.Has<ActionModelAttribute>() && when(c),
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -333,6 +337,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
+            order = order.ThemeDefault;
 
             conventions.AddParameterAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
@@ -343,7 +348,7 @@ public static class ThemeExtensions
                 },
                 when: c => c.Type.Has<ControllerModelAttribute>() && c.Parameter.Has<ParameterModelAttribute>() && when(c),
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -385,16 +390,17 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
+            order = order.ThemeDefault;
 
             conventions.AddTypeAttributeConfiguration<GeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (s, cc) => schema(s, c, cc),
                     where: where,
-                    order: order.ThemeDefault
+                    order: order
                 ),
                 when: c => when(c),
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -426,16 +432,17 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
+            order = order.ThemeDefault;
 
             conventions.AddPropertyAttributeConfiguration<GeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (s, cc) => schema(s, c, cc),
                     where: where,
-                    order: order.ThemeDefault
+                    order: order
                 ),
                 when: c => when(c),
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -508,16 +515,17 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
+            order = order.ThemeDefault;
 
             conventions.AddParameterAttributeConfiguration<GeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (s, cc) => schema(s, c, cc),
                     where: where,
-                    order: order.ThemeDefault
+                    order: order
                 ),
                 when: c => when(c),
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -553,6 +561,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
+            order = order.ThemeDefault;
 
             conventions.AddTypeAttribute(
                 apply: (c, add) =>
@@ -570,7 +579,7 @@ public static class ThemeExtensions
                 },
                 when: c => when(c),
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -616,6 +625,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
+            order = order.ThemeDefault;
 
             conventions.AddPropertyAttribute(
                 apply: (c, add) =>
@@ -633,7 +643,7 @@ public static class ThemeExtensions
                 },
                 when: c => when(c),
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -742,6 +752,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
+            order = order.ThemeDefault;
 
             conventions.AddParameterAttribute(
                 apply: (c, add) =>
@@ -759,7 +770,7 @@ public static class ThemeExtensions
                 },
                 when: c => c.Type.Has<ControllerModelAttribute>() && c.Parameter.Has<ParameterModelAttribute>() && when(c),
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -803,16 +814,17 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
+            order = order.ThemeDefault;
 
             conventions.AddTypeAttributeConfiguration<ComponentGeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (d, cc) => component(d, c, cc),
                     where: where,
-                    order: order.ThemeDefault
+                    order: order
                 ),
                 when: c => when(c),
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -846,16 +858,17 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
+            order = order.ThemeDefault;
 
             conventions.AddPropertyAttributeConfiguration<ComponentGeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (d, cc) => component(d, c, cc),
                     where: where,
-                    order: order.ThemeDefault
+                    order: order
                 ),
                 when: c => when(c),
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -889,16 +902,17 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
+            order = order.ThemeDefault;
 
             conventions.AddMethodAttributeConfiguration<ComponentGeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (d, cc) => component(d, c, cc),
                     where: where,
-                    order: order.ThemeDefault
+                    order: order
                 ),
                 when: c => when(c),
-                order: order.ThemeDefault
+                order: order
             );
         }
 
@@ -932,16 +946,17 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
+            order = order.ThemeDefault;
 
             conventions.AddParameterAttributeConfiguration<ComponentGeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
                     context: c,
                     apply: (d, cc) => component(d, c, cc),
                     where: where,
-                    order: order.ThemeDefault
+                    order: order
                 ),
                 when: c => when(c),
-                order: order.ThemeDefault
+                order: order
             );
         }
     }

--- a/core/src/Baked/Theme/ThemeExtensions.cs
+++ b/core/src/Baked/Theme/ThemeExtensions.cs
@@ -10,7 +10,6 @@ using Baked.Theme;
 using Baked.Theme.Default;
 using Baked.Ui;
 using Baked.Ui.Configuration;
-using Microsoft.OpenApi;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;

--- a/core/src/Baked/Theme/ThemeExtensions.cs
+++ b/core/src/Baked/Theme/ThemeExtensions.cs
@@ -171,7 +171,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Add;
 
             conventions.AddTypeAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
@@ -192,7 +192,7 @@ public static class ThemeExtensions
         {
             conventions.RemoveTypeAttribute<GeneratorAttribute<TSchema>>(when: when,
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order.ThemeDefault.Add
             );
         }
 
@@ -226,7 +226,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Add;
 
             conventions.AddPropertyAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
@@ -247,7 +247,7 @@ public static class ThemeExtensions
         {
             conventions.RemovePropertyAttribute<GeneratorAttribute<TSchema>>(when: when,
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order.ThemeDefault.Add
             );
         }
 
@@ -281,7 +281,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Add;
 
             conventions.AddMethodAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
@@ -302,7 +302,7 @@ public static class ThemeExtensions
         {
             conventions.RemoveMethodAttribute<GeneratorAttribute<TSchema>>(when: when,
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order.ThemeDefault.Add
             );
         }
 
@@ -336,7 +336,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Add;
 
             conventions.AddParameterAttribute(
                 attribute: c => new GeneratorAttribute<TSchema>
@@ -357,7 +357,7 @@ public static class ThemeExtensions
         {
             conventions.RemoveParameterAttribute<GeneratorAttribute<TSchema>>(when: when,
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order.ThemeDefault.Add
             );
         }
 
@@ -389,7 +389,7 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Configure;
 
             conventions.AddTypeAttributeConfiguration<GeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
@@ -431,7 +431,7 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Configure;
 
             conventions.AddPropertyAttributeConfiguration<GeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
@@ -473,7 +473,7 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Configure;
 
             conventions.AddMethodAttributeConfiguration<GeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
@@ -515,7 +515,7 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Configure;
 
             conventions.AddParameterAttributeConfiguration<GeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
@@ -561,7 +561,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Add;
 
             conventions.AddTypeAttribute(
                 apply: (c, add) =>
@@ -589,7 +589,7 @@ public static class ThemeExtensions
         {
             conventions.RemoveTypeAttribute<ComponentGeneratorAttribute<TSchema>>(when,
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order.ThemeDefault.Add
             );
         }
 
@@ -625,7 +625,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Add;
 
             conventions.AddPropertyAttribute(
                 apply: (c, add) =>
@@ -653,7 +653,7 @@ public static class ThemeExtensions
         {
             conventions.RemovePropertyAttribute<ComponentGeneratorAttribute<TSchema>>(when,
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order.ThemeDefault.Add
             );
         }
 
@@ -689,7 +689,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= cc => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Add;
 
             conventions.AddMethodAttribute(
                 apply: (c, add) =>
@@ -717,7 +717,7 @@ public static class ThemeExtensions
         {
             conventions.RemoveMethodAttribute<ComponentGeneratorAttribute<TSchema>>(when,
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order.ThemeDefault.Add
             );
         }
 
@@ -753,7 +753,7 @@ public static class ThemeExtensions
         {
             when ??= c => true;
             where ??= c => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Add;
 
             conventions.AddParameterAttribute(
                 apply: (c, add) =>
@@ -781,7 +781,7 @@ public static class ThemeExtensions
         {
             conventions.RemoveParameterAttribute<ComponentGeneratorAttribute<TSchema>>(when,
                 beforeBuildingIndexes: false,
-                order: order.ThemeDefault
+                order: order.ThemeDefault.Add
             );
         }
 
@@ -815,7 +815,7 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Configure;
 
             conventions.AddTypeAttributeConfiguration<ComponentGeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
@@ -859,7 +859,7 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Configure;
 
             conventions.AddPropertyAttributeConfiguration<ComponentGeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
@@ -903,7 +903,7 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Configure;
 
             conventions.AddMethodAttributeConfiguration<ComponentGeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(
@@ -947,7 +947,7 @@ public static class ThemeExtensions
         {
             when ??= _ => true;
             where ??= _ => true;
-            order = order.ThemeDefault;
+            order = order.ThemeDefault.Configure;
 
             conventions.AddParameterAttributeConfiguration<ComponentGeneratorAttribute<TSchema>>(
                 attribute: (attribute, c) => attribute.WrapGenerator(

--- a/core/test/Baked.Test.Specs/Buildtime/ReportingDiagnostics.cs
+++ b/core/test/Baked.Test.Specs/Buildtime/ReportingDiagnostics.cs
@@ -32,20 +32,6 @@ public class ReportingDiagnostics
     }
 
     [Test]
-    public void Error_reports_the_whole_stack_trace_when_feature_is_not_captured()
-    {
-        var messages = new List<DiagnosticMessage>();
-        using (var diagnostics = Diagnostics.Start("test", result => messages.AddRange(result.Messages)))
-        {
-            diagnostics.Diagnose(() => throw DiagnosticCode.UndefinedLevel.Exception("test"));
-        }
-
-        messages.Count.ShouldBe(2);
-        messages[1].Level.ShouldBe("info");
-        messages[1].Message.ShouldContain($"{nameof(ReportingDiagnostics)}.cs:line");
-    }
-
-    [Test]
     public void Non_diagnostics_exceptions_are_reported_along_with_their_stack_trace()
     {
         var messages = new List<DiagnosticMessage>();

--- a/core/test/Baked.Test.Specs/Buildtime/ReportingDiagnostics.cs
+++ b/core/test/Baked.Test.Specs/Buildtime/ReportingDiagnostics.cs
@@ -68,7 +68,7 @@ public class ReportingDiagnostics
             diagnostics.Diagnose(() => diagnostics.ReportWarning(DiagnosticCode.Unknown, "test"));
         }
 
-        messages[0].ToString().ShouldContain(
+        messages[0].ToString().ShouldBe(
             "[bold darkorange3]warning [link=https://baked.mouseless.codes/errors#unknown]B9999[/][/]: test"
         );
     }

--- a/core/test/Baked.Test.Specs/Buildtime/ReportingDiagnostics.cs
+++ b/core/test/Baked.Test.Specs/Buildtime/ReportingDiagnostics.cs
@@ -1,4 +1,5 @@
 using Baked.Buildtime.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace Baked.Test.Buildtime;
 
@@ -19,7 +20,19 @@ public class ReportingDiagnostics
     }
 
     [Test]
-    public void Diagnostic_exceptions_includes_code_and_line_number()
+    public void Error_captures_and_reports_feature_name_from_stack_trace()
+    {
+        var messages = new List<DiagnosticMessage>();
+        using (var diagnostics = Diagnostics.Start("test", result => messages.AddRange(result.Messages)))
+        {
+            diagnostics.Diagnose(() => new TestFeature().Configure(() => throw DiagnosticCode.UndefinedLevel.Exception("test")));
+        }
+
+        messages.ShouldContain(m => Regex.IsMatch(m.Message, @"\[gray]\[link=.*]TestFeature\[/]:\d+\[/]"), customMessage: messages.Join(Environment.NewLine));
+    }
+
+    [Test]
+    public void Error_reports_the_whole_stack_trace_when_feature_is_not_captured()
     {
         var messages = new List<DiagnosticMessage>();
         using (var diagnostics = Diagnostics.Start("test", result => messages.AddRange(result.Messages)))
@@ -27,9 +40,9 @@ public class ReportingDiagnostics
             diagnostics.Diagnose(() => throw DiagnosticCode.UndefinedLevel.Exception("test"));
         }
 
-        messages[0].ToString().ShouldContain(
-            "[gray]«[/] $\"[magenta]ReportingDiagnostics:27[/]"
-        );
+        messages.Count.ShouldBe(2);
+        messages[1].Level.ShouldBe("info");
+        messages[1].Message.ShouldContain($"{nameof(ReportingDiagnostics)}.cs:line");
     }
 
     [Test]
@@ -57,20 +70,6 @@ public class ReportingDiagnostics
 
         messages[0].ToString().ShouldContain(
             "[bold darkorange3]warning [link=https://baked.mouseless.codes/errors#unknown]B9999[/][/]: test"
-        );
-    }
-
-    [Test]
-    public void Warning_includes_code_and_line_number()
-    {
-        var messages = new List<DiagnosticMessage>();
-        using (var diagnostics = Diagnostics.Start("test", result => messages.AddRange(result.Messages)))
-        {
-            diagnostics.Diagnose(() => diagnostics.ReportWarning(DiagnosticCode.Unknown, "test"));
-        }
-
-        messages[0].ToString().ShouldContain(
-            "[gray]«[/] $\"[magenta]ReportingDiagnostics:69[/]"
         );
     }
 

--- a/core/test/Baked.Test.Specs/Buildtime/ReportingDiagnostics.cs
+++ b/core/test/Baked.Test.Specs/Buildtime/ReportingDiagnostics.cs
@@ -13,8 +13,22 @@ public class ReportingDiagnostics
             diagnostics.Diagnose(() => throw new("test"));
         }
 
-        messages[0].ToString().ShouldBe(
+        messages[0].ToString().ShouldContain(
             "[bold maroon]error [link=https://baked.mouseless.codes/errors#unknown]B9999[/][/]: test"
+        );
+    }
+
+    [Test]
+    public void Diagnostic_exceptions_includes_code_and_line_number()
+    {
+        var messages = new List<DiagnosticMessage>();
+        using (var diagnostics = Diagnostics.Start("test", result => messages.AddRange(result.Messages)))
+        {
+            diagnostics.Diagnose(() => throw DiagnosticCode.UndefinedLevel.Exception("test"));
+        }
+
+        messages[0].ToString().ShouldContain(
+            "[gray]«[/] $\"[magenta]ReportingDiagnostics:27[/]"
         );
     }
 
@@ -41,8 +55,22 @@ public class ReportingDiagnostics
             diagnostics.Diagnose(() => diagnostics.ReportWarning(DiagnosticCode.Unknown, "test"));
         }
 
-        messages[0].ToString().ShouldBe(
+        messages[0].ToString().ShouldContain(
             "[bold darkorange3]warning [link=https://baked.mouseless.codes/errors#unknown]B9999[/][/]: test"
+        );
+    }
+
+    [Test]
+    public void Warning_includes_code_and_line_number()
+    {
+        var messages = new List<DiagnosticMessage>();
+        using (var diagnostics = Diagnostics.Start("test", result => messages.AddRange(result.Messages)))
+        {
+            diagnostics.Diagnose(() => diagnostics.ReportWarning(DiagnosticCode.Unknown, "test"));
+        }
+
+        messages[0].ToString().ShouldContain(
+            "[gray]«[/] $\"[magenta]ReportingDiagnostics:69[/]"
         );
     }
 

--- a/core/test/Baked.Test.Specs/Buildtime/TestFeature.cs
+++ b/core/test/Baked.Test.Specs/Buildtime/TestFeature.cs
@@ -1,0 +1,7 @@
+﻿namespace Baked.Test.Buildtime;
+
+public class TestFeature
+{
+    public void Configure(Action action) =>
+        action();
+}

--- a/core/test/Baked.Test.Specs/Domain/InspectingAttributes.cs
+++ b/core/test/Baked.Test.Specs/Domain/InspectingAttributes.cs
@@ -227,7 +227,7 @@ public class InspectingAttributes : TestSpec
     }
 
     [Test]
-    public void Reports_member_in_gray_for_readability()
+    public void Reports_member_in_magenta_for_readability()
     {
         _inspect.Attribute<CustomAttribute>();
         var c = GiveMe.ATypeModelContext<Parent>();
@@ -237,7 +237,7 @@ public class InspectingAttributes : TestSpec
             _trace.CaptureAttribute(c, () => new CustomAttribute());
         }
 
-        _messages.ShouldContain(m => m.Message.Contains("[gray]Baked.Playground.Orm.Parent[/]"));
+        _messages.ShouldContain(m => m.Message.Contains("[magenta]Baked.Playground.Orm.Parent[/]"));
     }
 
     [Test]
@@ -432,7 +432,7 @@ public class InspectingAttributes : TestSpec
             new StubFeature(c).Configure(() => new CustomAttribute());
         }
 
-        _messages.ShouldContain(m => Regex.IsMatch(m.Message, @"\[magenta]\[link=.*]StubFeature\[/]:\d+\[/]"), customMessage: _messages.Join(Environment.NewLine));
+        _messages.ShouldContain(m => Regex.IsMatch(m.Message, @"\[gray]\[link=.*]StubFeature\[/]:\d+\[/]"), customMessage: _messages.Join(Environment.NewLine));
     }
 
     [Test]
@@ -466,6 +466,6 @@ public class InspectingAttributes : TestSpec
             new StubFeature(c).Configure(() => new CustomAttribute(), orderInfo: "orderInfo");
         }
 
-        _messages.ShouldContain(m => Regex.IsMatch(m.Message, @"\[gray].*Order: orderInfo.*"), customMessage: _messages.Join(Environment.NewLine));
+        _messages.ShouldContain(m => Regex.IsMatch(m.Message, @"\[gray].*orderInfo.*"), customMessage: _messages.Join(Environment.NewLine));
     }
 }

--- a/core/test/Baked.Test.Specs/Domain/InspectingAttributes.cs
+++ b/core/test/Baked.Test.Specs/Domain/InspectingAttributes.cs
@@ -454,4 +454,18 @@ public class InspectingAttributes : TestSpec
             ), customMessage: _messages.Join(Environment.NewLine)
         );
     }
+
+    [Test]
+    public void Reports_order_info_when_provided()
+    {
+        _inspect.Attribute<CustomAttribute>();
+        var c = GiveMe.ATypeModelContext<Parent>();
+
+        using (_diagnostics)
+        {
+            new StubFeature(c).Configure(() => new CustomAttribute(), orderInfo: "orderInfo");
+        }
+
+        _messages.ShouldContain(m => Regex.IsMatch(m.Message, @"\[gray].*Order: orderInfo.*"), customMessage: _messages.Join(Environment.NewLine));
+    }
 }

--- a/core/test/Baked.Test.Specs/Domain/ManagingOrders.cs
+++ b/core/test/Baked.Test.Specs/Domain/ManagingOrders.cs
@@ -189,4 +189,27 @@ public class ManagingOrders
         exception.Code.ShouldBe(DiagnosticCode.OrderOutOfBounds);
         exception.Message.ShouldBe("Order (BaseA.LevelA.ExtA: 5000) must be between -5000 - 4999");
     }
+
+    [Test]
+    public void To_string_returns_base_level_ext_and_offset_info()
+    {
+        var order = Order.At
+            .WithBase("BaseA")
+            .WithLevel("LevelA")
+            .WithExtension("ExtA");
+        var orderWithPositiveOffset = order + 10;
+        var orderWithNegativeOffset = order - 10;
+
+        order.ToString().ShouldBe("BLE+0000");
+        orderWithPositiveOffset.ToString().ShouldBe("BLE+0010");
+        orderWithNegativeOffset.ToString().ShouldBe("BLE-0010");
+    }
+
+    [Test]
+    public void ToString_returns_question_mark_for_unknown_order_parts()
+    {
+        var order = Order.At.WithBase("BaseA");
+
+        order.ToString().ShouldBe("B??+0000");
+    }
 }

--- a/core/test/Baked.Test.Specs/Domain/RespectingAttributeUsage.cs
+++ b/core/test/Baked.Test.Specs/Domain/RespectingAttributeUsage.cs
@@ -35,7 +35,8 @@ public class RespectingAttributeUsage : TestSpec
         var domain = GiveMe.TheDomainModel();
         var convention = new AddAttributeConvention<TypeModelContext>(
             _when: _ => true,
-            _apply: (c, set) => set(c.Type.GetMetadata(), attribue)
+            _apply: (c, set) => set(c.Type.GetMetadata(), attribue),
+            _order: Order.At
         );
         convention.Apply(new TypeModelContext()
         {
@@ -49,7 +50,8 @@ public class RespectingAttributeUsage : TestSpec
         var domain = GiveMe.TheDomainModel();
         var convention = new SetAttributeConvention<TypeModelContext>(
             _when: _ => true,
-            _apply: (c, set) => set(c.Type.GetMetadata(), attribue)
+            _apply: (c, set) => set(c.Type.GetMetadata(), attribue),
+            _order: Order.At
         );
         convention.Apply(new TypeModelContext()
         {

--- a/core/test/Baked.Test.Specs/Domain/RespectingAttributeUsage.cs
+++ b/core/test/Baked.Test.Specs/Domain/RespectingAttributeUsage.cs
@@ -30,12 +30,12 @@ public class RespectingAttributeUsage : TestSpec
     [AttributeUsage(AttributeTargets.Property)]
     public class TargetPropertyAttribute : Attribute;
 
-    void Add(TypeModel type, Attribute attribue)
+    void Add(TypeModel type, Attribute attribute)
     {
         var domain = GiveMe.TheDomainModel();
         var convention = new AddAttributeConvention<TypeModelContext>(
             _when: _ => true,
-            _apply: (c, set) => set(c.Type.GetMetadata(), attribue),
+            _apply: (c, set) => set(c.Type.GetMetadata(), attribute),
             _order: Order.At
         );
         convention.Apply(new TypeModelContext()
@@ -45,12 +45,12 @@ public class RespectingAttributeUsage : TestSpec
         });
     }
 
-    void Set(TypeModel type, Attribute attribue)
+    void Set(TypeModel type, Attribute attribute)
     {
         var domain = GiveMe.TheDomainModel();
         var convention = new SetAttributeConvention<TypeModelContext>(
             _when: _ => true,
-            _apply: (c, set) => set(c.Type.GetMetadata(), attribue),
+            _apply: (c, set) => set(c.Type.GetMetadata(), attribute),
             _order: Order.At
         );
         convention.Apply(new TypeModelContext()

--- a/core/test/Baked.Test.Specs/Domain/StubFeature.cs
+++ b/core/test/Baked.Test.Specs/Domain/StubFeature.cs
@@ -7,6 +7,8 @@ public class StubFeature(DomainModelContext c)
 {
     readonly Trace _trace = Trace.Here();
 
-    public TSchema Configure<TSchema>(Func<TSchema> create) =>
-        _trace.CaptureAttribute(c, create);
+    public TSchema Configure<TSchema>(Func<TSchema> create,
+        string? orderInfo = default
+    ) =>
+        _trace.CaptureAttribute(c, create, orderInfo: orderInfo);
 }

--- a/core/test/Baked.Test.Specs/Domain/StubFeature.cs
+++ b/core/test/Baked.Test.Specs/Domain/StubFeature.cs
@@ -9,6 +9,5 @@ public class StubFeature(DomainModelContext c)
 
     public TSchema Configure<TSchema>(Func<TSchema> create,
         string? orderInfo = default
-    ) =>
-        _trace.CaptureAttribute(c, create, orderInfo: orderInfo);
+    ) => _trace.CaptureAttribute(c, create, orderInfo: orderInfo);
 }

--- a/core/test/Baked.Test.Specs/Theme/InspectingComponentAndSchemas.cs
+++ b/core/test/Baked.Test.Specs/Theme/InspectingComponentAndSchemas.cs
@@ -319,7 +319,7 @@ public class InspectingComponentAndSchemas : TestSpec
     }
 
     [Test]
-    public void Reports_path_in_gray_for_readability()
+    public void Reports_path_in_magenta_for_readability()
     {
         _inspect.Component<Text>();
         var c = GiveMe.ATypeModelContext<Parent>();
@@ -330,7 +330,7 @@ public class InspectingComponentAndSchemas : TestSpec
             _trace.CaptureDescriptor(c, cc, () => B.Text());
         }
 
-        _messages.ShouldContain(m => m.Message.Contains("[gray]/test/path[/]"));
+        _messages.ShouldContain(m => m.Message.Contains("[magenta]/test/path[/]"));
     }
 
     [Test]

--- a/docs/features/theme.md
+++ b/docs/features/theme.md
@@ -208,38 +208,38 @@ Configure an inspect to watch a property value of a component or a schema so
 that you can see which UX or Theme feature sets what value and in which order.
 
 ```csharp
-configurator.Domain.ConfigureInspect(inspect =>
+configurator.Domain.ConfigureBuilder(builder =>
 {
     // To inspect a component or a schema on types
-    inspect.TypeCompnent<MyComponent>( // or inspect.TypeSchema
+    builder.Inspect.TypeCompnent<MyComponent>( // or inspect.TypeSchema
         when: c => c.Type..., // optional to inspect specific type models
         where: cc => cc.Path..., // optional to inspect specific component paths
         component: mc => mc.Value // optional to inspect just this value
     );
 
     // To inspect a component or a schema on properties
-    inspect.PropertyComponent<MyComponent>( // or inspect.PropertySchema
+    builder.Inspect.PropertyComponent<MyComponent>( // or inspect.PropertySchema
         when: c => c.Property..., // optional to inspect specific property models
         where: cc => cc.Path..., // optional to inspect specific component paths
         component: mc => mc.Value // optional to inspect just this value
     );
 
     // To inspect a component or a schema on methods
-    inspect.MethodComponent<MyComponent>( // or inspect.MethodSchema
+    builder.Inspect.MethodComponent<MyComponent>( // or inspect.MethodSchema
         when: c => c.Method..., // optional to inspect specific method models
         where: cc => cc.Path..., // optional to inspect specific component paths
         component: mc => mc.Value // optional to inspect just this value
     );
 
     // To inspect a component or a schema on parameters
-    inspect.ParameterComponent<MyComponent>( // or inspect.ParameterSchema
+    builder.Inspect.ParameterComponent<MyComponent>( // or inspect.ParameterSchema
         when: c => c.Parameter..., // optional to inspect specific parameter models
         where: cc => cc.Path..., // optional to inspect specific component path
         component: mc => mc.Value // optional to inspect just this value
     );
 
     // To inspect a component or a schema on any member
-    inspect.Component<MyComponent>( // or inspect.Schema
+    builder.Inspect.Component<MyComponent>( // or inspect.Schema
         when: c => c..., // optional to inspect specific members
         where: cc => cc.Path..., // optional to inspect specific component paths
         component: mc => mc.Value // optional to inspect just this value

--- a/docs/layers/domain.md
+++ b/docs/layers/domain.md
@@ -32,56 +32,6 @@ also provides `DomainServiceCollection` configuration target for features to add
 `IServiceAdder` implementation. The generated `IServiceAdder` is then used in
 `Start` mode for auto registering domain types to service collection.
 
-### `Inspect`
-
-> [!WARNING]
->
-> This feature is still in experimentation and might print false-negative
-> output, meaning it might not capture every change of the inspected attribute.
-
-This target is provided from `DomainModelBuilderOptions` in `AddDomainTypes` 
-phase. To configure it in a feature;
-
-```csharp
-configurator.Domain.ConfigureBuilder(builder =>
-{
-    // To inspect an attribute on types
-    builder.Inspect.TypeAttribute<MyAttribute>(
-        when: c => c.Type..., // optional to inspect specific type models
-        attribute: ma => ma.Value // optional to inspect just this value
-    );
-
-    // To inspect an attribute properties
-    builder.Inspect.PropertyAttribute<MyAttribute>(
-        when: c => c.Property..., // optional to inspect specific property models
-        attribute: ma => ma.Value // optional to inspect just this value
-    );
-
-    // To inspect an attribute methods
-    builder.Inspect.MethodAttribute<MyAttribute>(
-        when: c => c.Method..., // optional to inspect specific method models
-        attribute: ma => ma.Value // optional to inspect just this value
-    );
-
-    // To inspect an attribute parameters
-    builder.Inspect.ParameterAttribute<MyAttribute>(
-        when: c => c.Parameter..., // optional to inspect specific parameter models
-        attribute: ma => ma.Value // optional to inspect just this value
-    );
-
-    // To inspect an attribute any member
-    builder.Inspect.Attribute<MyAttribute>(
-        when: c => c..., // optional to inspect specific members
-        attribute: ma => ma.Value // optional to inspect just this value
-    );
-});
-```
-
-> [!NOTE]
->
-> Only one inspect is allowed. If you configure more than one,
-> `InvalidOperationException` will be thrown
-
 ### `IDomainTypeCollection`
 
 This target is provided in `AddDomainTypes` phase. To configure it in a feature;
@@ -210,3 +160,57 @@ Add versions to `Directory.Packages.props`;
 >   <Virtuosity />
 > </Weavers>
 > ```
+
+### Debugging Domain Model Generation
+
+We provide a tool to debug domain model generation process during a generate phase.
+
+#### `Inspect`
+
+> [!WARNING]
+>
+> This feature is still in experimentation and might print false-negative
+> output, meaning it might not capture every change of the inspected attribute.
+
+This target is provided from `DomainModelBuilderOptions` in `AddDomainTypes` 
+phase. To configure it in a feature;
+
+```csharp
+configurator.Domain.ConfigureBuilder(builder =>
+{
+    // To inspect an attribute on types
+    builder.Inspect.TypeAttribute<MyAttribute>(
+        when: c => c.Type..., // optional to inspect specific type models
+        attribute: ma => ma.Value // optional to inspect just this value
+    );
+
+    // To inspect an attribute properties
+    builder.Inspect.PropertyAttribute<MyAttribute>(
+        when: c => c.Property..., // optional to inspect specific property models
+        attribute: ma => ma.Value // optional to inspect just this value
+    );
+
+    // To inspect an attribute methods
+    builder.Inspect.MethodAttribute<MyAttribute>(
+        when: c => c.Method..., // optional to inspect specific method models
+        attribute: ma => ma.Value // optional to inspect just this value
+    );
+
+    // To inspect an attribute parameters
+    builder.Inspect.ParameterAttribute<MyAttribute>(
+        when: c => c.Parameter..., // optional to inspect specific parameter models
+        attribute: ma => ma.Value // optional to inspect just this value
+    );
+
+    // To inspect an attribute any member
+    builder.Inspect.Attribute<MyAttribute>(
+        when: c => c..., // optional to inspect specific members
+        attribute: ma => ma.Value // optional to inspect just this value
+    );
+});
+```
+
+> [!NOTE]
+>
+> Only one inspect is allowed. If you configure more than one,
+> `InvalidOperationException` will be thrown

--- a/docs/layers/domain.md
+++ b/docs/layers/domain.md
@@ -30,7 +30,57 @@ configuration targets for building `DomainModel`, `AttributeDatas` and
 also provides `DomainServiceCollection` configuration target for features to add
 `DomainServiceDescriptor` for domain types which then be used to generate an
 `IServiceAdder` implementation. The generated `IServiceAdder` is then used in
-`Start` mode for auto registering domain types to service collection. 
+`Start` mode for auto registering domain types to service collection.
+
+### `Inspect`
+
+> [!WARNING]
+>
+> This feature is still in experimentation and might print false-negative
+> output, meaning it might not capture every change of the inspected attribute.
+
+This target is provided from `DomainModelBuilderOptions` in `AddDomainTypes` 
+phase. To configure it in a feature;
+
+```csharp
+configurator.Domain.ConfigureBuilder(builder =>
+{
+    // To inspect an attribute on types
+    builder.Inspect.TypeAttribute<MyAttribute>(
+        when: c => c.Type..., // optional to inspect specific type models
+        attribute: ma => ma.Value // optional to inspect just this value
+    );
+
+    // To inspect an attribute properties
+    builder.Inspect.PropertyAttribute<MyAttribute>(
+        when: c => c.Property..., // optional to inspect specific property models
+        attribute: ma => ma.Value // optional to inspect just this value
+    );
+
+    // To inspect an attribute methods
+    builder.Inspect.MethodAttribute<MyAttribute>(
+        when: c => c.Method..., // optional to inspect specific method models
+        attribute: ma => ma.Value // optional to inspect just this value
+    );
+
+    // To inspect an attribute parameters
+    builder.Inspect.ParameterAttribute<MyAttribute>(
+        when: c => c.Parameter..., // optional to inspect specific parameter models
+        attribute: ma => ma.Value // optional to inspect just this value
+    );
+
+    // To inspect an attribute any member
+    builder.Inspect.Attribute<MyAttribute>(
+        when: c => c..., // optional to inspect specific members
+        attribute: ma => ma.Value // optional to inspect just this value
+    );
+});
+```
+
+> [!NOTE]
+>
+> Only one inspect is allowed. If you configure more than one,
+> `InvalidOperationException` will be thrown
 
 ### `IDomainTypeCollection`
 
@@ -50,18 +100,6 @@ provided in `AddDomainTypes` phase. To configure it in a feature;
 
 ```csharp
 configurator.Domain.ConfigureBuilder(builder =>
-{
-    ...
-});
-```
-
-### `IDomainModelConventionCollection`
-
-This target exposes options for configuring domain conventions and levels and is
-provided in `AddDomainTypes` phase. To configure it in a feature;
-
-```csharp
-configurator.Domain.ConfigureConventions(conventions =>
 {
     ...
 });
@@ -127,248 +165,6 @@ This layer introduces following `Generate` phases to the application it is added
 >     ...
 > });
 > ```
-
-## Domain Model
-
-`DomainModel` is a reflection cache that stores and reuses type metadata,
-properties, methods, parameters, and attribute information. Since baked relies 
-on dynamic code generation based on certain set of rules or conventions, 
-`DomainModel` serves as the core foundation of the system by providing 
-a reusable and extendable reflection metadata.
-
-### Extending Domain Model
-
-Baked utilizes the `Attribute` system to mark or add additional metadata to
-reflected types, members, or parameters. All models defined within the 
-`DomainModel` has their own attributes collection initialized with dotnet
-or user provided attributes, which allows layers and features to define custom 
-behaviors, metadata, or runtime behaviours.
-
-In order to create a specific set of rules or behaviors, `DomainLayer` provides 
-convention based configuration mechanism which are configured using 
-`DomainModelBuilder` configuration target's `Conventions`. 
-
-### Indexing Models
-
-Baked provides indexing mechanism of domain models according to their owned 
-or added attributes to improve performance. Indexes of a model in domain can 
-be specified from its builder options.
-
-```csharp
-configurator.Domain.ConfigureBuilder(builder =>
-{
-    builder.Index.Type.Add<MyTypeAttribute>();
-    builder.Index.Property.Add<MyPropertyAttribute>();
-    builder.Index.Method.Add<MyMethodAttribute>();
-    builder.Index.Parameter.Add<MyParameterAttribute>();
-}
-```
-
-When any model type are indexed, they can be accessed using `.Having` extension
-method instead of querying through models.
-
-```csharp
-foreach(var type in domain.Types.Where(t => t.TryGetMetadata(out var metadata) && metadata.Has<MyTypeAttribute>()))
-{
-    ...
-}
-
-// Indexed, no query needed
-foreach(var type in domain.Types.Having<MyTypeAttribute>())
-{
-    ...
-}
-```
-
-## Convention System
-
-Attributes can be directly added to types or members as well as using built-in
-convetion system of baked. A convention can be used to add/remove or configure
-an attribute. Baked provides `IDomainModelConvention<TModel>` to create custom
-convention classes and extension methods for `DomainModelConventionCollection` 
-to manage attributes.
-
-```csharp
-public class IdConvention : IDomainModelConvention<PropertyModelContext>
-{
-    public void Apply(PropertyModelContext context) 
-    {
-        if(c.Property.Name != "Id") { continue; }
-
-        ((IMutableAttributeCollection).Property.CustomAttributes).Add(new IdAttribute());
-    }
-}
-
-configurator.Domain.ConfigureConventions(conventions =>
-{
-    // Adding an implemented convention
-    conventions.Add(new IdConvention());
-
-    // Adding convention via extensions
-    conventions.SetPropertyAttribute(
-        when: c => c.Property.Name == "Id"
-        attribute: () => new IdAttribute()
-    );
-}
-```
-
-### Ordering Conventions
-
-By deault a convention is applied in the order which it is added with respect to
-its feature order. A global value can be also set when a specific convention is
-required to execute at the exact order. 
-
-```csharp
-// program.cs
-app.Features.Add(new FeatureA());
-app.Features.Add(new FeatureB());
-
-public class FeatureA : IFeature 
-{
-    // this convention wil apply before conventions
-    // in feature B with default order
-    conventions.SetPropertyAttribute(...);
-}
-
-public class FeatureB : IFeature 
-{
-    // This convention will apply first since a
-    // global order is given
-    conventions.SetPropertyAttribute(
-        ...,
-        order: Order.Earliest
-    );
-
-    // This convention will apply after conventions
-    // in feature A
-    conventions.SetPropertyAttribute(...);
-}
-```
-
-Another key factor that affects convention execution order is whether a
-convention should execute before or after indexes are built. Some conventions
-may need to modify metadata or add attributes before the indexing stage begins,
-so that the attributes they add can be using in `.Having<T>()` clauses in
-conventions that run after building indexes. 
-
-```mermaid
-flowchart
-  BBI(Conventions Before <br/> Building Indexes)
-  BI@{ shape: hex, label: "Build Indexes" }
-  ABI(Conventions After <br/> Building Indexes)
-
-  subgraph Convention Order
-    direction LR
-    BBI --> BI --> ABI
-  end
-```
-
-To support this behavior, conventions can be marked with the 
-`beforeBuildingIndexes` flag. These conventions are grouped and executed in a 
-separate stage, guaranteeing that they run before index generation and all 
-remaining conventions.
-
-```csharp
-// This convention will apply before the indexes are built
-conventions.SetPropertyAttribute(
-    ...,
-    order: Order.Latest;
-    beforeBuildingIndexes: true
-);
-
-// This convention will apply after the indexes are built
-conventions.SetPropertyAttribute(
-    ...,
-    order: Order.Earliest,
-);
-```
-
-Baked also provides a level system that allows conventions to be grouped and 
-executed within a specific stage. This helps organize convention execution 
-accross multiple features and provide a predictable ordering between related 
-convention groups.
-
-```csharp
-configurator.Domain.ConfigureConventions(builder =>
-{
-    conventions.Levels.Add("LevelA");
-    conventions.Levels.Add("LevelB");
-
-    conventions.SetPropertyAttribute(
-        ...,
-        order: Order.Level("LevelB")
-    );
-
-    // This convention executes first
-    conventions.SetPropertyAttribute(
-        ...,
-        order: Order.Level("LevelA")
-    );
-}
-```
-
-A convention with given level order will be added to the median, in other words
-will have 0 as its order relative to its level. It is also possible to specify 
-min/max values or a specific position within the level.
-
-```csharp
-conventions.SetPropertyAttribute(
-    ...,
-    order: Order.Level("LevelA").Min
-);
-
-conventions.SetPropertyAttribute(
-    ...,
-    order: Order.Level("LevelA") + 10
-);
-```
-
-#### `Order`
-
-Possible order usages;
-
-```csharp
-Order.Global.AbsoluteMin
-Order.Global.Min
-Order.Level("prior-level").AbsoluteMin
-Order.Level("prior-level").Min
-Order.Level("prior-level") // .Zero
-Order.Level("prior-level").Max
-Order.Level("prior-level").AbsoluteMax
-Order.AbsoluteMin
-Order.Min
-Order.Zero // 0
-Order.Max
-Order.AbsoluteMax
-Order.Level("posterior-level").AbsoluteMin
-Order.Level("posterior-level").Min
-Order.Level("posterior-level") // .Zero
-Order.Level("posterior-level").Max
-Order.Level("posterior-level").AbsoluteMax
-Order.Global.Max
-Order.Global.AbsoluteMax
-```
-
-Following operatior overloads are implemented
-```csharp
-{Order} = {Order} +- {int}
-{Order} = {int}
-
-// e.g.
-order: Order.Level("my-level") + 10
-order: Order.Max - 10
-order: 10 // Order.Zero + 10
-```
-
-> [!NOTE]
->
-> Levels does not allow values exceeding their absolute boundaries, absolute 
-> values should be avaoided unless it is requried to override exceptional cases
-
-> [!CAUTION]
->
-> Order has range between int.MinValue and int.MaxValue, any
-> values exceeding will throw error
 
 ## Proxifying Entities
 

--- a/docs/layers/domain.md
+++ b/docs/layers/domain.md
@@ -30,7 +30,9 @@ configuration targets for building `DomainModel`, `AttributeDatas` and
 also provides `DomainServiceCollection` configuration target for features to add
 `DomainServiceDescriptor` for domain types which then be used to generate an
 `IServiceAdder` implementation. The generated `IServiceAdder` is then used in
-`Start` mode for auto registering domain types to service collection.
+`Start` mode for auto registering domain types to service collection. Domain
+layer also provides an `Inspect` object to inspect on metadata while
+`DomainModelBuilder` builds the domain model through conventions.
 
 ### `IDomainTypeCollection`
 
@@ -50,6 +52,18 @@ provided in `AddDomainTypes` phase. To configure it in a feature;
 
 ```csharp
 configurator.Domain.ConfigureBuilder(builder =>
+{
+    ...
+});
+```
+
+### `IDomainModelConventionCollection`
+
+This target exposes options for configuring domain conventions and levels and is
+provided in `AddDomainTypes` phase. To configure it in a feature;
+
+```csharp
+configurator.Domain.ConfigureConventions(conventions =>
 {
     ...
 });
@@ -116,6 +130,248 @@ This layer introduces following `Generate` phases to the application it is added
 > });
 > ```
 
+## Domain Model
+
+`DomainModel` is a reflection cache that stores and reuses type metadata,
+properties, methods, parameters, and attribute information. Since baked relies 
+on dynamic code generation based on certain set of rules or conventions, 
+`DomainModel` serves as the core foundation of the system by providing 
+a reusable and extendable reflection metadata.
+
+### Extending Domain Model
+
+Baked utilizes the `Attribute` system to mark or add additional metadata to
+reflected types, members, or parameters. All models defined within the 
+`DomainModel` has their own attributes collection initialized with dotnet
+or user provided attributes, which allows layers and features to define custom 
+behaviors, metadata, or runtime behaviours.
+
+In order to create a specific set of rules or behaviors, `DomainLayer` provides 
+convention based configuration mechanism which are configured using 
+`DomainModelBuilder` configuration target's `Conventions`. 
+
+### Indexing Models
+
+Baked provides indexing mechanism of domain models according to their owned 
+or added attributes to improve performance. Indexes of a model in domain can 
+be specified from its builder options.
+
+```csharp
+configurator.Domain.ConfigureBuilder(builder =>
+{
+    builder.Index.Type.Add<MyTypeAttribute>();
+    builder.Index.Property.Add<MyPropertyAttribute>();
+    builder.Index.Method.Add<MyMethodAttribute>();
+    builder.Index.Parameter.Add<MyParameterAttribute>();
+}
+```
+
+When any model type are indexed, they can be accessed using `.Having` extension
+method instead of querying through models.
+
+```csharp
+foreach(var type in domain.Types.Where(t => t.TryGetMetadata(out var metadata) && metadata.Has<MyTypeAttribute>()))
+{
+    ...
+}
+
+// Indexed, no query needed
+foreach(var type in domain.Types.Having<MyTypeAttribute>())
+{
+    ...
+}
+```
+
+## Convention System
+
+Attributes can be directly added to types or members as well as using built-in
+convetion system of baked. A convention can be used to add/remove or configure
+an attribute. Baked provides `IDomainModelConvention<TModel>` to create custom
+convention classes and extension methods for `DomainModelConventionCollection` 
+to manage attributes.
+
+```csharp
+public class IdConvention : IDomainModelConvention<PropertyModelContext>
+{
+    public void Apply(PropertyModelContext context) 
+    {
+        if(c.Property.Name != "Id") { continue; }
+
+        ((IMutableAttributeCollection).Property.CustomAttributes).Add(new IdAttribute());
+    }
+}
+
+configurator.Domain.ConfigureConventions(conventions =>
+{
+    // Adding an implemented convention
+    conventions.Add(new IdConvention());
+
+    // Adding convention via extensions
+    conventions.SetPropertyAttribute(
+        when: c => c.Property.Name == "Id"
+        attribute: () => new IdAttribute()
+    );
+}
+```
+
+### Ordering Conventions
+
+By deault a convention is applied in the order which it is added with respect to
+its feature order. A global value can be also set when a specific convention is
+required to execute at the exact order. 
+
+```csharp
+// program.cs
+app.Features.Add(new FeatureA());
+app.Features.Add(new FeatureB());
+
+public class FeatureA : IFeature 
+{
+    // this convention wil apply before conventions
+    // in feature B with default order
+    conventions.SetPropertyAttribute(...);
+}
+
+public class FeatureB : IFeature 
+{
+    // This convention will apply first since a
+    // global order is given
+    conventions.SetPropertyAttribute(
+        ...,
+        order: Order.Earliest
+    );
+
+    // This convention will apply after conventions
+    // in feature A
+    conventions.SetPropertyAttribute(...);
+}
+```
+
+Another key factor that affects convention execution order is whether a
+convention should execute before or after indexes are built. Some conventions
+may need to modify metadata or add attributes before the indexing stage begins,
+so that the attributes they add can be using in `.Having<T>()` clauses in
+conventions that run after building indexes. 
+
+```mermaid
+flowchart
+  BBI(Conventions Before <br/> Building Indexes)
+  BI@{ shape: hex, label: "Build Indexes" }
+  ABI(Conventions After <br/> Building Indexes)
+
+  subgraph Convention Order
+    direction LR
+    BBI --> BI --> ABI
+  end
+```
+
+To support this behavior, conventions can be marked with the 
+`beforeBuildingIndexes` flag. These conventions are grouped and executed in a 
+separate stage, guaranteeing that they run before index generation and all 
+remaining conventions.
+
+```csharp
+// This convention will apply before the indexes are built
+conventions.SetPropertyAttribute(
+    ...,
+    order: Order.Latest;
+    beforeBuildingIndexes: true
+);
+
+// This convention will apply after the indexes are built
+conventions.SetPropertyAttribute(
+    ...,
+    order: Order.Earliest,
+);
+```
+
+Baked also provides a level system that allows conventions to be grouped and 
+executed within a specific stage. This helps organize convention execution 
+accross multiple features and provide a predictable ordering between related 
+convention groups.
+
+```csharp
+configurator.Domain.ConfigureConventions(builder =>
+{
+    conventions.Levels.Add("LevelA");
+    conventions.Levels.Add("LevelB");
+
+    conventions.SetPropertyAttribute(
+        ...,
+        order: Order.Level("LevelB")
+    );
+
+    // This convention executes first
+    conventions.SetPropertyAttribute(
+        ...,
+        order: Order.Level("LevelA")
+    );
+}
+```
+
+A convention with given level order will be added to the median, in other words
+will have 0 as its order relative to its level. It is also possible to specify 
+min/max values or a specific position within the level.
+
+```csharp
+conventions.SetPropertyAttribute(
+    ...,
+    order: Order.Level("LevelA").Min
+);
+
+conventions.SetPropertyAttribute(
+    ...,
+    order: Order.Level("LevelA") + 10
+);
+```
+
+#### `Order`
+
+Possible order usages;
+
+```csharp
+Order.Global.AbsoluteMin
+Order.Global.Min
+Order.Level("prior-level").AbsoluteMin
+Order.Level("prior-level").Min
+Order.Level("prior-level") // .Zero
+Order.Level("prior-level").Max
+Order.Level("prior-level").AbsoluteMax
+Order.AbsoluteMin
+Order.Min
+Order.Zero // 0
+Order.Max
+Order.AbsoluteMax
+Order.Level("posterior-level").AbsoluteMin
+Order.Level("posterior-level").Min
+Order.Level("posterior-level") // .Zero
+Order.Level("posterior-level").Max
+Order.Level("posterior-level").AbsoluteMax
+Order.Global.Max
+Order.Global.AbsoluteMax
+```
+
+Following operatior overloads are implemented
+```csharp
+{Order} = {Order} +- {int}
+{Order} = {int}
+
+// e.g.
+order: Order.Level("my-level") + 10
+order: Order.Max - 10
+order: 10 // Order.Zero + 10
+```
+
+> [!NOTE]
+>
+> Levels does not allow values exceeding their absolute boundaries, absolute 
+> values should be avaoided unless it is requried to override exceptional cases
+
+> [!CAUTION]
+>
+> Order has range between int.MinValue and int.MaxValue, any
+> values exceeding will throw error
+
 ## Proxifying Entities
 
 It is possible to avoid adding `protected virtual` and default constructors to
@@ -159,7 +415,7 @@ Add versions to `Directory.Packages.props`;
 >   <Publicize />
 >   <Virtuosity />
 > </Weavers>
-> ```
+> 
 
 ### Debugging Domain Model Generation
 

--- a/docs/layers/domain.md
+++ b/docs/layers/domain.md
@@ -30,58 +30,7 @@ configuration targets for building `DomainModel`, `AttributeDatas` and
 also provides `DomainServiceCollection` configuration target for features to add
 `DomainServiceDescriptor` for domain types which then be used to generate an
 `IServiceAdder` implementation. The generated `IServiceAdder` is then used in
-`Start` mode for auto registering domain types to service collection. Domain
-layer also provides an `Inspect` object to inspect on metadata while
-`DomainModelBuilder` builds the domain model through conventions.
-
-### `Inspect`
-
-> [!WARNING]
->
-> This feature is still in experimentation and might print false-negative
-> output, meaning it might not capture every change of the inspected attribute.
-
-This target is provided in `AddDomainTypes` phase. To configure it in a feature;
-
-```csharp
-configurator.Domain.ConfigureInspect(inspect =>
-{
-    // To inspect an attribute on types
-    inspect.TypeAttribute<MyAttribute>(
-        when: c => c.Type..., // optional to inspect specific type models
-        attribute: ma => ma.Value // optional to inspect just this value
-    );
-
-    // To inspect an attribute properties
-    inspect.PropertyAttribute<MyAttribute>(
-        when: c => c.Property..., // optional to inspect specific property models
-        attribute: ma => ma.Value // optional to inspect just this value
-    );
-
-    // To inspect an attribute methods
-    inspect.MethodAttribute<MyAttribute>(
-        when: c => c.Method..., // optional to inspect specific method models
-        attribute: ma => ma.Value // optional to inspect just this value
-    );
-
-    // To inspect an attribute parameters
-    inspect.ParameterAttribute<MyAttribute>(
-        when: c => c.Parameter..., // optional to inspect specific parameter models
-        attribute: ma => ma.Value // optional to inspect just this value
-    );
-
-    // To inspect an attribute any member
-    inspect.Attribute<MyAttribute>(
-        when: c => c..., // optional to inspect specific members
-        attribute: ma => ma.Value // optional to inspect just this value
-    );
-});
-```
-
-> [!NOTE]
->
-> Only one inspect is allowed. If you configure more than one,
-> `InvalidOperationException` will be thrown
+`Start` mode for auto registering domain types to service collection. 
 
 ### `IDomainTypeCollection`
 

--- a/ui/playground/.baked/app.json
+++ b/ui/playground/.baked/app.json
@@ -54,13 +54,11 @@
       "resolver": "MetaUrl"
     },
     {
-      "expirationInMinutes": 60,
       "basePath": "./runtime/plugins/",
       "name": "cacheApplication",
       "resolver": "MetaUrl"
     },
     {
-      "expirationInMinutes": 60,
       "basePath": "./runtime/plugins/",
       "name": "cacheUser",
       "resolver": "MetaUrl"

--- a/ui/src/module.ts
+++ b/ui/src/module.ts
@@ -7,6 +7,7 @@ export interface ModuleOptions {
   apiBaseURL: String,
   components?: Components,
   composables: Composables,
+  plugins?: Plugins,
   primevue: PrimeVueOptions,
   i18n: NuxtI18nOptions
 }
@@ -28,6 +29,15 @@ export interface Composables {
   useBreakpoints?: UseBreakpointsOptions,
   useDataFetcher: UseDataFetcherOptions,
   useFormat?: UseFormatOptions
+}
+
+export interface Plugins {
+  cacheApplication?: CacheOptions,
+  cacheUser?: CacheOptions
+}
+
+export interface CacheOptions {
+  expirationInMinutes: any
 }
 
 export interface UseDataFetcherOptions {

--- a/ui/src/runtime/plugins/cacheApplication.js
+++ b/ui/src/runtime/plugins/cacheApplication.js
@@ -5,8 +5,8 @@ export default defineNuxtPlugin({
   name: "cache-application",
   enforce: "pre",
   setup(nuxtApp) {
-    const { public: { cacheApplication } } = useRuntimeConfig();
-    const { expirationInMinutes } = cacheApplication;
+    const { public: { plugins: { cacheApplication = { } } = { } } } = useRuntimeConfig();
+    const { expirationInMinutes = 60 } = cacheApplication;
     const cache = useCache("cache:application", { expirationInMinutes });
     const { $fetchInterceptors } = nuxtApp;
 

--- a/ui/src/runtime/plugins/cacheUser.js
+++ b/ui/src/runtime/plugins/cacheUser.js
@@ -5,8 +5,8 @@ export default defineNuxtPlugin({
   name: "cache-user",
   enforce: "pre",
   setup(nuxtApp) {
-    const { public: { cacheUser } } = useRuntimeConfig();
-    const { expirationInMinutes } = cacheUser;
+    const { public: { plugins: { cacheUser = { } } = { } } } = useRuntimeConfig();
+    const { expirationInMinutes = 60 } = cacheUser;
     const cache = useCache("cache:user", { expirationInMinutes });
     const { $fetchInterceptors } = nuxtApp;
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -4,6 +4,32 @@
 
 - `Domain` layer now introduces a level system to improve managing convention
   execution orders.
+  ```csharp
+  configurator.Domain.ConfigureDomainModelBuilder(builder =>
+  {
+    builder.ConventionOrderMatrix.Bases.Add("Base");
+    ...
+    builder.ConventionOrderMatrix.Levels.Add("Level");
+    ...
+    builder.ConventionOrderMatrix.Extensions.Add("Ext");
+    ...
+
+    builder.ConventionOrderMatrix.FallbackBase = convention => ...;
+    builder.ConventionOrderMatrix.FallbackLevel = convention => ...;
+    builder.ConventionOrderMatrix.FallbackExtension = convention => ...;
+
+    builder.DefaultConventionLevel = "...";
+  });
+
+  configurator.Domain.ConfigureDomainConventions(conventions => 
+  {
+    conventions.SetTypeAttribute(
+      when: _ => true,
+      attribute: () => new GroupAttribute(),
+      order: Order.At.WithBase("Base").WithLevel("Level").WithExtension("Ext")
+    );
+  });
+  ```
 
 ## Breaking Changes
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -72,7 +72,20 @@
   // use below instead
   conventions.Add(..., order: Order.At.Global.Min);
   ```
+- `Inpect` is now moved to `DomainModelBuilderOptions`
+  ```csharp
+  // old usage
+  configurator.Domain.ConfigureInspect(inspect =>
+  {
+      inspect.Attribute<...>();
+  });
 
+  // new usage
+  configurator.Domain.ConfigureDomainModelBuilder(builder =>
+  {
+      builder.Inspect.Attribute<...>();
+  });
+  ```
 ## Bugfixes
 
 - Adding locate action by conventions was missing claim requirements, fixed


### PR DESCRIPTION
Configure inspect to print convention level information

## Tasks

- [x] Analysis for current development
- [x] Add `Order` to
  - [x] AddAttributeConvention
  - [x] SetAttributeConvention
  - [x] AttributeConfigurationConventionBase
- [x] Pass `Order` parameter to convention in business extensions
- [x] Build `OrderInfo` property and pass to CaptureDescriptor in theme
  extensions
- [x] Add order string property to ICaptureType
- [x] Add "ToString()" override to `Order`
- [x] Print order string property in Evaluate
  - [gray] 
    ```bash
    -BDA+0010
    +BCC-0010
    -B??-0000
    ```

## Additional Tasks

- [x] Include code and line number in diagnostic errors
  - provide file link when available 
  - same with capture source but gray color
- ~~Feature settings should default to Setting~~ 
- [x] Move settings for CacheFeatures features to ui
  - [x] Expose configuration from module.ts 
- [x] Move configure inspect to `DomainModelBuilderOptions`
- [x] Fix tests failing when an inspect is configured
